### PR TITLE
feat(Section): Deprecate section groups and slim sections

### DIFF
--- a/docs/components/Home/Preface/Preface.js
+++ b/docs/components/Home/Preface/Preface.js
@@ -13,7 +13,7 @@ export default () => (
 
     <Columns>
 
-      <Section group>
+      <div>
         <Section>
           <Text strong>Design with empathy</Text>
           <Text>Understand our customers and end users better than they understand themselves.</Text>
@@ -33,9 +33,9 @@ export default () => (
           <Text strong>Content is king</Text>
           <Text>A person’s focus should be on their content, not on the UI. Help people work without interference.</Text>
         </Section>
-      </Section>
+      </div>
 
-      <Section group>
+      <div>
         <Section>
           <Text strong>Simplicity is powerful</Text>
           <Text>A minimalist form and function keeps users focused on their goals without distraction. It improves on-screen responsiveness as well as being suited to small-screen implementations.</Text>
@@ -55,9 +55,9 @@ export default () => (
           <Text strong>Accessibile design is good design</Text>
           <Text>In principle Seek design should be usable on all devices by all of the people in all situations. Design is simple, touch friendly and clear and aims for AA accessibility.</Text>
         </Section>
-      </Section>
+      </div>
 
-      <Section group>
+      <div>
         <Section>
           <Text strong>Make it mine</Text>
           <Text>The jobseeking experience is highly personal one that takes place over extended periods of time. The experience should align to the way that users conduct their jobseeking, allowing them to continue where they left off.</Text>
@@ -67,7 +67,7 @@ export default () => (
           <Text strong>Don’t make users think</Text>
           <Text>Observation shows that users do not read instructions. Interactions should be task focused, eliminating decision points and generally use one clear call to action.</Text>
         </Section>
-      </Section>
+      </div>
     </Columns>
   </PageBlock>
 );

--- a/docs/components/Playground/Playground.js
+++ b/docs/components/Playground/Playground.js
@@ -96,19 +96,18 @@ const renderJobDetailDate = () => (
 const renderJobDetailMetadata = () => (
   <div>
     <Card>
-      <Section group>
-        <Section>
-          <Button color="pink" className={styles.fullWidthTextField}>Apply for this job</Button>
-        </Section>
-        <Section>
-          <Text secondary>{'Applications for this role will take you to the advertiser\'s site.'}</Text>
-        </Section>
-        <Section>
-          <Columns tight>
-            <Button color="gray" className={styles.fullWidthTextField}><StarIcon /> Save Job</Button>
-            <Button color="gray" className={styles.fullWidthTextField}><MailIcon /> Send Job</Button>
-          </Columns>
-        </Section>
+      <Section>
+        <Button color="pink" className={styles.fullWidthTextField}>Apply for this job</Button>
+        <Text secondary>
+          <br />
+          {'Applications for this role will take you to the advertiser\'s site.'}
+          <br />
+          <br />
+        </Text>
+        <Columns tight>
+          <Button color="gray" className={styles.fullWidthTextField}><StarIcon /> Save Job</Button>
+          <Button color="gray" className={styles.fullWidthTextField}><MailIcon /> Send Job</Button>
+        </Columns>
       </Section>
     </Card>
     <Card>
@@ -190,7 +189,7 @@ export default class Playground extends Component {
 
           <AsidedLayout reverse renderAside={renderAsideSignIn} size="360px">
             <Card>
-              <Section slim className={styles.cardHeader}>
+              <Section className={styles.cardHeader}>
                 <TextLink href="https://www.seek.com.au" chevron="right">Are you an Employer?</TextLink>
               </Section>
 
@@ -214,7 +213,7 @@ export default class Playground extends Component {
 
           <AsidedLayout reverse renderAside={renderAsideRegister} size="360px">
             <Card>
-              <Section slim className={styles.cardHeader}>
+              <Section className={styles.cardHeader}>
                 <TextLink href="https://www.seek.com.au" chevron="right">Are you an Employer?</TextLink>
               </Section>
               <Section>
@@ -323,13 +322,13 @@ export default class Playground extends Component {
             <Text hero>This job is no longer advertised</Text>
           </Section>
           <Card>
-            <Section group>
-              <Section>
-                <Text>Expired jobs remain on SEEK for 90 days after last advertised, or until they are removed by the advertiser.</Text>
-              </Section>
-              <Section>
-                <Button color="pink">Search for another job</Button>
-              </Section>
+            <Section>
+              <Text>
+                Expired jobs remain on SEEK for 90 days after last advertised, or until they are removed by the advertiser.
+                <br />
+                <br />
+              </Text>
+              <Button color="pink">Search for another job</Button>
             </Section>
           </Card>
         </PageBlock>

--- a/docs/components/Playground/Playground.less
+++ b/docs/components/Playground/Playground.less
@@ -21,6 +21,8 @@
 .cardHeader {
   background: @sk-gray-lightest;
   text-align: right;
+  padding-top: 0;
+  padding-bottom: 0;
 
   @media only screen and (max-width: 740px) {
     display: none;

--- a/react/Section/Section.js
+++ b/react/Section/Section.js
@@ -2,16 +2,14 @@ import styles from './Section.less';
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 
-export default function Section({ children, className, group, header, slim, ...restProps }) {
+export default function Section({ children, className, header, ...restProps }) {
   return (
     <div
       {...restProps}
       className={classnames({
         [className]: className,
         [styles.root]: true,
-        [styles.group]: group,
-        [styles.header]: header,
-        [styles.slim]: slim
+        [styles.header]: header
       })}>
       {children}
     </div>
@@ -21,7 +19,5 @@ export default function Section({ children, className, group, header, slim, ...r
 Section.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
-  group: PropTypes.bool,
-  header: PropTypes.bool,
-  slim: PropTypes.bool
+  header: PropTypes.bool
 };

--- a/react/Section/Section.less
+++ b/react/Section/Section.less
@@ -2,23 +2,10 @@
 
 .root {
   padding: (@grid-row-height * 2) @grid-gutter-width;
-  .group & {
-    padding-top: @grid-row-height;
-    padding-bottom: @grid-row-height;
-  }
   @media only screen and (min-width: (@grid-container-width + (@grid-gutter-width * 2))) {
     padding-left: (@grid-gutter-width * 1.5);
     padding-right: (@grid-gutter-width * 1.5);
   }
-}
-
-.group {
-  padding: @grid-row-height 0;
-}
-
-.slim {
-  padding-top: 0;
-  padding-bottom: 0;
 }
 
 .header {


### PR DESCRIPTION
After some initial feedback, the whitespace-altering variants of the `Section` component are proving to be more confusing than anticipated, often providing either too much or too little whitespace.

As a result, we've decided to roll these back, opting for manual application-level styling in the short term. However, we'll continue a longer term focus on working with designers to figure out which whitespace rules we can standardise, but only after clear patterns have emerged across multiple applications.

BREAKING CHANGE: The "group" and "slim" props no longer have any effect on Section components

## Upgrade guide

Remove slim sections:

```diff
-<Section slim>
+<Section className={styles.slim}>

+.slim {
+  padding-top: 0;
+  padding-bottom: 0;
+}
```

Remove section groups (note that you'll need to manually adjust whitespace):

```diff
-<Section group>
  <Section>...</Section>
  <Section>...</Section>
  <Section>...</Section>
-</Section>
```
