### PR TITLE
fix(components): Spread props on presentational components

### DIFF
--- a/react/AsidedLayout/AsidedLayout.js
+++ b/react/AsidedLayout/AsidedLayout.js
@@ -12,9 +12,10 @@ const conditionallyRenderAside = (condition, renderAside, size) => (
     null
 );
 
-export default function AsidedLayout({ className, children, renderAside = defaultRenderAside, size, reverse }) {
+export default function AsidedLayout({ className, children, renderAside = defaultRenderAside, size, reverse, ...restProps }) {
   return (
     <div
+      {...restProps}
       className={classnames({
         [className]: className,
         [styles.root]: true,

--- a/react/Card/Card.js
+++ b/react/Card/Card.js
@@ -2,9 +2,10 @@ import styles from './Card.less';
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 
-export default function Card({ className, children, transparent }) {
+export default function Card({ className, children, transparent, ...restProps }) {
   return (
     <div
+      {...restProps}
       className={classnames({
         [className]: className,
         [styles.root]: true,

--- a/react/PageBlock/PageBlock.js
+++ b/react/PageBlock/PageBlock.js
@@ -2,9 +2,9 @@ import styles from './PageBlock.less';
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 
-export default function PageBlock({ children, className }) {
+export default function PageBlock({ children, className, ...restProps }) {
   return (
-    <div className={classnames(className)}>
+    <div {...restProps} className={classnames(className)}>
       <div className={styles.content}>
         {children}
       </div>

--- a/react/Secondary/Secondary.js
+++ b/react/Secondary/Secondary.js
@@ -1,14 +1,16 @@
 import styles from './Secondary.less';
 import React, { PropTypes } from 'react';
+import classnames from 'classnames';
 
-export default function Secondary({ children }) {
+export default function Secondary({ children, className, ...restProps }) {
   return (
-    <span className={styles.root}>
+    <span {...restProps} className={classnames(styles.root, className)}>
       {children}
     </span>
   );
 }
 
 Secondary.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string
 };

--- a/react/Section/Section.js
+++ b/react/Section/Section.js
@@ -2,9 +2,10 @@ import styles from './Section.less';
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 
-export default function Section({ children, className, header, slim }) {
+export default function Section({ children, className, header, slim, ...restProps }) {
   return (
     <div
+      {...restProps}
       className={classnames({
         [className]: className,
         [styles.root]: true,

--- a/react/Strong/Strong.js
+++ b/react/Strong/Strong.js
@@ -1,14 +1,16 @@
 import styles from './Strong.less';
 import React, { PropTypes } from 'react';
+import classnames from 'classnames';
 
-export default function Strong({ children }) {
+export default function Strong({ children, className, ...restProps }) {
   return (
-    <strong className={styles.root}>
+    <strong {...restProps} className={classnames(styles.root, className)}>
       {children}
     </strong>
   );
 }
 
 Strong.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string
 };

--- a/react/Text/Text.js
+++ b/react/Text/Text.js
@@ -10,10 +10,12 @@ export default function Text({
   headline,
   heading,
   hero,
-  raw
+  raw,
+  ...restProps
 }) {
   return (
     <div
+      {...restProps}
       className={classnames({
         [styles.root]: true,
         [className]: className,


### PR DESCRIPTION
Any extra props passed to presentation components were being ignored, forcing you to add redundant wrapper elements if you needed to add aria roles, data attributes etc.