### PR TITLE
docs(site): Fix GitHub Pages deployment

### DIFF
--- a/scripts/deploy-gh-pages.js
+++ b/scripts/deploy-gh-pages.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var ghpages = require('gh-pages');
-var basePath = path.join(__dirname, '../dist');
+var basePath = path.join(__dirname, '../docs/dist');
 var repoUrl = require('../package.json').repository.url;
 
 var GH_PAGES_TOKEN = process.env.GH_PAGES_TOKEN;


### PR DESCRIPTION
The `basePath` in the deployment script was pointing at the old `dist` directory 😞 