### PR TITLE
fix(monthpicker): Fix stacking order of native month picker chevron

### DIFF
--- a/react/fields/MonthPicker/NativeMonthPicker/NativeMonthPicker.less
+++ b/react/fields/MonthPicker/NativeMonthPicker/NativeMonthPicker.less
@@ -7,7 +7,6 @@
 .input {
   .touchableText();
   display: block;
-  position: relative;
   width: 100%;
   height: @grid-row-height * 5;
   padding: 0 @field-gutter-width;
@@ -50,7 +49,6 @@
   display: flex;
   align-items: center;
   pointer-events: none;
-  z-index: 2;
 }
 
 .chevronSvg {


### PR DESCRIPTION
There is an unnecessary `z-index: 2` on the month pickers chevron that is causing issues with elements that overlap the chevron.

This fixes a bug we are seeing in showcase for the new profile page:

![screen shot 2017-03-08 at 2 18 24 pm](https://cloud.githubusercontent.com/assets/1896277/23688686/1b9d4952-040a-11e7-8fc6-1b89e1b72817.png)
