### PR TITLE
fix(Autosuggest): Bind scrolling to suggestions shown event

### DIFF
--- a/react/Autosuggest/Autosuggest.js
+++ b/react/Autosuggest/Autosuggest.js
@@ -7,7 +7,6 @@ import ReactAutosuggest from 'react-autosuggest';
 import IsolatedScroll from 'react-isolated-scroll';
 import ScrollLock from 'react-scrolllock';
 
-import invoke from 'lodash/invoke';
 import omit from 'lodash/omit';
 
 import TextField from '../TextField/TextField';
@@ -51,21 +50,23 @@ export default class Autosuggest extends Component {
     showMobileBackdrop: false
   };
 
-  constructor() {
-    super();
-
-    this.storeInputReference = this.storeInputReference.bind(this);
-    this.storeTextFieldReference = this.storeTextFieldReference.bind(this);
-    this.renderInputComponent = this.renderInputComponent.bind(this);
+  state = {
+    areSuggestionsShown: false
   }
 
-  storeInputReference(autosuggest) {
+  componentWillUpdate(nextProps, nextState) {
+    if (!this.state.areSuggestionsShown && nextState.areSuggestionsShown && smallDeviceOnly()) {
+      smoothScroll(this.textField);
+    }
+  }
+
+  storeInputReference = autosuggest => {
     if (autosuggest !== null) {
       this.input = autosuggest.input;
     }
   }
 
-  storeTextFieldReference(textField) {
+  storeTextFieldReference = textField => {
     if (textField !== null) {
       this.textField = textField.container;
     }
@@ -75,6 +76,11 @@ export default class Autosuggest extends Component {
     const { ref, ...rest } = containerProps;
     const { showMobileBackdrop } = this.props;
     const areSuggestionsShown = children !== null;
+
+    if (this.state.areSuggestionsShown !== areSuggestionsShown) {
+      this.setState({ areSuggestionsShown });
+    }
+
     const callRef = isolatedScroll => {
       if (isolatedScroll !== null) {
         ref(isolatedScroll.component);
@@ -94,24 +100,8 @@ export default class Autosuggest extends Component {
     );
   }
 
-  scrollOnFocus = () => {
-    if (smallDeviceOnly()) {
-      smoothScroll(this.textField);
-    }
-  }
-
-  renderInputComponent(inputProps) {
+  renderInputComponent = inputProps => {
     const { labelProps = {} } = inputProps;
-
-    const onFocus = event => {
-      this.scrollOnFocus();
-      invoke(inputProps, 'onFocus', event);
-    };
-
-    const enrichedInputProps = {
-      ...omit(inputProps, 'onFocus'),
-      onFocus
-    };
 
     const enrichedlabelProps = {
       ...labelProps,
@@ -123,7 +113,7 @@ export default class Autosuggest extends Component {
 
     const allInputProps = {
       ref: this.storeTextFieldReference,
-      inputProps: enrichedInputProps,
+      inputProps,
       labelProps: enrichedlabelProps,
       ...omit(this.props, [ 'inputProps', 'autosuggestProps' ])
     };


### PR DESCRIPTION
Currently if user focuses on autosuggest field browser scrolls to the field.

However, when user selects a suggestion then scrolls a bit and then clears suggestions, browser won't scroll back to the field as field is still focused and this focus even is not called, which leads to incorrect behaviour in conjunction with scroll locking on mobile.

This is also the case when you select a suggestion, scroll and then trying to change suggestions again without blurring out of the field. Overlay will be shown, scroll lock will happen, however, browser won't scroll to the field.

This PR binds scrolling to the event when suggestions are shown instead of the focus event.