### PR TITLE
fix(AsidedLayout): Fix AsidedLayout responsive mixin

### DIFF
--- a/react/AsidedLayout/AsidedLayout.less
+++ b/react/AsidedLayout/AsidedLayout.less
@@ -1,6 +1,6 @@
 @import (reference) "~seek-style-guide/theme";
 
-.aboveSmallDevice{
+.aboveSmallDevice({
   .root {
     display: flex;
   }
@@ -18,4 +18,4 @@
     flex-grow: 0;
     flex-shrink: 0;
   }
-}
+});


### PR DESCRIPTION
Luckily a release of this hadn't been triggered yet because it was a refactor. Picked this up by looking at the new page layout docs and noticing that the `<AsidedLayout>` demos were broken.