### PR TITLE
docs(site): Ensure demo components re-render correctly

### DIFF
--- a/docs/src/components/Demo/Demo.js
+++ b/docs/src/components/Demo/Demo.js
@@ -8,9 +8,12 @@ import Baseline from 'react-baseline';
 import Code from './Code/Code';
 import flatten from 'lodash/flatten';
 
-const DefaultContainer = ({ component: DemoComponent }) => <DemoComponent />;
+const DefaultContainer = ({ component: DemoComponent, componentProps }) => (
+  <DemoComponent {...componentProps} />
+);
 DefaultContainer.propTypes = {
-  component: PropTypes.func.isRequired
+  component: PropTypes.func.isRequired,
+  componentProps: PropTypes.object.isRequired
 };
 
 export default class Demo extends Component {
@@ -126,8 +129,7 @@ export default class Demo extends Component {
       options
     } = this.props.spec;
 
-    const demoElement = <DemoComponent {...this.calculateProps()} />;
-    const BoundComponent = props => <DemoComponent {...this.calculateProps()} {...props} />;
+    const codeElement = <DemoComponent {...this.calculateProps()} />;
 
     return (
       <div className={styles.root}>
@@ -147,7 +149,7 @@ export default class Demo extends Component {
               [styles.component]: true,
               [styles.component_block]: block
             })}>
-            <Container component={BoundComponent} />
+            <Container component={DemoComponent} componentProps={this.calculateProps()} />
           </div>
         </Baseline>
         {
@@ -166,7 +168,7 @@ export default class Demo extends Component {
           null
         }
         <PageBlock className={styles.codeBlock}>
-          <Code jsx={demoElement} />
+          <Code jsx={codeElement} />
         </PageBlock>
       </div>
     );

--- a/docs/src/components/PageLayout/PageLayout.js
+++ b/docs/src/components/PageLayout/PageLayout.js
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 import { PageBlock, AsidedLayout, Card, Section, Paragraph, Text, TextLink, Strong } from 'seek-style-guide/react';
 import Demo from '../Demo/Demo';
 
