### PR TITLE
feat(Autosuggest): Remove scroll locking feature from autosuggest

### DIFF
--- a/react/Autosuggest/Autosuggest.js
+++ b/react/Autosuggest/Autosuggest.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import ReactAutosuggest from 'react-autosuggest';
 import IsolatedScroll from 'react-isolated-scroll';
-import ScrollLock from 'react-scrolllock';
 
 import omit from 'lodash/omit';
 
@@ -74,7 +73,6 @@ export default class Autosuggest extends Component {
 
   renderSuggestionsContainer = ({ containerProps, children }) => {
     const { ref, ...rest } = containerProps;
-    const { showMobileBackdrop } = this.props;
     const areSuggestionsShown = children !== null;
 
     if (this.state.areSuggestionsShown !== areSuggestionsShown) {
@@ -90,12 +88,6 @@ export default class Autosuggest extends Component {
     return (
       <IsolatedScroll {...rest} ref={callRef}>
         {children}
-        {
-          showMobileBackdrop &&
-          areSuggestionsShown &&
-          smallDeviceOnly() ?
-            <ScrollLock /> : null
-        }
       </IsolatedScroll>
     );
   }


### PR DESCRIPTION
Current behaviour in Autosuggest is to lock scrolling on the page when suggestions list is presented and backdrop is shown.

This feature turned to be super buggy in mobile iOS Safari, so we will probably release without scroll-locking and then give it a go one more time.

Here are the issues we faced:
- Adding ScrollLock component prevents touch-scrolling inside the list when it overflows
- Attempt of re-enabling touch-scrolling inside the list (whilst body is locked) leads to the issue that when suggestions list ended and user is continuing scrolling (keeping finger inside the suggestions list) it scrolls the page itself
- Just setting body/wrapping component styles in many ways keeps being ignored by touch events