### PR TITLE
fix(PageBlock): Align PageBlock content with header responsively

### DIFF
--- a/react/PageBlock/PageBlock.less
+++ b/react/PageBlock/PageBlock.less
@@ -1,10 +1,11 @@
 @import (reference) "~seek-style-guide/theme";
 
-.content {
-  max-width: @grid-container-width + (@grid-gutter-width * 2);
-  margin: 0 auto;
+@classic-ia: ~"only screen and (min-width: 1025px)";
 
-  @media only screen and (min-width: @responsive-breakpoint) {
+.content {
+  @media @classic-ia {
+    max-width: @grid-container-width + (@grid-gutter-width * 2);
+    margin: 0 auto;
     padding-left: @grid-gutter-width;
     padding-right: @grid-gutter-width;
   }


### PR DESCRIPTION
This PR aligns the content area provided by `PageBlock` with the `Header`. The `Header` goes full width below `1025px` so `PageBlock` now follows suit removing width and gutters.