### PR TITLE
fix(Button): Remove focus ring from transparent button

### DIFF
--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -86,6 +86,10 @@
     transform: none;
   });
 
+  .focusState({
+    box-shadow: none;
+  });
+
   @media only screen and (min-width: @responsive-breakpoint) {
     .touchableText(@standard-type-scale);
   }


### PR DESCRIPTION
A transparent button should have the same focus behaviour as our links, however they are currently displaying like this:
![screen shot 2017-04-20 at 10 09 26 am](https://cloud.githubusercontent.com/assets/912060/25207380/7764a636-25b1-11e7-8c9d-a07b4876552b.png)
