### PR TITLE
Move react and react-dom to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,14 @@
     "postcss-loader": "0.8.2",
     "postcss-local-scope": "0.0.5",
     "raw-loader": "0.5.1",
-    "react": "15.0.1",
-    "react-dom": "15.0.1",
     "style-loader": "0.13.1",
     "svgo": "0.6.6",
     "svgo-loader": "1.1.0",
     "url-loader": "0.5.7"
+  },
+  "peerDependencies": {
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0"
   },
   "devDependencies": {
     "@kadira/react-split-pane": "1.3.0",
@@ -58,8 +60,10 @@
     "json-loader": "0.5.4",
     "jsx-to-string": "0.2.11",
     "less-vars-to-js": "1.1.1",
+    "react": "15.0.2",
     "react-baseline": "0.2.1",
     "react-copy-to-clipboard": "4.1.0",
+    "react-dom": "15.0.2",
     "webpack": "1.13.0",
     "webpack-dev-middleware": "1.6.1",
     "webpack-hot-middleware": "2.10.0"


### PR DESCRIPTION
Kinda goes without saying, but this change is so we can avoid duplicate copies of React running in the same application 👯 
