### PR TITLE
Add accessible swatch styles

### DIFF
--- a/theme/palette/palette.story.js
+++ b/theme/palette/palette.story.js
@@ -50,16 +50,41 @@ const getPalette = (name, palette) => (
   </div>
 );
 
+const lookupValue = value => {
+  const isVariable = value.indexOf('@') === 0;
+  return isVariable ? dictionary[value] : value;
+};
+
+const isAccessible = name => /-on-/.test(name);
+
+const getAccessibleSwatchStyle = name => {
+  const color = dictionary[name];
+  const backgroundValue = `@sk-${name.split('-on-')[1]}`;
+  const backgroundColor = lookupValue(backgroundValue);
+
+  return { color, backgroundColor };
+}
+
+const getStandardSwatchStyle = name => {
+  const value = dictionary[name];
+  const backgroundColor = lookupValue(value);
+  const color = blackOrWhite(backgroundColor);
+
+  return { color, backgroundColor };
+}
+
+const getSwatchStyle = name => isAccessible(name) ?
+  getAccessibleSwatchStyle(name) :
+  getStandardSwatchStyle(name);
+
 const getSwatch = name => {
   const value = dictionary[name];
-  const isVariable = value.indexOf('@') === 0;
-  const colourValue = isVariable ? dictionary[value] : value;
 
   return (
     <div
       key={name}
       title={name.replace('@', '')}
-      style={{color: blackOrWhite(colourValue), backgroundColor: colourValue}}
+      style={getSwatchStyle(name)}
       className={styles.swatch}>
       <span className={styles.swatchName}>{name.replace('@', '')}</span>
       <span className={styles.swatchColour}>{value.replace('@', '')}</span>


### PR DESCRIPTION
We're now displaying the accessible variants with the correct text and background colours intact, rather than as a block colour with black or white text.

<img width="1201" alt="screen shot 2016-04-27 at 5 01 45 pm" src="https://cloud.githubusercontent.com/assets/696693/14844339/0de8634a-0c9a-11e6-8a14-67eba5c439b0.png">
