### PR TITLE
fix(Header): fix overflow & consistent xbrowser gutters

### DIFF
--- a/react/Header/Header.js
+++ b/react/Header/Header.js
@@ -92,7 +92,7 @@ export default function Header({
             divider={divider}
           />
         </Hidden>
-        <Hidden print className={styles.topBanner}>
+        <Hidden print mobile className={styles.topBanner}>
           <div className={styles.topBannerContent}>
             <PartnerSites locale={locale} linkRenderer={linkRenderer} />
             <div className={styles.locale}>

--- a/react/Header/Header.less
+++ b/react/Header/Header.less
@@ -23,7 +23,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  flex: 1 0 auto;
+  width: 100%;
   padding: 0 (@grid-gutter-width / 2);
   max-width: @grid-container-width + @grid-gutter-width;
   .smallDeviceOnly({
@@ -36,29 +36,13 @@
   @media print {
     justify-content: flex-start;
   }
-  @media only screen and (min-width: (@grid-container-width)) { //IE11 flexbox horizontal centering
-    flex: 0 0 @grid-container-width;
-  }
-  @media only screen and (min-width: (@grid-container-width + @grid-gutter-width)) {
-    padding: 0;
-  }
 }
 
 .topBanner {
-  .smallDeviceOnly({
-    display: none;
-  });
-  .aboveSmallDevice({
-    display: flex;
-    background-color: @sk-background;
-    order: 0;
-    flex: 0 1 100%;
-    justify-content: center;
-    padding: 0 (@grid-gutter-width / 2);
-  });
-  @media only screen and (min-width: @responsive-breakpoint) and (max-width: (@grid-container-width + @grid-gutter-width)) {
-    padding: 0;
-  }
+  order: 0;
+  width: 100%;
+  background-color: @sk-background;
+  padding: 0 (@grid-gutter-width / 2);
 }
 
 .topBannerContent {
@@ -67,9 +51,7 @@
   flex-grow: 1;
   justify-content: center;
   max-width: @grid-container-width;
-  @media only screen and (min-width: (@grid-container-width)) { //IE11 flexbox horizontal centering
-    flex: 0 0 @grid-container-width;
-  }
+  margin: 0 auto;
 }
 
 .navigation {
@@ -168,9 +150,6 @@
 .locale {
   position: absolute;
   right: 0;
-  @media only screen and (min-width: @responsive-breakpoint) and (max-width: (@grid-container-width + @grid-gutter-width - 1)) {
-    right: (@grid-gutter-width / 2);
-  }
 }
 
 .divider {

--- a/react/Header/Navigation/Navigation.less
+++ b/react/Header/Navigation/Navigation.less
@@ -1,9 +1,5 @@
 @import (reference) "~seek-style-guide/theme";
 
-@nav-item-width: (@grid-column-width * 3);
-@number-nav-items: 5;
-@nav-min-width: (@nav-item-width * @number-nav-items);
-
 .root {
   display: flex;
   justify-content: center;
@@ -20,14 +16,16 @@
 
 .list {
   display: flex;
+  justify-content: space-around;
   flex-grow: 1;
   max-width: @grid-container-width;
+  .aboveSmallDevice({
+    flex: 0 1 @grid-container-width;
+  });
 }
 
 .item {
-  @media only screen and (max-width: (@nav-min-width - 1)) {
-    flex-grow: 1;
-  }
+  flex: 1 1 20%;
   .smallDeviceOnly({
     display: none;
   });
@@ -40,18 +38,13 @@
   display: inline-block;
   white-space: nowrap;
   text-align: center;
+  width: 100%;
   &:hover {
     cursor: pointer;
   }
   .aboveSmallDevice({
     color: @sk-black;
   });
-  @media only screen and (max-width: (@nav-min-width - 1)) {
-    width: 100%;
-  }
-  @media only screen and (min-width: @nav-min-width) {
-    width: @nav-item-width;
-  }
 }
 
 .link_isActive {

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -406,7 +406,7 @@ exports[`Header: should append returnUrl to signin and register links if present
       </nav>
     </span>
     <span
-      class="topBanner print"
+      class="topBanner mobile print"
     >
       <div
         class="topBannerContent"
@@ -939,7 +939,7 @@ exports[`Header: should render first part of email address when username isn't p
       </nav>
     </span>
     <span
-      class="topBanner print"
+      class="topBanner mobile print"
     >
       <div
         class="topBannerContent"
@@ -1456,7 +1456,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
       </nav>
     </span>
     <span
-      class="topBanner print"
+      class="topBanner mobile print"
     >
       <div
         class="topBannerContent"
@@ -1989,7 +1989,7 @@ exports[`Header: should render when authenticated 1`] = `
       </nav>
     </span>
     <span
-      class="topBanner print"
+      class="topBanner mobile print"
     >
       <div
         class="topBannerContent"
@@ -2518,7 +2518,7 @@ exports[`Header: should render when authenticated but username and email is not 
       </nav>
     </span>
     <span
-      class="topBanner print"
+      class="topBanner mobile print"
     >
       <div
         class="topBannerContent"
@@ -3035,7 +3035,7 @@ exports[`Header: should render when authentication is pending 1`] = `
       </nav>
     </span>
     <span
-      class="topBanner print"
+      class="topBanner mobile print"
     >
       <div
         class="topBannerContent"
@@ -3586,7 +3586,7 @@ exports[`Header: should render when unauthenticated 1`] = `
       </nav>
     </span>
     <span
-      class="topBanner print"
+      class="topBanner mobile print"
     >
       <div
         class="topBannerContent"
@@ -4103,7 +4103,7 @@ exports[`Header: should render with locale of AU 1`] = `
       </nav>
     </span>
     <span
-      class="topBanner print"
+      class="topBanner mobile print"
     >
       <div
         class="topBannerContent"
@@ -4583,7 +4583,7 @@ exports[`Header: should render with locale of NZ 1`] = `
       </nav>
     </span>
     <span
-      class="topBanner print"
+      class="topBanner mobile print"
     >
       <div
         class="topBannerContent"
@@ -5100,7 +5100,7 @@ exports[`Header: should render with no divider 1`] = `
       </nav>
     </span>
     <span
-      class="topBanner print"
+      class="topBanner mobile print"
     >
       <div
         class="topBannerContent"


### PR DESCRIPTION
Refactored the `Header` to make gutters more consistent and cross browser compliant. We had some issues in IE11 at certain screen sizes and inconsistent gutters. This unifies the top banner and the logo/user banner to only have a half gutter spacing below the `grid-container-width`.

Tested across many browsers and looks good to me. The same `Header` you have always known now just more consistent with 11 less media queries 🎉 