### PR TITLE
Run ESLint during test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
   "scripts": {
     "start": "BASE_HREF=/ node server",
     "lint": "eslint app react test ./*.js",
-    "test": "BABEL_ENV=test mocha 'react/**/*.test.js' --compilers js:babel-register --require test/setup.js",
-    "prebuild": "npm run lint && npm test",
-    "local-build": "npm run prebuild && rm -rf dist/ && mkdir dist && NODE_ENV=production BASE_HREF=/ webpack --config webpack.gh-pages.server.config.js && rm dist/render.js && NODE_ENV=production webpack --config webpack.gh-pages.client.config.js",
-    "gh-pages-build": "npm run prebuild && rm -rf dist/ && mkdir dist && NODE_ENV=production BASE_HREF=/seek-style-guide/ webpack --config webpack.gh-pages.server.config.js && rm dist/render.js && NODE_ENV=production webpack --config webpack.gh-pages.client.config.js",
+    "test": "BABEL_ENV=test mocha 'react/**/*.test.js' --compilers js:babel-register --require test/setup.js && npm run lint",
+    "local-build": "npm run test && rm -rf dist/ && mkdir dist && NODE_ENV=production BASE_HREF=/ webpack --config webpack.gh-pages.server.config.js && rm dist/render.js && NODE_ENV=production webpack --config webpack.gh-pages.client.config.js",
+    "gh-pages-build": "npm run test && rm -rf dist/ && mkdir dist && NODE_ENV=production BASE_HREF=/seek-style-guide/ webpack --config webpack.gh-pages.server.config.js && rm dist/render.js && NODE_ENV=production webpack --config webpack.gh-pages.client.config.js",
     "preversion": "npm run gh-pages-build",
     "postversion": "npm publish && git push && git push --tags && npm run deploy",
     "deploy": "gh-pages -d dist && printf '\nURL: http://seek-jobs.github.io/seek-style-guide\n\n'",

--- a/react/index.js
+++ b/react/index.js
@@ -1,6 +1,6 @@
 // Components
 export { default as StyleGuideProvider } from './StyleGuideProvider/StyleGuideProvider';
-export { default as SeekApp } from './StyleGuideProvider/StyleGuideProvider';  //Alias for backwards compatibility
+export { default as SeekApp } from './StyleGuideProvider/StyleGuideProvider';  // Alias for backwards compatibility
 export { default as TextLink } from './TextLink/TextLink';
 export { default as Button } from './Button/Button';
 export { default as Logo } from './Logo/Logo';


### PR DESCRIPTION
I couldn't release the latest version of the style guide because of a linting error. Turns out we run ESLint before release but not as part of the test script, which is why it also wasn't being run in CI.