### PR TITLE
Stop rendering comment nodes in templates

### DIFF
--- a/app/components/Droplet/Droplet.js
+++ b/app/components/Droplet/Droplet.js
@@ -23,13 +23,14 @@ export default function Droplet({ colour, outline, outlineColour, showHex, showV
     <div className={styles.root}>
       <div className={styles.drop} style={dropletStyles} />
       {
-        (showHex || showVariable) && (
+        (showHex || showVariable) ?
           <div className={styles.hex}>
-            {showHex && <p>{colour}</p>}
-            {(showHex && showVariable) && ' — '}
-            {showVariable && <p>{variableName}</p>}
-          </div>
-      )}
+            {showHex ? <p>{colour}</p> : null}
+            {(showHex && showVariable) ? ' — ' : null}
+            {showVariable ? <p>{variableName}</p> : null}
+          </div> :
+          null
+      }
     </div>
   );
 }

--- a/app/components/Typography/Typography.js
+++ b/app/components/Typography/Typography.js
@@ -171,7 +171,7 @@ export default class Typography extends Component {
             }}
           />
           {
-            isTypeScaleConfigurable &&
+            isTypeScaleConfigurable ?
               <div style={{ display: 'inline-block' }}>
                 <div className={styles.divider} />
                 <SandboxToggle
@@ -186,7 +186,8 @@ export default class Typography extends Component {
                     onChange: this.setTypeScale
                   }}
                 />
-              </div>
+              </div> :
+              null
           }
         </SandboxTogglePanel>
 

--- a/react/fields/TextField/TextField.js
+++ b/react/fields/TextField/TextField.js
@@ -93,24 +93,35 @@ export default class TextField extends Component {
     return (
       <div className={classnames(styles.root, className, { [styles.invalid]: invalid })}>
         {
-          label &&
+          label ?
             <label className={styles.label} {...labelProps} htmlFor={id || null}>
               {label}
-            </label>
+            </label> :
+            null
         }
         <input className={classnames(styles.input, inputClassName)} ref={this.storeInputReference} {...remainingInputProps} id={id} />
         {
-          (!invalid && help) &&
+          (!invalid && help) ?
             <p className={styles.help} {...helpProps}>
               {help}
-            </p>
+            </p> :
+            null
         }
         {
-          message &&
+          message ?
             <p className={styles.message} {...messageProps}>
-              {invalid && <ErrorIcon filled={true} className={styles.messageIcon} svgClassName={styles.messageIconSvg} />}
+              {
+                invalid ?
+                  <ErrorIcon
+                    filled={true}
+                    className={styles.messageIcon}
+                    svgClassName={styles.messageIconSvg}
+                  /> :
+                  null
+              }
               {message}
-            </p>
+            </p> :
+            null
         }
       </div>
     );


### PR DESCRIPTION
Swapping out our boolean-foo in our react templates to use ternary operators instead of simply `&&`. These result in html comment nodes when `false`, wheres as explicitly returning `null` does not pollute the markup.
