### PR TITLE
ci(PullApprove): Assign style guide team to PullApprove reviewers list

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -3,7 +3,8 @@ version: 2
 groups:
   reviewers:
     required: 2
-    users: all # all repo collaborators
+    teams:
+      - seek-style-guide-contributors
     # Enable github reviews when integration is sufficient:
     # https://github.com/pullapprove/support/issues/98#issuecomment-256447253
     # github_reviews:


### PR DESCRIPTION
This should (hopefully) fix an issue where some PR approvals were being ignored. Besides, this also seems to make more sense—only those on the style guide team should be able to issue approvals anyway.