### PR TITLE
Fix documentation layout

### DIFF
--- a/app/components/App/components/Header/Header.less
+++ b/app/components/App/components/Header/Header.less
@@ -1,15 +1,14 @@
 @import (reference) "~seek-style-guide/theme";
 
 .root {
-  height: (@grid-row-height * 14);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  height: (@grid-row-height * 16);
+  padding-top: (@grid-row-height * 2);
 }
 
 .logo {
   display: flex;
   align-items: center;
+  margin-left: -(@grid-gutter-width / 2);
 }
 
 .title {
@@ -24,7 +23,7 @@
   .touchableText(@standard-type-scale);
   .link();
   display: inline-block;
-  margin-left: @grid-gutter-width;
+  margin-right: @grid-gutter-width;
   color: @sk-mid-gray-dark;
   &:before {
     content: '';


### PR DESCRIPTION
We've added too many navigation items for the existing layout, causing it to wrap unexpectedly.

At some point we'll need a more holistic change to the documentation layout, but this at least gets us back to a non-broken state.

Preview:
![screen shot 2017-01-13 at 3 54 09 pm](https://cloud.githubusercontent.com/assets/696693/21918748/c8cf52dc-d9a8-11e6-87eb-45f153f0378a.png)
