### PR TITLE
Bump less-vars-to-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "json-loader": "^0.5.4",
     "less": "2.6.1",
     "less-loader": "2.2.3",
-    "less-vars-to-js": "^1.0.0",
+    "less-vars-to-js": "^1.1.1",
     "postcss-loader": "0.8.2",
     "postcss-local-scope": "0.0.5",
     "raw-loader": "^0.5.1",


### PR DESCRIPTION
Fixed a problem where regex would extract variables that were values of properties, eg.

``` less
color: @foo;
```

Now only returns variables declarations.
