### PR TITLE
fix(Header): Fix standalone Header menu by upgrading Preact

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "opn-cli": "^3.1.0",
     "pad-left": "^2.1.0",
     "postcss-prefix-selector": "^1.6.0",
-    "preact": "^7.2.1",
+    "preact": "^8.1.0",
     "preact-compat": "^3.14.3",
     "react": "^15.3.1",
     "react-addons-pure-render-mixin": "^15.3.1",


### PR DESCRIPTION
With the previous version of Preact, it took two clicks to open the menu because the underlying checkbox wasn't being updated. This issue is resolved with the latest version of Preact.