### PR TITLE
feat(Text): Add condensed text variant, tweak mobile headline styles

### DIFF
--- a/react/Text/Text.demo.js
+++ b/react/Text/Text.demo.js
@@ -21,10 +21,10 @@ export default {
           })
         },
         {
-          label: 'Condensed',
+          label: 'Compact',
           transformProps: props => ({
             ...props,
-            condensed: true
+            compact: true
           })
         }
       ]

--- a/react/Text/Text.demo.js
+++ b/react/Text/Text.demo.js
@@ -19,6 +19,13 @@ export default {
             ...props,
             strong: true
           })
+        },
+        {
+          label: 'Condensed',
+          transformProps: props => ({
+            ...props,
+            condensed: true
+          })
         }
       ]
     },

--- a/react/Text/Text.js
+++ b/react/Text/Text.js
@@ -18,7 +18,7 @@ export default function Text({
   heading,
   hero,
   raw,
-  condensed,
+  compact,
   positive,
   critical,
   secondary,
@@ -37,7 +37,7 @@ export default function Text({
         [styles.heading]: heading,
         [styles.hero]: hero,
         [styles.raw]: raw,
-        [styles.condensed]: condensed
+        [styles.compact]: compact
       })}>
       <span
         className={classnames({
@@ -61,7 +61,7 @@ Text.propTypes = {
   heading: PropTypes.bool,
   hero: PropTypes.bool,
   raw: PropTypes.bool,
-  condensed: PropTypes.bool,
+  compact: PropTypes.bool,
   positive: PropTypes.bool,
   critical: PropTypes.bool,
   secondary: PropTypes.bool,

--- a/react/Text/Text.js
+++ b/react/Text/Text.js
@@ -18,6 +18,7 @@ export default function Text({
   heading,
   hero,
   raw,
+  condensed,
   positive,
   critical,
   secondary,
@@ -35,7 +36,8 @@ export default function Text({
         [styles.headline]: headline,
         [styles.heading]: heading,
         [styles.hero]: hero,
-        [styles.raw]: raw
+        [styles.raw]: raw,
+        [styles.condensed]: condensed
       })}>
       <span
         className={classnames({
@@ -59,6 +61,7 @@ Text.propTypes = {
   heading: PropTypes.bool,
   hero: PropTypes.bool,
   raw: PropTypes.bool,
+  condensed: PropTypes.bool,
   positive: PropTypes.bool,
   critical: PropTypes.bool,
   secondary: PropTypes.bool,

--- a/react/Text/Text.less
+++ b/react/Text/Text.less
@@ -1,7 +1,6 @@
 @import (reference) "~seek-style-guide/theme";
 
 .root {
-  .standardTextResponsive();
   padding-bottom: @grid-row-height;
 
   .root {
@@ -20,11 +19,19 @@
   }
 }
 
-.small { .smallTextResponsive(); }
-.subheading { .subheadingTextResponsive(); }
-.headline { .headlineTextResponsive(); }
-.heading { .headingTextResponsive(); }
-.hero { .heroTextResponsive(); }
+.root:not(.condensed) { .standardTextResponsive(); }
+.small:not(.condensed) { .smallTextResponsive(); }
+.subheading:not(.condensed) { .subheadingTextResponsive(); }
+.headline:not(.condensed) { .headlineTextResponsive(); }
+.heading:not(.condensed) { .headingTextResponsive(); }
+.hero:not(.condensed) { .heroTextResponsive(); }
+
+.root.condensed { .standardTextResponsive(@condensed: true); }
+.small.condensed { .smallTextResponsive(@condensed: true); }
+.subheading.condensed { .subheadingTextResponsive(@condensed: true); }
+.headline.condensed { .headlineTextResponsive(@condensed: true); }
+.heading.condensed { .headingTextResponsive(@condensed: true); }
+.hero.condensed { .heroTextResponsive(@condensed: true); }
 
 .raw {
   padding-bottom: 0;

--- a/react/Text/Text.less
+++ b/react/Text/Text.less
@@ -19,19 +19,19 @@
   }
 }
 
-.root:not(.condensed) { .standardTextResponsive(); }
-.small:not(.condensed) { .smallTextResponsive(); }
-.subheading:not(.condensed) { .subheadingTextResponsive(); }
-.headline:not(.condensed) { .headlineTextResponsive(); }
-.heading:not(.condensed) { .headingTextResponsive(); }
-.hero:not(.condensed) { .heroTextResponsive(); }
+.root:not(.compact) { .standardTextResponsive(); }
+.small:not(.compact) { .smallTextResponsive(); }
+.subheading:not(.compact) { .subheadingTextResponsive(); }
+.headline:not(.compact) { .headlineTextResponsive(); }
+.heading:not(.compact) { .headingTextResponsive(); }
+.hero:not(.compact) { .heroTextResponsive(); }
 
-.root.condensed { .standardTextResponsive(@condensed: true); }
-.small.condensed { .smallTextResponsive(@condensed: true); }
-.subheading.condensed { .subheadingTextResponsive(@condensed: true); }
-.headline.condensed { .headlineTextResponsive(@condensed: true); }
-.heading.condensed { .headingTextResponsive(@condensed: true); }
-.hero.condensed { .heroTextResponsive(@condensed: true); }
+.root.compact { .standardTextResponsive(@compact: true); }
+.small.compact { .smallTextResponsive(@compact: true); }
+.subheading.compact { .subheadingTextResponsive(@compact: true); }
+.headline.compact { .headlineTextResponsive(@compact: true); }
+.heading.compact { .headingTextResponsive(@compact: true); }
+.hero.compact { .heroTextResponsive(@compact: true); }
 
 .raw {
   padding-bottom: 0;

--- a/theme/mixins/type.less
+++ b/theme/mixins/type.less
@@ -10,12 +10,12 @@
 .standardText()   { .__baselineType(@standard-type-scale, @standard-type-row-span);     }
 .smallText()      { .__baselineType(@small-type-scale, @small-type-row-span);           }
 
-.heroTextResponsive(@condensed: false)       { .__responsiveType("hero"; @condensed);       }
-.headlineTextResponsive(@condensed: false)   { .__responsiveType("headline"; @condensed);   }
-.headingTextResponsive(@condensed: false)    { .__responsiveType("heading"; @condensed);    }
-.subheadingTextResponsive(@condensed: false) { .__responsiveType("subheading"; @condensed); }
-.standardTextResponsive(@condensed: false)   { .__responsiveType("standard"; @condensed);   }
-.smallTextResponsive(@condensed: false)      { .__responsiveType("small"; @condensed);      }
+.heroTextResponsive(@compact: false)       { .__responsiveType("hero"; @compact);       }
+.headlineTextResponsive(@compact: false)   { .__responsiveType("headline"; @compact);   }
+.headingTextResponsive(@compact: false)    { .__responsiveType("heading"; @compact);    }
+.subheadingTextResponsive(@compact: false) { .__responsiveType("subheading"; @compact); }
+.standardTextResponsive(@compact: false)   { .__responsiveType("standard"; @compact);   }
+.smallTextResponsive(@compact: false)      { .__responsiveType("small"; @compact);      }
 
 .touchableText(@font-scale: @interaction-type-scale) {
   .rawText(@font-scale);

--- a/theme/mixins/type.less
+++ b/theme/mixins/type.less
@@ -10,12 +10,12 @@
 .standardText()   { .__baselineType(@standard-type-scale, @standard-type-row-span);     }
 .smallText()      { .__baselineType(@small-type-scale, @small-type-row-span);           }
 
-.heroTextResponsive()       { .__responsiveType("hero");       }
-.headlineTextResponsive()   { .__responsiveType("headline");   }
-.headingTextResponsive()    { .__responsiveType("heading");    }
-.subheadingTextResponsive() { .__responsiveType("subheading"); }
-.standardTextResponsive()   { .__responsiveType("standard");   }
-.smallTextResponsive()      { .__responsiveType("small");      }
+.heroTextResponsive(@condensed: false)       { .__responsiveType("hero"; @condensed);       }
+.headlineTextResponsive(@condensed: false)   { .__responsiveType("headline"; @condensed);   }
+.headingTextResponsive(@condensed: false)    { .__responsiveType("heading"; @condensed);    }
+.subheadingTextResponsive(@condensed: false) { .__responsiveType("subheading"; @condensed); }
+.standardTextResponsive(@condensed: false)   { .__responsiveType("standard"; @condensed);   }
+.smallTextResponsive(@condensed: false)      { .__responsiveType("small"; @condensed);      }
 
 .touchableText(@font-scale: @interaction-type-scale) {
   .rawText(@font-scale);

--- a/theme/type/responsiveType.less
+++ b/theme/type/responsiveType.less
@@ -1,7 +1,7 @@
 @import (reference) "type";
 @import (reference) "baselineType";
 
-.__responsiveType(@variant; @condensed) when (isstring(@variant)) {
+.__responsiveType(@variant; @compact) when (isstring(@variant)) {
   // Define responsive text breakpoint limits
   @max-breakpoint: (@responsive-breakpoint - 1);
   @min-breakpoint: @responsive-breakpoint;
@@ -11,8 +11,8 @@
   @row-span: "@{variant}-type-row-span";
   @weight: "@{variant}-type-weight";
 
-  .makeMobileVarSuffix() when (not(@condensed)) { @mobile-var-suffix: ""; }
-  .makeMobileVarSuffix() when (@condensed) { @mobile-var-suffix: "-condensed"; }
+  .makeMobileVarSuffix() when (not(@compact)) { @mobile-var-suffix: ""; }
+  .makeMobileVarSuffix() when (@compact) { @mobile-var-suffix: "-compact"; }
   .makeMobileVarSuffix();
 
   @mobile-type-scale: "@{type-scale}-mobile@{mobile-var-suffix}";

--- a/theme/type/responsiveType.less
+++ b/theme/type/responsiveType.less
@@ -1,7 +1,7 @@
 @import (reference) "type";
 @import (reference) "baselineType";
 
-.__responsiveType(@variant) when (isstring(@variant)) {
+.__responsiveType(@variant; @condensed) when (isstring(@variant)) {
   // Define responsive text breakpoint limits
   @max-breakpoint: (@responsive-breakpoint - 1);
   @min-breakpoint: @responsive-breakpoint;
@@ -10,9 +10,14 @@
   @type-scale: "@{variant}-type-scale";
   @row-span: "@{variant}-type-row-span";
   @weight: "@{variant}-type-weight";
-  @mobile-type-scale: "@{type-scale}-mobile";
-  @mobile-row-span: "@{row-span}-mobile";
-  @mobile-weight: "@{variant}-type-weight-mobile";
+
+  .makeMobileVarSuffix() when (not(@condensed)) { @mobile-var-suffix: ""; }
+  .makeMobileVarSuffix() when (@condensed) { @mobile-var-suffix: "-condensed"; }
+  .makeMobileVarSuffix();
+
+  @mobile-type-scale: "@{type-scale}-mobile@{mobile-var-suffix}";
+  @mobile-row-span: "@{row-span}-mobile@{mobile-var-suffix}";
+  @mobile-weight: "@{variant}-type-weight-mobile@{mobile-var-suffix}";
 
   @media only screen and (max-width: @max-breakpoint) {
     .__baselineType(@@mobile-type-scale, @@mobile-row-span);

--- a/theme/type/type.less
+++ b/theme/type/type.less
@@ -16,13 +16,19 @@
 @hero-type-scale-mobile: 3.6;
 @hero-type-weight: @sk-light;
 @hero-type-weight-mobile: @sk-light;
+@hero-type-row-span-mobile-condensed: 4;
+@hero-type-scale-mobile-condensed: 2.8;
+@hero-type-weight-mobile-condensed: @sk-light;
 
 @headline-type-row-span: 4;
 @headline-type-scale: 2.8;
-@headline-type-row-span-mobile: @headline-type-row-span;
-@headline-type-scale-mobile: @headline-type-scale;
+@headline-type-row-span-mobile: 3;
+@headline-type-scale-mobile: 2.4;
 @headline-type-weight: 400;
-@headline-type-weight-mobile: 400;
+@headline-type-weight-mobile: @sk-bold;
+@headline-type-row-span-mobile-condensed: @headline-type-row-span-mobile;
+@headline-type-scale-mobile-condensed: @headline-type-scale-mobile;
+@headline-type-weight-mobile-condensed: @headline-type-weight-mobile;
 
 @heading-type-row-span: 3;
 @heading-type-scale: 2.1;
@@ -30,6 +36,9 @@
 @heading-type-scale-mobile: 2.4;
 @heading-type-weight: 400;
 @heading-type-weight-mobile: @sk-bold;
+@heading-type-row-span-mobile-condensed: @heading-type-row-span;
+@heading-type-scale-mobile-condensed: @heading-type-scale;
+@heading-type-weight-mobile-condensed: @heading-type-weight;
 
 @subheading-type-row-span: 3;
 @subheading-type-scale: 1.8;
@@ -37,6 +46,9 @@
 @subheading-type-scale-mobile: 2.1;
 @subheading-type-weight: 400;
 @subheading-type-weight-mobile: 400;
+@subheading-type-row-span-mobile-condensed: @subheading-type-row-span;
+@subheading-type-scale-mobile-condensed: @subheading-type-scale;
+@subheading-type-weight-mobile-condensed: @subheading-type-weight;
 
 @standard-type-row-span: 2;
 @standard-type-scale: 1.4;
@@ -44,6 +56,9 @@
 @standard-type-scale-mobile: 1.8;
 @standard-type-weight: 400;
 @standard-type-weight-mobile: 400;
+@standard-type-row-span-mobile-condensed: @standard-type-row-span;
+@standard-type-scale-mobile-condensed: @standard-type-scale;
+@standard-type-weight-mobile-condensed: @standard-type-weight;
 
 @small-type-row-span: 2;
 @small-type-scale: 1.2;
@@ -51,6 +66,9 @@
 @small-type-scale-mobile: @small-type-scale;
 @small-type-weight: 400;
 @small-type-weight-mobile: 400;
+@small-type-row-span-mobile-condensed: @small-type-row-span-mobile;
+@small-type-scale-mobile-condensed: @small-type-scale-mobile;
+@small-type-weight-mobile-condensed: @small-type-weight-mobile;
 
 @interaction-type-row-span: 5;
 @interaction-type-scale: 1.8;

--- a/theme/type/type.less
+++ b/theme/type/type.less
@@ -16,9 +16,9 @@
 @hero-type-scale-mobile: 3.6;
 @hero-type-weight: @sk-light;
 @hero-type-weight-mobile: @sk-light;
-@hero-type-row-span-mobile-condensed: 4;
-@hero-type-scale-mobile-condensed: 2.8;
-@hero-type-weight-mobile-condensed: @sk-light;
+@hero-type-row-span-mobile-compact: 4;
+@hero-type-scale-mobile-compact: 2.8;
+@hero-type-weight-mobile-compact: @sk-light;
 
 @headline-type-row-span: 4;
 @headline-type-scale: 2.8;
@@ -26,9 +26,9 @@
 @headline-type-scale-mobile: 2.4;
 @headline-type-weight: 400;
 @headline-type-weight-mobile: @sk-bold;
-@headline-type-row-span-mobile-condensed: @headline-type-row-span-mobile;
-@headline-type-scale-mobile-condensed: @headline-type-scale-mobile;
-@headline-type-weight-mobile-condensed: @headline-type-weight-mobile;
+@headline-type-row-span-mobile-compact: @headline-type-row-span-mobile;
+@headline-type-scale-mobile-compact: @headline-type-scale-mobile;
+@headline-type-weight-mobile-compact: @headline-type-weight-mobile;
 
 @heading-type-row-span: 3;
 @heading-type-scale: 2.1;
@@ -36,9 +36,9 @@
 @heading-type-scale-mobile: 2.4;
 @heading-type-weight: 400;
 @heading-type-weight-mobile: @sk-bold;
-@heading-type-row-span-mobile-condensed: @heading-type-row-span;
-@heading-type-scale-mobile-condensed: @heading-type-scale;
-@heading-type-weight-mobile-condensed: @heading-type-weight;
+@heading-type-row-span-mobile-compact: @heading-type-row-span;
+@heading-type-scale-mobile-compact: @heading-type-scale;
+@heading-type-weight-mobile-compact: @heading-type-weight;
 
 @subheading-type-row-span: 3;
 @subheading-type-scale: 1.8;
@@ -46,9 +46,9 @@
 @subheading-type-scale-mobile: 2.1;
 @subheading-type-weight: 400;
 @subheading-type-weight-mobile: 400;
-@subheading-type-row-span-mobile-condensed: @subheading-type-row-span;
-@subheading-type-scale-mobile-condensed: @subheading-type-scale;
-@subheading-type-weight-mobile-condensed: @subheading-type-weight;
+@subheading-type-row-span-mobile-compact: @subheading-type-row-span;
+@subheading-type-scale-mobile-compact: @subheading-type-scale;
+@subheading-type-weight-mobile-compact: @subheading-type-weight;
 
 @standard-type-row-span: 2;
 @standard-type-scale: 1.4;
@@ -56,9 +56,9 @@
 @standard-type-scale-mobile: 1.8;
 @standard-type-weight: 400;
 @standard-type-weight-mobile: 400;
-@standard-type-row-span-mobile-condensed: @standard-type-row-span;
-@standard-type-scale-mobile-condensed: @standard-type-scale;
-@standard-type-weight-mobile-condensed: @standard-type-weight;
+@standard-type-row-span-mobile-compact: @standard-type-row-span;
+@standard-type-scale-mobile-compact: @standard-type-scale;
+@standard-type-weight-mobile-compact: @standard-type-weight;
 
 @small-type-row-span: 2;
 @small-type-scale: 1.2;
@@ -66,9 +66,9 @@
 @small-type-scale-mobile: @small-type-scale;
 @small-type-weight: 400;
 @small-type-weight-mobile: 400;
-@small-type-row-span-mobile-condensed: @small-type-row-span-mobile;
-@small-type-scale-mobile-condensed: @small-type-scale-mobile;
-@small-type-weight-mobile-condensed: @small-type-weight-mobile;
+@small-type-row-span-mobile-compact: @small-type-row-span-mobile;
+@small-type-scale-mobile-compact: @small-type-scale-mobile;
+@small-type-weight-mobile-compact: @small-type-weight-mobile;
 
 @interaction-type-row-span: 5;
 @interaction-type-scale: 1.8;


### PR DESCRIPTION
This change is to better support pages with a higher density of text on mobile, particularly when user-generated content is provided and line lengths can vary wildly. Note that these are designed to be used sparingly where appropriate, not wholesale across an entire page.

BREAKING CHANGE: Since mobile headlines are now smaller and heavier, you may need to make some minor adjustments to the design of your product.