### PR TITLE
Fix body overflow bug

### DIFF
--- a/react/SeekApp/SeekApp.less
+++ b/react/SeekApp/SeekApp.less
@@ -6,11 +6,6 @@
   html {
     background-color: @sk-background;
     min-height: 100%;
-    overflow-y: auto;
-  }
-
-  body {
-    overflow-y: hidden;
   }
 }
 


### PR DESCRIPTION
Fixes bug when scrolling down the page on page load clips the top of the page. These rules were originally added to address seeing the Search Form above/behind the Header when viewing Houston on an iPhone (when search form is collapsed on the results page).

We will revisit this fix, as it only affects our app on iOS devices and it's an edge case.
