### PR TITLE
fix(dist): Add .npmignore so dist folder is published

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+npm-debug.log
+yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
 node_modules
-dist
+docs
 npm-debug.log
 yarn.lock


### PR DESCRIPTION
It is a copy of what was in .gitignore but swapped dist for docs so we can use https://github.com/seek-oss/seek-style-guide/pull/169.