### PR TITLE
Fix react-copy-to-clipboard version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react": "^15.0.2",
     "react-addons-pure-render-mixin": "^15.0.2",
     "react-baseline": "^1.0.1",
-    "react-copy-to-clipboard": "^4.1.0",
+    "react-copy-to-clipboard": "4.1.0",
     "react-dom": "^15.0.2",
     "react-hot-loader": "^3.0.0-beta.2",
     "react-prism": "^3.2.0",


### PR DESCRIPTION
`react-copy-to-clipboard` versions 4.1.1 and 4.2.0 throw the following error when running `npm run gh-pages-build`:

> ERROR in ReferenceError: navigator is not defined

Until [this issue](https://github.com/nkbt/react-copy-to-clipboard/issues/30) is fixed, let's fix the version to 4.1.0.
