### PR TITLE
fix(Header): Switch out Preact for React (standalone components)

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,6 @@
     "opn-cli": "^3.1.0",
     "pad-left": "^2.1.0",
     "postcss-prefix-selector": "^1.6.0",
-    "preact": "^8.1.0",
-    "preact-compat": "^3.14.3",
     "react": "^15.3.1",
     "react-addons-pure-render-mixin": "^15.3.1",
     "react-baseline": "^1.0.1",

--- a/standalone/header-footer/webpack.config.js
+++ b/standalone/header-footer/webpack.config.js
@@ -51,13 +51,7 @@ const config = {
   },
 
   resolve: {
-    modulesDirectories: ['node_modules', 'components'],
-    alias: {
-      // Use Preact to dramatically reduce bundle size
-      // since consumers don't already have React.
-      'react': 'preact-compat',
-      'react-dom': 'preact-compat'
-    }
+    modulesDirectories: ['node_modules', 'components']
   },
 
   postcss: [


### PR DESCRIPTION
The mobile menu (in particular the latest change with scroll locking) wasn't correctly working when using the standalone version of the Header. After discussion with @markdalgleish we decided to switch back to using vanilla React even at the cost of file size (98kb vs 220kb).