### PR TITLE
chore(GitHub): Add initial pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,9 @@
-Based on the nature of your change, please use the relevant template below and modify to suit your needs.
+IMPORTANT
+=========
 
-Please ensure you copy the completed "Commit Message For Review" section below into your final commit body when merging to master. This allows us to validate that the generated release notes are clear enough for consumers to follow.
+Please ensure that, when eventually merging this PR to master, you copy the completed "Commit Message For Review" section below into your final commit body. This allows us to review our release notes, validating that they're clear enough for consumers to follow.
 
-Don't forget that what's written here forms the upgrade guide for consumers, and upgrading can easily become a long and arduous process. To counter this, please be as descriptive as possible, explaining the reasoning behind the change. Since there are many different consumers, changes should be documented from the perspective of the style guide itself, so avoid making specific reference to the application you're working on.
+Don't forget that what's written here forms the upgrade guide for consumers, and upgrading can easily become a long and arduous process. To counter this, please be as descriptive as possible, explaining the reasoning behind the change, and showing a clear usage example or migration guide where appropriate. Since there are many different consumers, changes should be documented from the perspective of the style guide itself, so avoid making specific reference to the application you're working on.
 
 
 Major release template
@@ -68,6 +69,7 @@ REASON FOR CHANGE:
 
 Non-release template
 ====================
+
 
 ## Commit Message For Review
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,74 @@
+Based on the nature of your change, please use the relevant template below and modify to suit your needs.
+
+Please ensure you copy the completed "Commit Message For Review" section below into your final commit body when merging to master. This allows us to validate that the generated release notes are clear enough for consumers to follow.
+
+Don't forget that what's written here forms the upgrade guide for consumers, and upgrading can easily become a long and arduous process. To counter this, please be as descriptive as possible, explaining the reasoning behind the change. Since there are many different consumers, changes should be documented from the perspective of the style guide itself, so avoid making specific reference to the application you're working on.
+
+
+Major release template
+======================
+
+
+## Commit Message For Review
+
+BREAKING CHANGE:
+
+{{ Description of breaking API change }}
+
+REASON FOR CHANGE:
+
+{{ Reason for change }}
+
+MIGRATION GUIDE:
+
+Before:
+
+```js
+{{ Old code }}
+```
+
+After:
+
+```js
+{{ New code }}
+```
+
+
+Minor release template
+======================
+
+
+## Commit Message For Review
+
+{{ Optional description of change }}
+
+REASON FOR CHANGE:
+
+{{ Reason for change }}
+
+EXAMPLE USAGE:
+
+```js
+{{ Code }}
+```
+
+
+Patch release template
+======================
+
+
+## Commit Message For Review
+
+{{ Optional description of change }}
+
+REASON FOR CHANGE:
+
+{{ Reason for change }}
+
+
+Non-release template
+====================
+
+## Commit Message For Review
+
+{{ Optional description of change }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,10 +95,18 @@ Once you've committed your work, push your changes to a branch of the same name 
 $ git push --set-upstream origin $(git symbolic-ref --short HEAD)
 ```
 
-Next, head over to the style guide's GitHub page and create a new pull request from your branch.
+Next, head over to the style guide's GitHub page and create a new pull request from your branch. You'll be presented with a pull request template, which provides separate outlines for major, minor, patch and non-release branches. Please follow this guide carefully, but raise any questions and concerns along the way if anything is unclear.
 
 In order for your pull request to be accepted, the [Travis CI](https://travis-ci.org) build needs to pass, and **2 other contributors needs to approve your work.** GitHub will block your PR until you have your first approval, but make sure you wait for a second approval. It's likely that you might need to make some changes for your work to be accepted, but don't take this personally! Ultimately, the aim is to make it feel like the codebase was written by a single person, but this takes a lot of work and constant review of each others' work.
 
-Once your work is approved and ready to go, hit the merge button and check that your commit message and description are clean and free of cruft, removing any irrelevant messages due to review feedback. Finally, take a deep breath, hit the green "confirm" button, and we have liftoff—your work should be automatically deployed!
+### Merging
+
+Once your work is approved and ready to go, follow these steps:
+
+1) Hit the merge button
+2) Ensure the commit message matches the title of the PR (it may have been edited!)
+3) Copy and paste the text under **"Commit Message For Review"** into the commit body (again, it may have been edited!)
+
+Finally, take a deep breath, hit the green "confirm" button, and we have liftoff—your work should be automatically deployed!
 
 🎨📦🚀


### PR DESCRIPTION
This is totally up for discussion, but figured I'd get the ball rolling with a first pass.

We've had some issues with our automatically generated release notes being too sparse, particularly when it comes to breaking changes, and confusion for contributors around what level of detail is required to address this.

So, to help guide contributors, I've added a pull request template which will show up in the description box when opening a PR.

Let me know what you think. Keen to discuss this more, but hoping to at least get a good initial version in place.