### PR TITLE
Remove scaling standardText demo

### DIFF
--- a/app/components/Typography/Typography.js
+++ b/app/components/Typography/Typography.js
@@ -108,7 +108,7 @@ export default class Typography extends Component {
 
   render() {
     const { typeLevel, typeScale, baseline } = this.state;
-    const isTypeScaleConfigurable = typeLevel.name === 'Standard' || typeLevel.name === 'Touchable';
+    const isTypeScaleConfigurable = typeLevel.name === 'Touchable';
     const typeScaleFloat = parseFloat(typeLevel.spec['Type Scale'], 10);
     const minTypeScale = typeScaleFloat - 1;
     const maxTypeScale = typeScaleFloat + 1;


### PR DESCRIPTION
StandardText is no longer configurable in it's size, removing the slider from the style guide app.
