### PR TITLE
fix(Text): Use nested span for modifiers to fix import order issues

### DIFF
--- a/react/Text/Text.js
+++ b/react/Text/Text.js
@@ -33,13 +33,17 @@ export default function Text({
         [styles.headline]: headline,
         [styles.heading]: heading,
         [styles.hero]: hero,
-        [styles.raw]: raw,
-        [stylesPositive.root]: positive,
-        [stylesCritical.root]: critical,
-        [stylesSecondary.root]: secondary,
-        [stylesStrong.root]: strong
+        [styles.raw]: raw
       })}>
-      {children}
+      <span
+        className={classnames({
+          [stylesPositive.root]: positive,
+          [stylesCritical.root]: critical,
+          [stylesSecondary.root]: secondary,
+          [stylesStrong.root]: strong
+        })}>
+        {children}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
This fixes an issue raised by @mengtzu, seemingly caused when text modifier components like `<Strong>` are imported *before* usage of its equivalent inline modifier like `<Text strong>`.

An example of this issue can be seen below (note that the `Strong` styles are defined *before* the `Text` styles):

![screen shot 2017-04-10 at 2 26 56 pm](https://cloud.githubusercontent.com/assets/696693/24846181/e501367c-1dfb-11e7-955e-86a4eb85d604.png)
