### PR TITLE
fix(styles): Provide browser list to Autoprefixer

### DIFF
--- a/config/autoprefixer.config.js
+++ b/config/autoprefixer.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  browsers: [
+    '> 1%',
+    'Last 2 versions',
+    'ie >= 10',
+    'Safari >= 8',
+    'iOS >= 8'
+  ]
+};

--- a/docs/webpack.static.client.config.js
+++ b/docs/webpack.static.client.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const autoprefixer = require('autoprefixer');
+const autoprefixerConfig = require('../config/autoprefixer.config');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const decorateClientConfig = require('../webpack').decorateClientConfig;
 const babelConfig = require('../babel.config.js')({ reactHotLoader: false });
@@ -48,7 +49,7 @@ const config = {
   },
 
   postcss: [
-    autoprefixer
+    autoprefixer(autoprefixerConfig)
   ],
 
   plugins: [

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -2,6 +2,7 @@ const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const nodeExternals = require('webpack-node-externals');
 const chalk = require('chalk');
+const autoprefixerConfig = require('../config/autoprefixer.config');
 
 const isProduction = () => process.env.NODE_ENV === 'production';
 
@@ -54,15 +55,7 @@ const decoratePostCss = (config, options) => {
   // Setup postcss-loader plugin packs
   // (https://github.com/postcss/postcss-loader#plugins-packs)
   const postcssPlugins = [
-    require('autoprefixer')({
-      browsers: [
-        '> 1%',
-        'Last 2 versions',
-        'ie >= 10',
-        'Safari >= 8',
-        'iOS >= 8'
-      ]
-    })
+    require('autoprefixer')(autoprefixerConfig)
   ].concat(!cssSelectorPrefix ? [] : [
     require('postcss-prefix-selector')({
       prefix: `:global(${cssSelectorPrefix})`

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -54,7 +54,15 @@ const decoratePostCss = (config, options) => {
   // Setup postcss-loader plugin packs
   // (https://github.com/postcss/postcss-loader#plugins-packs)
   const postcssPlugins = [
-    require('autoprefixer')
+    require('autoprefixer')({
+      browsers: [
+        '> 1%',
+        'Last 2 versions',
+        'ie >= 10',
+        'Safari >= 8',
+        'iOS >= 8'
+      ]
+    })
   ].concat(!cssSelectorPrefix ? [] : [
     require('postcss-prefix-selector')({
       prefix: `:global(${cssSelectorPrefix})`


### PR DESCRIPTION
We're currently relying on the default browser support policy of Autoprefixer, instead of defining our own, as we would typically do in an application context. The list in this PR is taken from our core search product, but further changes may be required.