### PR TITLE
ci(PullApprove): Disable 'reset_on_push'

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -14,6 +14,6 @@ groups:
       title_regex: '(WIP|wip)'
       explanation: 'This PR is a work in progress...'
     reset_on_push:
-      enabled: true
+      enabled: false
     reset_on_reopened:
       enabled: true


### PR DESCRIPTION
This option sounds great in theory, but causes a lot of friction. Every time you merge the latest changes into your PR branch, it invalidates all approvals. This forces everyone to re-approve if another PR is merged ahead of you.