### PR TITLE
fix(SlideToggle): Fix tick icon alignment in slide toggle

### DIFF
--- a/react/SlideToggle/SlideToggle.less
+++ b/react/SlideToggle/SlideToggle.less
@@ -104,5 +104,6 @@
   fill: white;
   opacity: 0;
   transition: opacity 0.15s;
-  vertical-align: sub;
+  position: relative;
+  top: 4px;
 }

--- a/react/SlideToggle/SlideToggle.less
+++ b/react/SlideToggle/SlideToggle.less
@@ -105,5 +105,5 @@
   opacity: 0;
   transition: opacity 0.15s;
   position: relative;
-  top: 4px;
+  top: 5px;
 }


### PR DESCRIPTION
The tick icon within the slide toggle is slight off centre.  Shifting it by a few pixels so it lines up nicely