### PR TITLE
ci(PullApprove): Validate PR titles

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -11,8 +11,8 @@ groups:
     approve_by_comment:
       enabled: false
     always_rejected:
-      title_regex: '(WIP|wip)'
-      explanation: 'This PR is a work in progress...'
+      title_regex: '^((?!: ).)*$'
+      explanation: 'Invalid title. Please read the contribution guide: https://github.com/seek-oss/seek-style-guide/blob/master/CONTRIBUTING.md'
     reset_on_push:
       enabled: true
     reset_on_reopened:


### PR DESCRIPTION
Rather than checking for `WIP`, I figured a more important check is that it features the string `: ` at all. WIP commits don't include this string, so they'll still fail. I could have gone a lot further with the validation, but figured I'd keep it simple enough for this use case.