### PR TITLE
fix(Autosuggest): Scroll through options on mobile if they overflow

### DIFF
--- a/react/Autosuggest/Autosuggest.less
+++ b/react/Autosuggest/Autosuggest.less
@@ -3,6 +3,9 @@
 @suggestionContainerRowsOffset: 6;
 @suggestionFieldHeightInRows: 5;
 
+@sectionTitleHeight: @grid-row-height * 4;
+@containerHeight: @touchableTextHeight + @sectionTitleHeight;
+
 .container {
   position: relative;
   display: inline-block;
@@ -25,6 +28,10 @@
   max-height: 385px;
   overflow-y: auto;
   top: @grid-row-height * @suggestionContainerRowsOffset;
+
+  .smallDeviceOnly({
+    max-height: ~"calc(100vh - @{containerHeight})";
+  });
 }
 
 .suggestionsContainerOpen {
@@ -43,8 +50,8 @@
 
 .sectionTitle {
   .rawText(1);
-  line-height: (@grid-row-height * 4);
-  height: (@grid-row-height * 4);
+  line-height: @sectionTitleHeight;
+  height: @sectionTitleHeight;
   margin: @grid-row-height (@grid-gutter-width * 0.75) 0;
   color: darken(@sk-highlight, 10%);
   font-weight: @sk-bold;

--- a/theme/mixins/type.less
+++ b/theme/mixins/type.less
@@ -52,10 +52,12 @@
   .__responsiveType("small"; @baseline);
 }
 
+@touchableTextHeight: @grid-row-height * @interaction-type-row-span;
+
 .touchableText(@font-scale: @interaction-type-scale) {
   .rawText(@font-scale);
-  line-height: (@grid-row-height * @interaction-type-row-span);
-  height: (@grid-row-height * @interaction-type-row-span);
+  line-height: @touchableTextHeight;
+  height: @touchableTextHeight;
 }
 
 .rawText(@font-scale: @standard-type-scale) {


### PR DESCRIPTION
Currently user can't observe full suggestions list if it overflows the screen.
![screen shot 2017-07-28 at 11 46 04 am](https://user-images.githubusercontent.com/15971854/28699038-8800953c-738a-11e7-8405-6bc32ec208b3.png)

So as a user I should be able to still browse all options even if they overflow. 
This PR fixes it.