### PR TITLE
feat(layout): Add Card and Section groups

### DIFF
--- a/app/components/Playground/Playground.js
+++ b/app/components/Playground/Playground.js
@@ -93,17 +93,19 @@ const renderJobDetailDate = () => (
 const renderJobDetailMetadata = () => (
   <div>
     <Card>
-      <Section>
-        <Button color="pink" className={styles.fullWidthTextField}>Apply for this job</Button>
-      </Section>
-      <Section>
-        <Text secondary>{'Applications for this role will take you to the advertiser\'s site.'}</Text>
-      </Section>
-      <Section>
-        <Columns tight>
-          <Button color="gray" className={styles.fullWidthTextField}><StarIcon /> Save Job</Button>
-          <Button color="gray" className={styles.fullWidthTextField}><MailIcon /> Send Job</Button>
-        </Columns>
+      <Section group>
+        <Section>
+          <Button color="pink" className={styles.fullWidthTextField}>Apply for this job</Button>
+        </Section>
+        <Section>
+          <Text secondary>{'Applications for this role will take you to the advertiser\'s site.'}</Text>
+        </Section>
+        <Section>
+          <Columns tight>
+            <Button color="gray" className={styles.fullWidthTextField}><StarIcon /> Save Job</Button>
+            <Button color="gray" className={styles.fullWidthTextField}><MailIcon /> Send Job</Button>
+          </Columns>
+        </Section>
       </Section>
     </Card>
     <Card>
@@ -234,14 +236,16 @@ export default class Playground extends Component {
           </Section>
 
           <AsidedLayout reverse renderAside={renderAsideRecommendedJobs} size="240px">
-            <Card>
+            <Card group>
               {
                 [0, 1, 2, 3].map(n => (
-                  <Section key={n} className={styles.borderBottom}>
-                    <TextLink subheading href="https://www.seek.com.au">Building Supervisor</TextLink>
-                    <Text>A1 Building Group</Text>
-                    <Text>CBD & Inner Suburbs, Melbourne</Text>
-                  </Section>
+                  <Card key={n}>
+                    <Section>
+                      <TextLink subheading href="https://www.seek.com.au">Building Supervisor</TextLink>
+                      <Text>A1 Building Group</Text>
+                      <Text>CBD & Inner Suburbs, Melbourne</Text>
+                    </Section>
+                  </Card>
                 ))
               }
             </Card>
@@ -255,24 +259,26 @@ export default class Playground extends Component {
             <Tab>Applied</Tab>
           </Section>
 
-          <Card>
+          <Card group>
             {
               [0, 1, 2, 3].map(n => (
-                <Section key={n} className={styles.borderBottom}>
-                  <AsidedLayout renderAside={renderAsideMyActivity} size="270px">
-                    <TextLink subheading href="https://www.seek.com.au">Local Health District Registered Nurse</TextLink>
-                    <Text>Western NSW Local Health District</Text>
-                    <Text raw>Job posted 30d+ ago</Text>
-                    <Text raw secondary>Dubbo & Central NSW</Text>
-                    <Text secondary>Salary Rate: $29.32 to $41.18 ph</Text>
-                    <Text>
-                      Are you a Registered Nurse and looking for variety and challenges on a daily basis? Yes? Here is your chance - Full Time or Part-time available.
-                    </Text>
-                  </AsidedLayout>
-                  <AsidedLayout renderAside={renderAsideMyActivityActions} size="270px">
-                    <IconButton icon="plus">Add Notes</IconButton>
-                  </AsidedLayout>
-                </Section>
+                <Card key={n}>
+                  <Section>
+                    <AsidedLayout renderAside={renderAsideMyActivity} size="270px">
+                      <TextLink subheading href="https://www.seek.com.au">Local Health District Registered Nurse</TextLink>
+                      <Text>Western NSW Local Health District</Text>
+                      <Text raw>Job posted 30d+ ago</Text>
+                      <Text raw secondary>Dubbo & Central NSW</Text>
+                      <Text secondary>Salary Rate: $29.32 to $41.18 ph</Text>
+                      <Text>
+                        Are you a Registered Nurse and looking for variety and challenges on a daily basis? Yes? Here is your chance - Full Time or Part-time available.
+                      </Text>
+                    </AsidedLayout>
+                    <AsidedLayout renderAside={renderAsideMyActivityActions} size="270px">
+                      <IconButton icon="plus">Add Notes</IconButton>
+                    </AsidedLayout>
+                  </Section>
+                </Card>
               ))
             }
           </Card>
@@ -288,16 +294,39 @@ export default class Playground extends Component {
           </Section>
 
           <AsidedLayout reverse renderAside={renderJobDetailMetadata} size="360px">
-            <Card>
-              <Section>
-                <Text>
-                  <div
-                    dangerouslySetInnerHTML={{ __html: jobDetailsContent }} // eslint-disable-line react/no-danger
-                  />
-                </Text>
-              </Section>
+            <Card group>
+              <Card>
+                <Section>
+                  <Text>
+                    <div
+                      dangerouslySetInnerHTML={{ __html: jobDetailsContent }} // eslint-disable-line react/no-danger
+                    />
+                  </Text>
+                </Section>
+              </Card>
+              <Card>
+                <Section>
+                  <Text>You must have the <Strong>right to live and work</Strong> in this location to apply for this job.</Text>
+                </Section>
+              </Card>
             </Card>
           </AsidedLayout>
+        </PageBlock>
+
+        <PageBlock>
+          <Section header>
+            <Text hero>This job is no longer advertised</Text>
+          </Section>
+          <Card>
+            <Section group>
+              <Section>
+                <Text>Expired jobs remain on SEEK for 90 days after last advertised, or until they are removed by the advertiser.</Text>
+              </Section>
+              <Section>
+                <Button color="pink">Search for another job</Button>
+              </Section>
+            </Section>
+          </Card>
         </PageBlock>
 
         <PageBlock>
@@ -360,23 +389,25 @@ export default class Playground extends Component {
           <Section header>
             <Text hero>Text variants</Text>
           </Section>
-          <Card>
-            <Section>
-              <Text heading>Text component modifiers</Text>
-              <Text positive>Positive text</Text>
-              <Text critical>Critical text</Text>
-              <Text secondary>Secondary text</Text>
-              <Text strong>Strong text</Text>
-            </Section>
-          </Card>
-          <Card>
-            <Section>
-              <Text heading>Inline variant components</Text>
-              <Text><Positive>Positive text</Positive></Text>
-              <Text><Critical>Critical text</Critical></Text>
-              <Text><Secondary>Secondary text</Secondary></Text>
-              <Text><Strong>Strong text</Strong></Text>
-            </Section>
+          <Card group>
+            <Card>
+              <Section>
+                <Text heading>Text component modifiers</Text>
+                <Text positive>Positive text</Text>
+                <Text critical>Critical text</Text>
+                <Text secondary>Secondary text</Text>
+                <Text strong>Strong text</Text>
+              </Section>
+            </Card>
+            <Card>
+              <Section>
+                <Text heading>Inline variant components</Text>
+                <Text><Positive>Positive text</Positive></Text>
+                <Text><Critical>Critical text</Critical></Text>
+                <Text><Secondary>Secondary text</Secondary></Text>
+                <Text><Strong>Strong text</Strong></Text>
+              </Section>
+            </Card>
           </Card>
         </PageBlock>
       </div>

--- a/react/Card/Card.js
+++ b/react/Card/Card.js
@@ -2,13 +2,14 @@ import styles from './Card.less';
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 
-export default function Card({ className, children, transparent, ...restProps }) {
+export default function Card({ className, children, group, transparent, ...restProps }) {
   return (
     <div
       {...restProps}
       className={classnames({
         [className]: className,
         [styles.root]: true,
+        [styles.group]: group,
         [styles.transparent]: transparent
       })}>
       {children}
@@ -19,5 +20,6 @@ export default function Card({ className, children, transparent, ...restProps })
 Card.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node.isRequired,
+  group: PropTypes.bool,
   transparent: PropTypes.bool
 };

--- a/react/Card/Card.less
+++ b/react/Card/Card.less
@@ -3,6 +3,13 @@
 .root {
   background: @sk-white;
   margin-bottom: (@grid-row-height * 2);
+  .group & {
+    margin-bottom: 0;
+    box-shadow: inset 0 -1px 0 0 @sk-gray-medium;
+    &:last-child {
+      box-shadow: none;
+    }
+  }
 }
 
 .transparent {

--- a/react/Section/Section.js
+++ b/react/Section/Section.js
@@ -2,13 +2,14 @@ import styles from './Section.less';
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 
-export default function Section({ children, className, header, slim, ...restProps }) {
+export default function Section({ children, className, group, header, slim, ...restProps }) {
   return (
     <div
       {...restProps}
       className={classnames({
         [className]: className,
         [styles.root]: true,
+        [styles.group]: group,
         [styles.header]: header,
         [styles.slim]: slim
       })}>
@@ -20,6 +21,7 @@ export default function Section({ children, className, header, slim, ...restProp
 Section.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  group: PropTypes.bool,
   header: PropTypes.bool,
   slim: PropTypes.bool
 };

--- a/react/Section/Section.less
+++ b/react/Section/Section.less
@@ -2,10 +2,18 @@
 
 .root {
   padding: (@grid-row-height * 2) @grid-gutter-width;
+  .group & {
+    padding-top: @grid-row-height;
+    padding-bottom: @grid-row-height;
+  }
   @media only screen and (min-width: (@grid-container-width + (@grid-gutter-width * 2))) {
     padding-left: (@grid-gutter-width * 1.5);
     padding-right: (@grid-gutter-width * 1.5);
   }
+}
+
+.group {
+  padding: @grid-row-height 0;
 }
 
 .slim {


### PR DESCRIPTION
This PR is a proposal to introduce a `group` concept for layout components. When using a series of layout components that form a group, the current implementation adds a lot of unnecessary whitespace. Sometimes we want to visually separate a single `<Card>` or `<Section>` with minimum visual disruption. In the case of closely related cards, we add a single grey separator between them, and in the case of closely related sections, we only use 2 grid rows to separate them.

@tamoore I'd love your input on this, since this is primarily aimed to address the gaps you've raised.