### PR TITLE
fix(header): Fix username class & remove divider responsively

### DIFF
--- a/react/Header/Header.less
+++ b/react/Header/Header.less
@@ -139,5 +139,9 @@
   width: @divider-width;
   height: 14px;
   border-right: @divider-width solid @sk-mid-gray-dark;
-  display: inline-block;
+  display: none;
+
+  @media @large-ia {
+    display: inline-block;
+  }
 }

--- a/react/Header/UserAccount/UserAccount.less
+++ b/react/Header/UserAccount/UserAccount.less
@@ -65,15 +65,16 @@
   bottom: 0;
 }
 
-.userDisplayName {
+.userName {
   pointer-events: none;
   overflow: hidden;
   text-overflow: ellipsis;
   display: inline-block;
-  max-width: 101px; // ~ 10 characters
+  white-space: nowrap;
+  max-width: 100px; // ~ 10 characters
 
   @media only screen and (min-width: 400px) {
-    max-width: 201px; // ~ 20 characters
+    max-width: 200px; // ~ 20 characters
   }
 }
 


### PR DESCRIPTION
Responsively we drop off the employer site link, but we were leaving the divider behind.
![screen shot 2017-02-27 at 11 41 45 am](https://cloud.githubusercontent.com/assets/912060/23345398/bc2994aa-fce1-11e6-9743-6e81e0cacecc.png)

Also noticed that the user name wasnt being truncated due to a class name not matching.
