### PR TITLE
fix(FieldMessage): adjust field message margin if it is empty set by Dropdown

### DIFF
--- a/react/private/FieldMessage/FieldMessage.less
+++ b/react/private/FieldMessage/FieldMessage.less
@@ -3,6 +3,10 @@
 .root {
   margin-bottom: (@grid-row-height * 3);
 
+  @media only screen and (max-width: 740px) {
+    margin-bottom: (@grid-row-height * 4);
+  }
+
    &.noMarginBottom {
     margin-bottom: 0;
   }

--- a/react/private/FieldMessage/FieldMessage.less
+++ b/react/private/FieldMessage/FieldMessage.less
@@ -3,9 +3,9 @@
 .root {
   margin-bottom: (@grid-row-height * 3);
 
-  @media only screen and (max-width: 740px) {
+  .smallDeviceOnly({
     margin-bottom: (@grid-row-height * 4);
-  }
+  });
 
    &.noMarginBottom {
     margin-bottom: 0;


### PR DESCRIPTION
This PR will resolve an issue for Dropdown, if the field message is set to empty on media screen.

Here is a summary of the current issue:
For now, The whole height of the dropdown with Help text as empty string, is set to 108.
![image](https://user-images.githubusercontent.com/16127935/27895321-544ce4ca-6255-11e7-8976-f7eb4f303b6b.png)
![image](https://user-images.githubusercontent.com/16127935/27895399-d891e618-6255-11e7-8af7-db210dccf0c0.png)

but, if with the error message, the whole height is 117.
![image](https://user-images.githubusercontent.com/16127935/27895411-eaeb73ba-6255-11e7-9c72-b4377da4790e.png)

so, the fix here is to add extra 9px to the margin-bottom on media screen.