### PR TITLE
ci(webpack): Remove extract text log spam from build output

### DIFF
--- a/webpack.static.client.config.js
+++ b/webpack.static.client.config.js
@@ -71,7 +71,9 @@ const config = {
         warnings: false
       }
     })
-  ]
+  ],
+
+  stats: { children: false }
 };
 
 module.exports = decorateClientConfig(config, {


### PR DESCRIPTION
Extract text plugin was spamming the output with: 

```
Child extract-text-webpack-plugin: 
     + 19 hidden modules
Child extract-text-webpack-plugin: 
     + 19 hidden modules
Child extract-text-webpack-plugin: 
     + 19 hidden modules
Child extract-text-webpack-plugin: 
     + 19 hidden modules
Child extract-text-webpack-plugin: 
     + 19 hidden modules
...
```

This fix suppresses those log reports. 

Reference: https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/97