### PR TITLE
fix(button): Prevent wrapping of button text

### DIFF
--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -24,6 +24,9 @@
   border-radius: 2px;
   transition: background-color 0.2s, transform .2s cubic-bezier(0.020, 1.505, 0.745, 1.235);
   cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   &:active,
   &.rootActive {
     box-shadow: none;


### PR DESCRIPTION
Fix for the following situation where the external layout forces the button text to wrap which should never be the case.

**Before:**
![wrapping button labels](https://cloud.githubusercontent.com/assets/912060/22631880/4d8c258c-ec68-11e6-8cc1-05dbeedfccca.png)

**After:**
![truncated button labels](https://cloud.githubusercontent.com/assets/912060/22631954/013f1e72-ec69-11e6-991c-cfd697ecefd7.png)

It makes it a less broken experience, but our implementations should hopefully never hit up against this anyway.

