### PR TITLE
ci(deployment): Skip deployment step on fork builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,21 @@ notifications:
 before_script:
   - npm prune
 after_success:
-  - if [ -n "$TRAVIS_PULL_REQUEST_SHA" ]; then
-      npm run deploy-surge -- -d seek-style-guide--${TRAVIS_PULL_REQUEST_SHA}.surge.sh;
-    elif [ "$TRAVIS_BRANCH" == "master" ]; then
-      npm run semantic-release;
+  - if [ ${TRAVIS_SECURE_ENV_VARS} = "true" ]; then
+      if [ -n "$TRAVIS_PULL_REQUEST_SHA" ]; then
+        npm run deploy-surge -- -d seek-style-guide--${TRAVIS_PULL_REQUEST_SHA}.surge.sh;
+      elif [ "$TRAVIS_BRANCH" == "master" ]; then
+        npm run semantic-release;
 
-      git config --global user.name "Travis-CI";
-      git config --global user.email "travis@example.com";
-      npm run build-gh-pages;
-      npm run deploy-gh-pages;
+        git config --global user.name "Travis-CI";
+        git config --global user.email "travis@example.com";
+        npm run build-gh-pages;
+        npm run deploy-gh-pages;
+      fi
+    else
+      echo -e \
+        "\n"\
+        "Skipping deployment step because secure environment variables are unavailable.\n"\
+        "This is most likely because this build is happening in the context of a fork, which is untrusted code.\n"\
+        "\n";
     fi


### PR DESCRIPTION
The Travis CI build step for PRs originating from forks are currently unable to pass because they
don't have access to secure environment variables, causing the deployment step to fail. Deployment
of static previews for PRs is a useful part of our workflow, but not something that should prevent
contribution from those who don't currently have access to the main repo.

I'm issuing this PR from my own personal fork to ensure this logic works correctly.