### PR TITLE
ci(gh-pages): Define default base path in webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm run test-unit && npm run lint && npm run build",
     "test-unit": "BABEL_ENV=test mocha 'react/**/*.test.js' --compilers js:babel-register --require test/setup.js",
     "lint": "eslint app react test ./*.js",
-    "compile-render": "NODE_ENV=production BASE_HREF=${BASE_HREF:-/} webpack --config webpack.static.render.config.js && rm dist/render.js",
+    "compile-render": "NODE_ENV=production webpack --config webpack.static.render.config.js && rm dist/render.js",
     "compile-client": "NODE_ENV=production webpack --config webpack.static.client.config.js",
     "build": "rm -rf dist/ && mkdir dist && npm run compile-render && npm run compile-client",
     "build-gh-pages": "BASE_HREF=/seek-style-guide/ npm run build",

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -62,7 +62,7 @@ const config = decorateClientConfig({
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new webpack.DefinePlugin({
-      'process.env.BASE_HREF': JSON.stringify(process.env.BASE_HREF)
+      'process.env.BASE_HREF': JSON.stringify(process.env.BASE_HREF || '/')
     })
   ]
 });

--- a/webpack.static.render.config.js
+++ b/webpack.static.render.config.js
@@ -77,7 +77,7 @@ const config = {
     new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify('production'),
-        BASE_HREF: JSON.stringify(process.env.BASE_HREF)
+        BASE_HREF: JSON.stringify(process.env.BASE_HREF || '/')
       }
     }),
     new StaticSiteGeneratorPlugin('render.js', routes, { template }),


### PR DESCRIPTION
We're still having issues with the base bath on GitHub Pages, so hopefully this fixes the issue. This change avoids playing around with defaulting environment variables, which might be hanging on to state between build steps, in favour of defaulting in the context of each webpack build.