### PR TITLE
fix(Dropdown): Change chevron color and alignment

### DIFF
--- a/react/Dropdown/Dropdown.less
+++ b/react/Dropdown/Dropdown.less
@@ -56,21 +56,15 @@
 .chevron {
   position: absolute;
   right: 0;
-  top: @grid-row-height * 3;
   overflow: hidden;
-  color: @sk-mid-gray;
   height: (@interaction-type-row-span * @grid-row-height);
   border: 0;
   padding: 0 @field-gutter-width;
   background-color: transparent;
-  color: @sk-mid-gray;
   display: flex;
   align-items: center;
   pointer-events: none;
-
-  &:first-child {
-    top: 0;
-  }
+  color: @sk-black;
 }
 
 .chevronSvg {


### PR DESCRIPTION
This PR changes the chevron color to black, based on talk with Dan, he thought the black chevron would make the dropdown appear actionable.

Plus, this PR would also fix a chevron issue on smaller screen if the label and dropdown list are going together. The reason is that on smaller screens, the font-size of the label would change to 18px from 14px on bigger screens. Removing the 'top' would fix this issue.

this is the chevron layout issue on small screen:
![chevron](https://cloud.githubusercontent.com/assets/16127935/23933259/661f907a-0991-11e7-924c-1d3d273d1195.PNG)
