### PR TITLE
feat(Autosuggest): move label prop to the root level of component

### DIFF
--- a/react/Autosuggest/Autosuggest.js
+++ b/react/Autosuggest/Autosuggest.js
@@ -116,6 +116,7 @@ export default class Autosuggest extends Component {
   render() {
     const { inputProps, label, autosuggestProps, suggestionsContainerClassName, showMobileBackdrop } = this.props;
     const { theme = {} } = autosuggestProps;
+
     const allAutosuggestProps = {
       renderSuggestionsContainer: this.renderSuggestionsContainer,
       renderInputComponent: this.renderInputComponent,

--- a/react/Autosuggest/Autosuggest.js
+++ b/react/Autosuggest/Autosuggest.js
@@ -87,11 +87,7 @@ export default class Autosuggest extends Component {
       }
     };
 
-    return (
-      <IsolatedScroll {...rest} ref={callRef}>
-        {children}
-      </IsolatedScroll>
-    );
+    return <IsolatedScroll {...rest} ref={callRef} children={children} />;
   }
 
   renderInputComponent = inputProps => {


### PR DESCRIPTION
## feat(Autosuggest): move label prop to the root level of component

Autosuggest now supports labelProps directly instead of via `inputProps.labelProps`

## Upgrade Guide

``` diff
- <Autosuggest {...} inputProps={ labelProps, ...inputProps } />
+ <Autosuggest {...} inputProps={ inputProps } labelProps={ labelProps } />
```


