### PR TITLE
build(devserver): Enable accessing dev server from VM

### DIFF
--- a/docs/server.js
+++ b/docs/server.js
@@ -8,8 +8,9 @@ new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath,
   contentBase: __dirname,
   hot: true,
-  historyApiFallback: true
-}).listen(port, 'localhost', error => {
+  historyApiFallback: true,
+  disableHostCheck: true
+}).listen(port, '0.0.0.0', error => {
   if (error) {
     console.log(error); // eslint-disable-line no-console
   } else {


### PR DESCRIPTION
Allows local dev server to be accessed from VM. This was required for me to test/dev against IE 11 recently. Thought it would be worth putting in a PR.