### PR TITLE
fix(type): Fix 'substandardText' mixin

### DIFF
--- a/theme/mixins/type.less
+++ b/theme/mixins/type.less
@@ -21,7 +21,7 @@
   .__type(@standard-type-scale, @standard-type-row-span, @baseline);
 }
 .substandardText(@baseline: true) {
-  .__type(@substandard-type-scale, @standard-type-row-span, @baseline);
+  .__type(@substandard-type-scale, @substandard-type-row-span, @baseline);
 }
 .smallText(@baseline: true) {
   .__type(@small-type-scale, @small-type-row-span, @baseline);


### PR DESCRIPTION
Noticed this minor error while introducing stylelint. Not sure this is affecting anyone, since these mixins are considered legacy at this point and substandard type is a new addition to the hierarchy, but worth cleaning up in the meantime regardless.