-const BackgroundContainer = ({ component: DemoComponent }) => (
+const BackgroundContainer = ({ component: DemoComponent, componentProps }) => (
   <div style={{ backgroundColor: '#eeeeee', padding: 0.1 }}>
-    <DemoComponent />
+    <DemoComponent {...componentProps} />
   </div>
 );
 BackgroundContainer.propTypes = {
-  component: PropTypes.any
+  component: PropTypes.any,
+  componentProps: PropTypes.object.isRequired
 };
 
 const MockContent = ({ text = 'Lorem ipsum' }) => (

--- a/react/Autosuggest/Autosuggest.demo.js
+++ b/react/Autosuggest/Autosuggest.demo.js
@@ -7,7 +7,8 @@ import fieldMessageOptions from '../private/FieldMessage/FieldMessage.demo';
 
 class AutosuggestContainer extends Component {
   static propTypes = {
-    component: PropTypes.func.isRequired
+    component: PropTypes.func.isRequired,
+    componentProps: PropTypes.object.isRequired
   };
 
   constructor() {
@@ -35,12 +36,13 @@ class AutosuggestContainer extends Component {
   };
 
   render() {
-    const { component: DemoComponent } = this.props;
+    const { component: DemoComponent, componentProps } = this.props;
     const { inputValue } = this.state;
 
     return (
       <div style={{ width: '300px' }}>
         <DemoComponent
+          {...componentProps}
           inputProps={{
             type: 'search',
             onChange: this.handleChange,

--- a/react/Checkbox/Checkbox.demo.js
+++ b/react/Checkbox/Checkbox.demo.js
@@ -6,7 +6,8 @@ import demoStyles from './Checkbox.demo.less';
 
 class CheckboxContainer extends Component {
   static propTypes = {
-    component: PropTypes.func.isRequired
+    component: PropTypes.func.isRequired,
+    componentProps: PropTypes.object.isRequired
   };
 
   constructor() {
@@ -24,12 +25,13 @@ class CheckboxContainer extends Component {
   };
 
   render() {
-    const { component: DemoComponent } = this.props;
+    const { component: DemoComponent, componentProps } = this.props;
     const { checked } = this.state;
 
     return (
       <div className={demoStyles.root}>
         <DemoComponent
+          {...componentProps}
           inputProps={{
             checked,
             onChange: this.handleChange

--- a/react/Dropdown/Dropdown.demo.js
+++ b/react/Dropdown/Dropdown.demo.js
@@ -9,7 +9,8 @@ import fieldLabelOptions from '../private/FieldLabel/FieldLabel.demo';
 
 class DropdownContainer extends Component {
   static propTypes = {
-    component: PropTypes.func.isRequired
+    component: PropTypes.func.isRequired,
+    componentProps: PropTypes.object.isRequired
   };
 
   constructor() {
@@ -27,11 +28,12 @@ class DropdownContainer extends Component {
   };
 
   render() {
-    const { component: DemoComponent } = this.props;
+    const { component: DemoComponent, componentProps } = this.props;
     const { value } = this.state;
 
     return (
       <DemoComponent
+        {...componentProps}
         inputProps={{
           value,
           onChange: this.handleChange

--- a/react/MonthPicker/MonthPicker.demo.js
+++ b/react/MonthPicker/MonthPicker.demo.js
@@ -8,7 +8,8 @@ import fieldLabelOptions from '../private/FieldLabel/FieldLabel.demo';
 
 class MonthPickerContainer extends Component {
   static propTypes = {
-    component: PropTypes.func.isRequired
+    component: PropTypes.func.isRequired,
+    componentProps: PropTypes.object.isRequired
   };
 
   constructor() {
@@ -24,11 +25,12 @@ class MonthPickerContainer extends Component {
   };
 
   render() {
-    const { component: DemoComponent } = this.props;
+    const { component: DemoComponent, componentProps } = this.props;
     const { value } = this.state;
 
     return (
       <DemoComponent
+        {...componentProps}
         className={styles.root}
         onChange={this.handleChange}
         value={value}

--- a/react/TextField/TextField.demo.js
+++ b/react/TextField/TextField.demo.js
@@ -9,7 +9,8 @@ import fieldLabelOptions from '../private/FieldLabel/FieldLabel.demo';
 
 class TextFieldContainer extends Component {
   static propTypes = {
-    component: PropTypes.func.isRequired
+    component: PropTypes.func.isRequired,
+    componentProps: PropTypes.object.isRequired
   };
 
   constructor() {
@@ -33,12 +34,13 @@ class TextFieldContainer extends Component {
   };
 
   render() {
-    const { component: DemoComponent } = this.props;
+    const { component: DemoComponent, componentProps } = this.props;
     const { inputValue } = this.state;
 
     return (
       <div style={{ width: '300px' }}>
         <DemoComponent
+          {...componentProps}
           inputProps={{
             onChange: this.handleChange,
             value: inputValue

--- a/react/Textarea/Textarea.demo.js
+++ b/react/Textarea/Textarea.demo.js
@@ -8,7 +8,8 @@ import fieldMessageOptions from '../private/FieldMessage/FieldMessage.demo';
 
 class TextareaContainer extends Component {
   static propTypes = {
-    component: PropTypes.func.isRequired
+    component: PropTypes.func.isRequired,
+    componentProps: PropTypes.object.isRequired
   };
 
   constructor() {
@@ -26,11 +27,12 @@ class TextareaContainer extends Component {
   };
 
   render() {
-    const { component: DemoComponent } = this.props;
+    const { component: DemoComponent, componentProps } = this.props;
     const { inputValue } = this.state;
 
     return (
       <DemoComponent
+        {...componentProps}
         inputProps={{
           onChange: this.handleChange,
           value: inputValue


### PR DESCRIPTION
The issue here was that we were creating a new component on every render (`<BoundComponent>`) so that we could bake in props ahead of time, but this was causing the component instance to be constantly destroyed and recreated. This meant that all state, both inside the component and in the DOM, wasn't being retained correctly.

To solve this, instead of binding the props to the component, we pass the props down to the `<Demo>` component and let it combine the props internally.

## Commit Message For Review

Fixes #276 