### PR TITLE
docs(Separator): Adding a Separator component for discussion.

### DIFF
--- a/app/components/Playground/Playground.js
+++ b/app/components/Playground/Playground.js
@@ -16,7 +16,8 @@ import {
   Positive,
   Critical,
   Secondary,
-  Strong
+  Strong,
+  Separator
 } from 'seek-style-guide/react';
 
 import TextLink from './Atoms/TextLink/TextLink';
@@ -295,6 +296,11 @@ export default class Playground extends Component {
                     dangerouslySetInnerHTML={{ __html: jobDetailsContent }} // eslint-disable-line react/no-danger
                   />
                 </Text>
+              </Section>
+              <Section>
+                <Separator>
+                  <Text>You must have the <Strong>right to live and work</Strong> in this location to apply for this job.</Text>
+                </Separator>
               </Section>
             </Card>
           </AsidedLayout>

--- a/react/Separator/Separator.js
+++ b/react/Separator/Separator.js
@@ -1,0 +1,21 @@
+import styles from './Separator.less';
+import React, { PropTypes } from 'react';
+import classnames from 'classnames';
+
+export default function Separator({ children, className, ...restProps }) {
+  return (
+    <div
+      {...restProps}
+      className={classnames({
+        [className]: className,
+        [styles.root]: true
+      })}>
+      {children}
+    </div>
+  );
+}
+
+Separator.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string
+};

--- a/react/Separator/Separator.less
+++ b/react/Separator/Separator.less
@@ -1,0 +1,6 @@
+@import (reference) "~seek-style-guide/theme";
+
+.root {
+  padding: (@grid-row-height * 2) 0;
+  box-shadow: inset 0 1px 0 0 @sk-mid-gray-light, inset 0 -1px 0 0 @sk-mid-gray-light;
+}

--- a/react/index.js
+++ b/react/index.js
@@ -18,6 +18,7 @@ export { default as Columns } from './Columns/Columns';
 export { default as Card } from './Card/Card';
 export { default as PageBlock } from './PageBlock/PageBlock';
 export { default as Section } from './Section/Section';
+export { default as Separator } from './Separator/Separator';
 
 // Icons
 export { default as ChevronIcon } from './icons/ChevronIcon/ChevronIcon';


### PR DESCRIPTION
In building out job details page, we have a component that sits within a section that 'separates' out some content around right to work and reporting a job. 

Experimented with using two sections but I had to add borders and also their was unnecessary padding. 

I've added this component as a proposal for inclusion in the design system. 

Designs for the component are below:
![image](https://cloud.githubusercontent.com/assets/11851685/22955494/85968026-f370-11e6-88be-77e4a7faaa1c.png)
