### PR TITLE
feat(Sketch): Publish Sketch files to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 npm-debug.log
 yarn.lock
 *.sketch
+sketch-manifest.json

--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,4 @@ node_modules
 docs
 npm-debug.log
 yarn.lock
-*.sketch
 *__sketch

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ notifications:
   email: false
 before_script:
   - npm prune
+script:
+  - npm test
+  - npm run git-to-sketch
 after_success:
   - if [ ${TRAVIS_SECURE_ENV_VARS} = "true" ]; then
       if [ -n "$TRAVIS_PULL_REQUEST_SHA" ]; then

--- a/scripts/git-to-sketch.js
+++ b/scripts/git-to-sketch.js
@@ -3,15 +3,27 @@ const glob = promisify(require('glob'));
 const zipFolder = promisify(require('zip-folder'));
 const chalk = require('chalk');
 const path = require('path');
+const fs = require('fs');
 
 glob('**/*__sketch/').then(sketchDirs => {
-  sketchDirs.forEach(sketchDir => {
+  const relativePaths = sketchDirs.map(sketchDir => {
     const targetFilePath = getTargetFilePath(sketchDir);
+    const relativeFilePath = path.relative(process.cwd(), targetFilePath);
 
     zipFolder(sketchDir, targetFilePath).then(() => {
-      console.log(chalk.green(`[💎 ] ${path.basename(targetFilePath)} is now ready for Sketch!`));
+      console.log(chalk.green(`[💎 ] ${relativeFilePath} is now ready for Sketch!`));
     });
-  })
+
+    return relativeFilePath;
+  });
+
+  const sketchManifestJson = JSON.stringify({
+    files: relativePaths
+  }, null, 2);
+
+  const sketchManifestPath = path.join(process.cwd(), 'sketch-manifest.json');
+  fs.writeFileSync(sketchManifestPath, sketchManifestJson);
+  console.log(chalk.green(`[📄 ] Wrote Sketch file manifest!`));
 });
 
 function getTargetFilePath(dir) {

--- a/scripts/sketch-to-git.js
+++ b/scripts/sketch-to-git.js
@@ -9,11 +9,12 @@ const path = require('path');
 glob('**/*.sketch').then(sketchFiles => {
   sketchFiles.forEach(sketchFile => {
     const targetPath = getTargetPath(sketchFile);
+    const relativePath = path.relative(process.cwd(), targetPath);
 
     rimraf(targetPath).then(() => {
       extractZip(sketchFile, { dir: targetPath }).then(() => {
         rewriteFiles('**/*__sketch/**/*.json', jsonTransformer).then(() => {
-          console.log(chalk.green(`[💎 ] ${path.basename(sketchFile)} is now ready for git!`));
+          console.log(chalk.green(`[💎 ] ${relativePath} is now ready for git!`));
         });
       });
     });


### PR DESCRIPTION
The idea is to enable design tooling to download the components' Sketch files, probably from [unpkg](https://unpkg.com) so that clients don't need to unpack tarballs from npm.

Since our design tools won't have any idea where to find all the Sketch files, we now generate a `sketch-manifest.json` file which lists all the relative paths for consumers to iterate over, which currently looks like this:

```json
{
  "files": [
    "react/Button/Button.sketch",
    "react/Checkbox/Checkbox.sketch"
  ]
}
```