### PR TITLE
fix(Text): Use a span tag for Text components instead of divs

### DIFF
--- a/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
+++ b/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
@@ -10,7 +10,7 @@ exports[`Autosuggest should render with label 1`] = `
         class=""
         for="Foo"
       >
-        <div
+        <span
           class="root baseline"
         >
           <span
@@ -23,7 +23,7 @@ exports[`Autosuggest should render with label 1`] = `
             </strong>
              
           </span>
-        </div>
+        </span>
       </label>
       <input
         aria-autocomplete="list"
@@ -75,7 +75,7 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
         class="isLabelCoveredWithBackdrop LABEL_TEST_CLASS"
         for="Foo"
       >
-        <div
+        <span
           class="root baseline"
         >
           <span
@@ -88,7 +88,7 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
             </strong>
              
           </span>
-        </div>
+        </span>
       </label>
       <input
         aria-autocomplete="list"

--- a/react/Text/Text.js
+++ b/react/Text/Text.js
@@ -31,7 +31,7 @@ export default function Text({
   ...restProps
 }) {
   return (
-    <div
+    <span
       {...restProps}
       className={classnames({
         [styles.root]: true,
@@ -57,7 +57,7 @@ export default function Text({
         })}>
         {children}
       </span>
-    </div>
+    </span>
   );
 }
 

--- a/react/Text/Text.less
+++ b/react/Text/Text.less
@@ -2,6 +2,7 @@
 
 .root {
   padding-bottom: @grid-row-height;
+  display: block;
 
   .root {
     position: relative;


### PR DESCRIPTION
## Commit Message for Review

Have modified the Text component to, by default, use a span instead of a div for semantic reasons.

REASON FOR CHANGE:
Block level elements aren't valid inside certain elements, e.g. a `<div>` inside an `<a>`

