### PR TITLE
feat(Text): Make desktop headings bolder, enforce base font colour

### DIFF
--- a/docs/src/components/PageLayout/PageLayout.js
+++ b/docs/src/components/PageLayout/PageLayout.js
@@ -73,13 +73,13 @@ export default () => (
           </Paragraph>
         </Section>
         <Section>
-          <Text headline>Header and Footer</Text>
+          <Text heading>Header and Footer</Text>
           <Paragraph>
             <Text superstandard>The obvious starting point is to add the <TextLink to="/header">Header</TextLink> and <TextLink to="/footer">Footer</TextLink> components to your page, both of which are fairly self explanatory and documented separately.</Text>
           </Paragraph>
         </Section>
         <Section>
-          <Text headline>Page Blocks</Text>
+          <Text heading>Page Blocks</Text>
           <Paragraph>
             <Text superstandard>Page blocks serve as the canvas for most content in your application. They are designed to break the content up into one or more horizontal bands. When used for hero content at the top of a page, they'll usually also have background colours applied to them.</Text>
           </Paragraph>
@@ -104,7 +104,7 @@ export default () => (
       <Card style={{ maxWidth: 720 }}>
         <Section>
           <Paragraph>
-            <Text headline>Sections</Text>
+            <Text heading>Sections</Text>
             <Text superstandard>
               Page blocks by themselves don't provide any inner padding. This may be desirable in some cases, but you'll usually want to provide some space above and below your content, as well as providing responsive gutters on either side.
             </Text>
@@ -172,7 +172,7 @@ export default () => (
         initialProps: {
           children: (
             <Section header>
-              <Text hero>Lorem ipsum</Text>
+              <Text headline>Lorem ipsum</Text>
             </Section>
           )
         },
@@ -183,7 +183,7 @@ export default () => (
       <Card style={{ maxWidth: 720 }}>
         <Section>
           <Paragraph>
-            <Text headline>Cards</Text>
+            <Text heading>Cards</Text>
             <Text superstandard>
               Once we start to add a lot of content to the page, you'll find yourself wanting to break it up into visually distinct blocks of colour. Cards make this extremely simple by providing a white background with vertical space underneath.
             </Text>
@@ -200,7 +200,7 @@ export default () => (
           children: (
             <div>
               <Section header>
-                <Text hero>Lorem ipsum</Text>
+                <Text headline>Lorem ipsum</Text>
               </Section>
               <Card>
                 <Section>
@@ -240,7 +240,7 @@ export default () => (
           children: (
             <div>
               <Section header>
-                <Text hero>Lorem ipsum</Text>
+                <Text headline>Lorem ipsum</Text>
               </Section>
               <Card>
                 <Section>
@@ -264,7 +264,7 @@ export default () => (
       <Card style={{ maxWidth: 720 }}>
         <Section>
           <Paragraph>
-            <Text headline>Card Groups</Text>
+            <Text heading>Card Groups</Text>
             <Text superstandard>
               When multiple cards are very closely related, they can be nested within a card group to ensure that this relationship is clearly communicated.
             </Text>
@@ -281,7 +281,7 @@ export default () => (
           children: (
             <div>
               <Section header>
-                <Text hero>Lorem ipsum</Text>
+                <Text headline>Lorem ipsum</Text>
               </Section>
               <Card group>
                 <Card>
@@ -313,7 +313,7 @@ export default () => (
       <Card style={{ maxWidth: 720 }}>
         <Section>
           <Paragraph>
-            <Text headline>Asided Layouts</Text>
+            <Text heading>Asided Layouts</Text>
             <Text superstandard>
               Even though we set a maximum content width on larger screens, it results in line lengths that extend beyond comfortable reading levels. This is where our asided layout component comes in, giving us the ability to quickly and easily place content side-by-side on large screens, while responsively collapsing down to a single column on small screens.
             </Text>
@@ -391,7 +391,7 @@ export default () => (
           children: (
             <div>
               <Section header>
-                <Text hero>Lorem ipsum</Text>
+                <Text headline>Lorem ipsum</Text>
               </Section>
               <AsidedLayout
                 size="33%"

--- a/react/StyleGuideProvider/StyleGuideProvider.less
+++ b/react/StyleGuideProvider/StyleGuideProvider.less
@@ -16,6 +16,7 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: @sk-background;
+  color: @sk-black;
   box-sizing: border-box;
 
   :global {

--- a/react/Text/Text.demo.js
+++ b/react/Text/Text.demo.js
@@ -28,6 +28,13 @@ export default {
           })
         },
         {
+          label: 'Light',
+          transformProps: props => ({
+            ...props,
+            light: true
+          })
+        },
+        {
           label: 'Disable baseline',
           transformProps: props => ({
             ...props,

--- a/react/Text/Text.js
+++ b/react/Text/Text.js
@@ -26,6 +26,7 @@ export default function Text({
   secondary,
   strong,
   regular,
+  light,
   baseline,
   ...restProps
 }) {
@@ -51,7 +52,8 @@ export default function Text({
           [stylesCritical.root]: critical,
           [stylesSecondary.root]: secondary,
           [stylesStrong.root]: strong,
-          [stylesRegular.root]: regular
+          [stylesRegular.root]: regular,
+          [styles.light]: light
         })}>
         {children}
       </span>
@@ -75,6 +77,7 @@ Text.propTypes = {
   secondary: PropTypes.bool,
   strong: PropTypes.bool,
   regular: PropTypes.bool,
+  light: PropTypes.bool,
   baseline: PropTypes.bool
 };
 

--- a/react/Text/Text.less
+++ b/react/Text/Text.less
@@ -59,6 +59,10 @@
   &.baseline { .heroTextResponsive(@baseline: true); }
 }
 
+.light {
+  font-weight: @sk-light;
+}
+
 .raw {
   padding-bottom: 0;
 }

--- a/theme/type/type.less
+++ b/theme/type/type.less
@@ -10,21 +10,21 @@
 // Hierarchy
 @hero-type-scale: 4.2;
 @hero-type-row-span: 6;
-@hero-type-weight: @sk-light;
+@hero-type-weight: @sk-regular;
 @hero-type-scale-mobile: 2.1;
 @hero-type-row-span-mobile: 3;
 @hero-type-weight-mobile: @sk-bold;
 
 @headline-type-scale: 2.8;
 @headline-type-row-span: 4;
-@headline-type-weight: @sk-regular;
+@headline-type-weight: @sk-bold;
 @headline-type-scale-mobile: 2.1;
 @headline-type-row-span-mobile: 3;
 @headline-type-weight-mobile: @sk-bold;
 
 @heading-type-scale: 2.1;
 @heading-type-row-span: 3;
-@heading-type-weight: @sk-regular;
+@heading-type-weight: @sk-bold;
 @heading-type-scale-mobile: 2.1;
 @heading-type-row-span-mobile: 3;
 @heading-type-weight-mobile: @sk-bold;


### PR DESCRIPTION
BREAKING CHANGE: Design review may be required.

This PR makes a few notable changes:
- Hero text is bumped up from light (300) to regular (400)
- Headline and heading text is bumped up from regular (400) to bold (600)
- `<Text>` now accepts a `light` prop if light text is still required, although this will be the exception going forwards.
- Base font colour of `<StyleGuideProvider>` is now set to `@sk-black`, which is #212121. Previously, no colour was set, which resulted in the browser default of #000000.

I also updated the page layout guide to use headings instead of headlines, since the new bolder headings now look great alongside `superstandard` type 🙌 