### PR TITLE
Remove dotted border from buttons in Firefox

### DIFF
--- a/react/buttons/BlueButton/BlueButton.js
+++ b/react/buttons/BlueButton/BlueButton.js
@@ -21,6 +21,18 @@ export default class BlueButton extends Component {
     loading: false
   };
 
+  constructor() {
+    super();
+
+    this.storeButtonReference = this.storeButtonReference.bind(this);
+  }
+
+  storeButtonReference(button) {
+    if (button !== null) {
+      this.button = button;
+    }
+  }
+
   render() {
     const { className, loading, children, ...props } = this.props;
 
@@ -30,6 +42,7 @@ export default class BlueButton extends Component {
         [styles.loading]: loading
       }),
       disabled: loading,
+      ref: this.storeButtonReference,
       ...props
     };
 

--- a/react/buttons/PinkButton/PinkButton.js
+++ b/react/buttons/PinkButton/PinkButton.js
@@ -21,6 +21,18 @@ export default class PinkButton extends Component {
     loading: false
   };
 
+  constructor() {
+    super();
+
+    this.storeButtonReference = this.storeButtonReference.bind(this);
+  }
+
+  storeButtonReference(button) {
+    if (button !== null) {
+      this.button = button;
+    }
+  }
+
   render() {
     const { className, loading, children, ...props } = this.props;
 
@@ -30,6 +42,7 @@ export default class PinkButton extends Component {
         [styles.loading]: loading
       }),
       disabled: loading,
+      ref: this.storeButtonReference,
       ...props
     };
 

--- a/react/buttons/PinkButton/PinkButton.less
+++ b/react/buttons/PinkButton/PinkButton.less
@@ -15,12 +15,14 @@
   &:hover {
     background-color: lighten(@sk-pink, 5%);
   }
+
   &:active {
     background-color: darken(@sk-pink, 5%);
     box-shadow: none;
     outline: none;
     transform: scale(0.95);
   }
+
   &:focus {
     .focus();
   }

--- a/theme/mixins/focus.less
+++ b/theme/mixins/focus.less
@@ -3,4 +3,8 @@
   z-index: 1;
   box-shadow: 0 0 0 @field-border-width @sk-focus;
   border-radius: @field-border-radius;
+
+  &::-moz-focus-inner {
+    border: 0;
+  }
 }


### PR DESCRIPTION
The main purpose of this PR was to remove the dotted border from buttons in Firefox.
In chalice, we focus on the SEEK button when form is submitted. To do this, we need an access to the actual `<button>` element that `PinkButton` and `BlueButton` wrap. This PR addresses this by adding `button` on the instance of `PinkButton`/`BlueButton`.
