### PR TITLE
Remove height setting from rawText mixin

### DIFF
--- a/app/components/App/App.less
+++ b/app/components/App/App.less
@@ -34,7 +34,7 @@
 
 .headerText {
   @border-width: 3px;
-  .rawText(@standard-type-scale, 5);
+  .touchableText(@standard-type-scale);
   display: block;
   text-align: center;
   text-transform: uppercase;

--- a/theme/mixins/type.less
+++ b/theme/mixins/type.less
@@ -27,12 +27,12 @@
   .basekick(@small-type-scale, @small-type-row-span, @font-descender-height-scale, @base-font-size, @grid-row-height);
 }
 
-.rawText(@font-scale: @standard-type-scale, @row-span: @standard-type-row-span) {
+.rawText(@font-scale: @standard-type-scale) {
   font-size: unit((@font-scale * @base-font-size), px);
-  line-height: (@grid-row-height * @row-span);
-  min-height: (@grid-row-height * @row-span);
 }
 
 .touchableText(@font-scale: @interaction-type-scale) {
-  .rawText(@font-scale, @interaction-type-row-span);
+  .rawText(@font-scale);
+  line-height: (@grid-row-height * @interaction-type-row-span);
+  height: (@grid-row-height * @interaction-type-row-span);
 }


### PR DESCRIPTION
Tidy up `rawText` mixin to leave `height` and `line-height` setting to the consuming rules. The benefit of this mixin means all setting of `font-size` uses a mixin from the style guide, so no client app should be setting this. Be good to lint against this in the future.

@moroshko 
