### PR TITLE
build(devDependencies): remove duplicate devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "babel-eslint": "^6.0.4",
     "babel-jest": "^18.0.0",
     "chai": "^3.5.0",
-    "chalk": "^1.1.3",
     "classnames": "^2.2.5",
     "commitizen": "^2.9.5",
     "cz-conventional-changelog": "^2.0.0",


### PR DESCRIPTION
Duplicate devDependancy already included in dependancies (picked up by yarn, can we remove `yarn.lock` from the `.gitignore` yet?! 🙏 )