### PR TITLE
Use common focus styles for Textfield

### DIFF
--- a/react/fields/TextField/TextField.less
+++ b/react/fields/TextField/TextField.less
@@ -25,16 +25,19 @@
   &:not([readonly]):not([disabled]):focus,
   .rootFocus & {
     outline: none;
-    border-color: @sk-focus;
+    border-color: transparent;
+    .focus();
   }
 
   .invalid & {
-    border-color: @sk-pink;
+    border-color: transparent;
+    box-shadow: 0 0 0 @field-border-width @sk-pink;
     margin-bottom: 0;
 
     &:not([readonly]):not([disabled]):focus,
     .rootFocus & {
-      border-color: @sk-pink;
+      border-color: transparent;
+      box-shadow: 0 0 0 @field-border-width @sk-pink;
     }
   }
 }


### PR DESCRIPTION
Previously we were changing the `border-color` on our `TextField` when focusing or marking as invalid. Now using centralised `.focus()` mixin that uses `box-shadow`.

Allows consumers to remove field border without breaking styles. We don't use `outline` because it does not follow the curvature of our `border-radius` on the field.
