### PR TITLE
docs(build): Render docs with static site crawler

### DIFF
--- a/docs/components/Playground/Playground.js
+++ b/docs/components/Playground/Playground.js
@@ -21,6 +21,7 @@ import {
   Footer
 } from 'seek-style-guide/react';
 
+import { dummyLinkRenderer } from 'seek-style-guide/react/Header/Header.demo';
 import TextLink from './Atoms/TextLink/TextLink';
 import IconButton from './Atoms/IconButton/IconButton';
 import Tab from './Atoms/Tab/Tab';
@@ -129,7 +130,7 @@ export default class Playground extends Component {
   render() {
     return (
       <div>
-        <Header />
+        <Header linkRenderer={dummyLinkRenderer} />
 
         <PageBlock className={styles.header}>
           <AsidedLayout size="340px">
@@ -415,7 +416,7 @@ export default class Playground extends Component {
           </Card>
         </PageBlock>
 
-        <Footer />
+        <Footer linkRenderer={dummyLinkRenderer} />
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "semantic-release": "^6.3.2",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
-    "static-site-generator-webpack-plugin": "^2.1.0",
+    "static-site-generator-webpack-plugin": "^3.4.1",
     "superstatic": "^4.0.3",
     "surge": "^0.18.0",
     "validate-commit-msg": "^2.8.2",

--- a/webpack.static.render.config.js
+++ b/webpack.static.render.config.js
@@ -18,22 +18,6 @@ const appPaths = [
   path.resolve(__dirname, 'wip_modules')
 ];
 
-const routes = [
-  '/',
-  '/playground',
-  '/buttons',
-  '/textfields',
-  '/autosuggest',
-  '/textarea',
-  '/dropdown',
-  '/checkbox',
-  '/monthpicker',
-  '/typography',
-  '/dropdown',
-  '/header',
-  '/footer'
-];
-
 const config = {
   entry: `./${BASE_DIR}/server-render`,
 
@@ -79,7 +63,14 @@ const config = {
         BASE_HREF: JSON.stringify(process.env.BASE_HREF)
       }
     }),
-    new StaticSiteGeneratorPlugin('render.js', routes, { template }),
+    new StaticSiteGeneratorPlugin({
+      crawl: true,
+      paths: [
+        '/',
+        '/playground' // Currently unreachable by crawler
+      ],
+      locals: { template }
+    }),
     new webpack.optimize.UglifyJsPlugin({
       output: {
         comments: false


### PR DESCRIPTION
Using the latest version of static-site-generator-webpack-plugin, we no longer need to manually maintain a list of paths to render. Instead, we can automatically crawl all relative links from the two entry points we have currently.

Once we formalise the playground into a pattern library, we won't even need to provide paths at all since all pages with be crawlable from the root path.