### PR TITLE
feat(AsidedLayout): Add interface for className for aside div

### DIFF
--- a/react/AsidedLayout/AsidedLayout.js
+++ b/react/AsidedLayout/AsidedLayout.js
@@ -4,15 +4,20 @@ import classnames from 'classnames';
 
 const defaultRenderAside = () => null;
 
-const conditionallyRenderAside = (condition, renderAside, size) => (
+const conditionallyRenderAside = (condition, renderAside, classNameAside, size) => (
   condition ?
-    <div className={styles.aside} style={{ flexBasis: size }}>
+    <div
+      className={classnames({
+        [classNameAside]: classNameAside,
+        [styles.aside]: true
+      })}
+      style={{ flexBasis: size }}>
       {renderAside()}
     </div> :
     null
 );
 
-export default function AsidedLayout({ className, children, renderAside = defaultRenderAside, size, reverse, ...restProps }) {
+export default function AsidedLayout({ className, children, renderAside = defaultRenderAside, classNameAside, size, reverse, ...restProps }) {
   return (
     <div
       {...restProps}
@@ -21,11 +26,11 @@ export default function AsidedLayout({ className, children, renderAside = defaul
         [styles.root]: true,
         [styles.reverse]: reverse
       })}>
-      { conditionallyRenderAside(reverse, renderAside, size) }
+      { conditionallyRenderAside(reverse, renderAside, classNameAside, size) }
       <div className={styles.content}>
         {children}
       </div>
-      { conditionallyRenderAside(!reverse, renderAside, size) }
+      { conditionallyRenderAside(!reverse, renderAside, classNameAside, size) }
     </div>
   );
 }
@@ -34,6 +39,7 @@ AsidedLayout.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node.isRequired,
   renderAside: PropTypes.func,
+  classNameAside: PropTypes.string,
   size: PropTypes.string,
   reverse: PropTypes.bool
 };


### PR DESCRIPTION
Need interface to be able to apply a class to the aside div, screenshot shows use case for where I need to add `align-self: flex-end;`.
<img width="941" alt="screen shot 2017-03-23 at 1 40 52 pm" src="https://cloud.githubusercontent.com/assets/7741507/24231132/80c40f58-0fce-11e7-8631-dc60a64eddfe.png">
