### PR TITLE
chore(commitizen): Update cz-conventional-changelog to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "chai": "^3.5.0",
     "classnames": "^2.2.5",
     "commitizen": "^2.9.5",
-    "cz-conventional-changelog": "^1.2.0",
+    "cz-conventional-changelog": "^2.0.0",
     "ejs": "^2.4.2",
     "eslint": "^3.1.0",
     "eslint-plugin-jest": "^1.0.2",


### PR DESCRIPTION
This update to our commit flow now asks for breaking changes as a separate question, automatically
prefixing the response with the standard breaking change message prefix, instead of relying on
developers to provide this manually.