### PR TITLE
docs(readme): Suggest installation as runtime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you'd instead like to work on a custom webpack project, you can use [seek-sty
 ## Installation
 
 ```bash
-$ npm install --save-dev seek-style-guide
+$ npm install --save seek-style-guide
 ```
 
 ## Setup


### PR DESCRIPTION
We've somehow missed this until recently, but installing the style guide as a dev dependency can cause issues in server rendered applications when running `npm install --only=production`. This can lead to missing dependencies at runtime, which varies depending on the dependencies of your own application. As a result, we're now recommending that style guide consumers *always* install it as a regular dependency instead.