### PR TITLE
Remove extra wrap from page block

### DIFF
--- a/react/PageBlock/PageBlock.js
+++ b/react/PageBlock/PageBlock.js
@@ -6,10 +6,8 @@ import classnames from 'classnames';
 
 export default function PageBlock({ children, className, ...restProps }) {
   return (
-    <div {...restProps} className={classnames(className)}>
-      <div className={styles.content}>
-        {children}
-      </div>
+    <div {...restProps} className={classnames(className, styles.content)}>
+      {children}
     </div>
   );
 }


### PR DESCRIPTION
I understand it's protecting from editing same container styles from the outside, but it's probably a common sense that if Page block is used then gutters css is not touched.

On the other hand it's introducing unnecessary layer of wrapping that is causing some styling troubles when you don't expect it to be a nested container.