### PR TITLE
fix(components): Automatically add displayName to React components

### DIFF
--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -1,9 +1,11 @@
 module.exports = ({ reactHotLoader = false }) => ({
+  babelrc: false,
   presets: [
     'es2015',
     'react'
   ],
   plugins: [
+    'add-react-displayname',
     'transform-class-properties',
     'transform-object-rest-spread'
   ].concat(reactHotLoader ? [

--- a/docs/webpack.dev.config.js
+++ b/docs/webpack.dev.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 const autoprefixer = require('autoprefixer');
 const decorateClientConfig = require('../webpack').decorateClientConfig;
-const babelConfig = require('../babel.config.js')({ reactHotLoader: true });
+const babelConfig = require('../config/babel.config.js')({ reactHotLoader: true });
 
 // Must be absolute paths
 const appPaths = [

--- a/docs/webpack.static.client.config.js
+++ b/docs/webpack.static.client.config.js
@@ -4,7 +4,7 @@ const autoprefixer = require('autoprefixer');
 const autoprefixerConfig = require('../config/autoprefixer.config');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const decorateClientConfig = require('../webpack').decorateClientConfig;
-const babelConfig = require('../babel.config.js')({ reactHotLoader: false });
+const babelConfig = require('../config/babel.config.js')({ reactHotLoader: false });
 
 const appCss = new ExtractTextPlugin('app.css');
 

--- a/docs/webpack.static.render.config.js
+++ b/docs/webpack.static.render.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 const webpack = require('webpack');
 const autoprefixer = require('autoprefixer');
 const decorateServerConfig = require('../webpack').decorateServerConfig;
-const babelConfig = require('../babel.config.js')({ reactHotLoader: false });
+const babelConfig = require('../config/babel.config.js')({ reactHotLoader: false });
 const StaticSiteGeneratorPlugin = require('static-site-generator-webpack-plugin');
 
 const templatePath = path.resolve(__dirname, 'index.ejs');

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "autoprefixer": "6.3.7",
     "babel-core": "6.10.4",
     "babel-loader": "6.2.4",
+    "babel-plugin-add-react-displayname": "0.0.4",
     "babel-plugin-transform-class-properties": "6.10.2",
     "babel-plugin-transform-object-rest-spread": "6.8.0",
     "babel-preset-es2015": "6.9.0",

--- a/standalone/header-footer/webpack.config.js
+++ b/standalone/header-footer/webpack.config.js
@@ -4,7 +4,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 const decorateClientConfig = require('../../webpack').decorateClientConfig;
-const babelConfig = require('../../babel.config.js')({ reactHotLoader: false });
+const babelConfig = require('../../config/babel.config.js')({ reactHotLoader: false });
 const cssSelectorPrefix = require('./cssSelectorPrefix');
 
 const headerCss = new ExtractTextPlugin('styles.css');

--- a/test/babel.transform.js
+++ b/test/babel.transform.js
@@ -1,4 +1,4 @@
 const babelJest = require('babel-jest');
-const babelConfig = require('../babel.config.js')({ reactHotLoader: false });
+const babelConfig = require('../config/babel.config.js')({ reactHotLoader: false });
 
 module.exports = babelJest.createTransformer(babelConfig);

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -2,6 +2,7 @@ const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const nodeExternals = require('webpack-node-externals');
 const chalk = require('chalk');
+const babelConfig = require('../config/babel.config.js')({ reactHotLoader: false });
 const autoprefixerConfig = require('../config/autoprefixer.config');
 
 const isProduction = () => process.env.NODE_ENV === 'production';
@@ -115,14 +116,7 @@ const getCommonLoaders = () => ([
     include: styleGuidePaths,
     exclude: /\.raw\.js$/,
     loader: require.resolve('babel-loader'),
-    query: {
-      babelrc: false,
-      presets: ['es2015', 'react'],
-      plugins: [
-        'transform-class-properties',
-        'transform-object-rest-spread'
-      ]
-    }
+    query: babelConfig
   },
   {
     test: /\.raw\.js$/,


### PR DESCRIPTION
Also refactored babel config into the 'config' folder, shared with webpack decorators.

I stumbled across this issue when I noticed that, seemingly since we fixed the minification step, our documentation now shows minified component names in many cases, e.g.


<img width="397" alt="screen shot 2017-04-10 at 1 28 13 pm" src="https://cloud.githubusercontent.com/assets/696693/24844953/98785844-1df1-11e7-897b-1da7bdb8a0c3.png">
