### PR TITLE
refactor(Tests): Fix warnings for deprecated react test packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "preact-compat": "^3.14.3",
     "react": "^15.3.1",
     "react-addons-pure-render-mixin": "^15.3.1",
-    "react-addons-test-utils": "^15.3.1",
     "react-autosuggest": "^8.0.0",
     "react-baseline": "^1.0.1",
     "react-copy-to-clipboard": "4.2.1",

--- a/react/Autosuggest/Autosuggest.test.js
+++ b/react/Autosuggest/Autosuggest.test.js
@@ -3,12 +3,12 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import React from 'react';
 import {
-  createRenderer,
   renderIntoDocument,
   scryRenderedDOMComponentsWithClass,
   findRenderedDOMComponentWithClass,
   Simulate
-} from 'react-addons-test-utils';
+} from 'react-dom/test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import Autosuggest from './Autosuggest';
 
 chai.use(sinonChai);

--- a/react/Button/Button.test.js
+++ b/react/Button/Button.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import React from 'react';
-import { createRenderer } from 'react-addons-test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import Button from './Button';
 
 const renderer = createRenderer();

--- a/react/Checkbox/Checkbox.test.js
+++ b/react/Checkbox/Checkbox.test.js
@@ -3,12 +3,12 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import React from 'react';
 import {
-  createRenderer,
   Simulate,
   renderIntoDocument,
   scryRenderedDOMComponentsWithClass,
   findRenderedDOMComponentWithClass
-} from 'react-addons-test-utils';
+} from 'react-dom/test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import SyntheticEvent from 'react-dom/lib/SyntheticEvent';
 import { findAllWithClass } from 'react-shallow-testutils';
 import Checkbox from './Checkbox';

--- a/react/Dropdown/Dropdown.test.js
+++ b/react/Dropdown/Dropdown.test.js
@@ -2,9 +2,7 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import React from 'react';
-import {
-  createRenderer
-} from 'react-addons-test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import {
   findAllWithClass,
   findAllWithType

--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.test.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.test.js
@@ -4,11 +4,11 @@ import sinonChai from 'sinon-chai';
 import React from 'react';
 import CustomMonthPicker from './CustomMonthPicker';
 import {
-  createRenderer,
   renderIntoDocument,
   Simulate,
   scryRenderedDOMComponentsWithClass
-} from 'react-addons-test-utils';
+} from 'react-dom/test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import { findAllWithClass } from 'react-shallow-testutils';
 
 chai.use(sinonChai);

--- a/react/MonthPicker/MonthPicker.test.js
+++ b/react/MonthPicker/MonthPicker.test.js
@@ -2,9 +2,7 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import React from 'react';
-import {
-  createRenderer
-} from 'react-addons-test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import { findAllWithClass } from 'react-shallow-testutils';
 import MonthPicker from './MonthPicker';
 

--- a/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.test.js
+++ b/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.test.js
@@ -4,11 +4,11 @@ import sinonChai from 'sinon-chai';
 import React from 'react';
 import NativeMonthPicker from './NativeMonthPicker';
 import {
-  createRenderer,
   renderIntoDocument,
   Simulate,
   findRenderedDOMComponentWithClass
-} from 'react-addons-test-utils';
+} from 'react-dom/test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import { findAllWithClass } from 'react-shallow-testutils';
 
 chai.use(sinonChai);

--- a/react/Rating/Rating.test.js
+++ b/react/Rating/Rating.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import React from 'react';
-import { createRenderer } from 'react-addons-test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import Rating from './Rating';
 
 describe('Rating', () => {

--- a/react/TextField/TextField.test.js
+++ b/react/TextField/TextField.test.js
@@ -3,12 +3,12 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import React from 'react';
 import {
-  createRenderer,
   Simulate,
   renderIntoDocument,
   findRenderedDOMComponentWithClass,
   scryRenderedDOMComponentsWithClass
-} from 'react-addons-test-utils';
+} from 'react-dom/test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import SyntheticEvent from 'react-dom/lib/SyntheticEvent';
 import { findAllWithClass } from 'react-shallow-testutils';
 import TextField from './TextField';

--- a/react/TextLink/TextLink.test.js
+++ b/react/TextLink/TextLink.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import React from 'react';
-import { createRenderer } from 'react-addons-test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import TextLink from './TextLink';
 
 const renderer = createRenderer();

--- a/react/Textarea/Textarea.test.js
+++ b/react/Textarea/Textarea.test.js
@@ -2,9 +2,7 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import React from 'react';
-import {
-  createRenderer
-} from 'react-addons-test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import { findAllWithClass } from 'react-shallow-testutils';
 import Textarea from './Textarea';
 

--- a/react/private/FieldLabel/FieldLabel.test.js
+++ b/react/private/FieldLabel/FieldLabel.test.js
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import React from 'react';
-import { createRenderer } from 'react-addons-test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import { findAllWithType } from 'react-shallow-testutils';
 import FieldLabel from './FieldLabel';
 import Secondary from '../../Secondary/Secondary';

--- a/react/private/FieldMessage/FieldMessage.test.js
+++ b/react/private/FieldMessage/FieldMessage.test.js
@@ -2,9 +2,7 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import React from 'react';
-import {
-  createRenderer
-} from 'react-addons-test-utils';
+import { createRenderer } from 'react-test-renderer/shallow';
 import { findAllWithClass } from 'react-shallow-testutils';
 import FieldMessage from './FieldMessage';
 


### PR DESCRIPTION
Were currently seeing a lot of warnings when running tests which is making it difficult to see when tests are failing.  This PR tidies up all those warnings

![screen shot 2017-05-15 at 1 50 09 pm](https://cloud.githubusercontent.com/assets/1896277/26042065/8b296a94-3975-11e7-8a0c-9180442661a0.png)
