### PR TITLE
docs(site): Group nav items into 'Guides' and 'Components'

### DIFF
--- a/docs/src/components/App/Header/Header.js
+++ b/docs/src/components/App/Header/Header.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 
 import { Link } from 'react-router';
-import { PageBlock, Section, Text } from 'seek-style-guide/react';
+import { PageBlock, Card, Section, Text, ScreenReaderOnly } from 'seek-style-guide/react';
 import Logo from './Logo/Logo';
 import demoSpecs from '../../../demoSpecs';
 
@@ -40,7 +40,7 @@ export default class Header extends Component {
             <div className={styles.sectionContent}>
               <Link className={styles.logoLink} to="/" onClick={this.handleMenuClose}>
                 <Logo svgClassName={styles.logo} />
-                <div className={styles.title}>style guide</div>
+                <h1 className={styles.title}><ScreenReaderOnly>Seek </ScreenReaderOnly>Style Guide</h1>
               </Link>
 
               <div className={styles.hamburger}>
@@ -61,17 +61,35 @@ export default class Header extends Component {
                 <div className={styles.menu} onClick={this.handleMenuClose}>
                   <PageBlock>
                     <Section header>
-                      <Text hero><Link className={styles.link} to="/">Home</Link></Text>
-                      <Text hero><Link className={styles.link} to="/page-layout">Page Layout</Link></Text>
-                      {
-                        demoSpecs.map(demoSpec => (
-                          <Text hero key={demoSpec.title}>
-                            <Link className={styles.link} to={demoSpec.route}>
-                              { demoSpec.title }
-                            </Link>
-                          </Text>
-                        ))
-                      }
+                      <Card transparent>
+                        <Text headline regular><Link className={styles.link} to="/">Home</Link></Text>
+                      </Card>
+
+                      <Card transparent>
+                        <h2>
+                          <Text h2 headline>Guides</Text>
+                        </h2>
+                      </Card>
+                      <Card transparent>
+                        <Text headline regular><Link className={styles.link} to="/page-layout">Page Layout</Link></Text>
+                      </Card>
+
+                      <Card transparent>
+                        <h2>
+                          <Text headline>Components</Text>
+                        </h2>
+                      </Card>
+                      <Card transparent>
+                        {
+                          demoSpecs.map(demoSpec => (
+                            <Text headline regular key={demoSpec.title}>
+                              <Link className={styles.link} to={demoSpec.route}>
+                                { demoSpec.title }
+                              </Link>
+                            </Text>
+                          ))
+                        }
+                      </Card>
                     </Section>
                   </PageBlock>
                 </div>

--- a/docs/src/components/App/Header/Header.js
+++ b/docs/src/components/App/Header/Header.js
@@ -40,7 +40,7 @@ export default class Header extends Component {
             <div className={styles.sectionContent}>
               <Link className={styles.logoLink} to="/" onClick={this.handleMenuClose}>
                 <Logo svgClassName={styles.logo} />
-                <h1 className={styles.title}><ScreenReaderOnly>Seek </ScreenReaderOnly>Style Guide</h1>
+                <h1 className={styles.title}><ScreenReaderOnly>SEEK </ScreenReaderOnly>Style Guide</h1>
               </Link>
 
               <div className={styles.hamburger}>

--- a/docs/src/components/App/Header/Header.js
+++ b/docs/src/components/App/Header/Header.js
@@ -67,7 +67,7 @@ export default class Header extends Component {
 
                       <Card transparent>
                         <h2>
-                          <Text h2 headline>Guides</Text>
+                          <Text headline>Guides</Text>
                         </h2>
                       </Card>
                       <Card transparent>

--- a/docs/src/components/App/Header/Header.less
+++ b/docs/src/components/App/Header/Header.less
@@ -29,6 +29,7 @@
 .title {
   .headingText();
 
+  text-transform: lowercase;
   position: absolute;
   color: @sk-white;
   text-decoration: none;
@@ -130,6 +131,6 @@
   display: inline-block;
   margin-bottom: @grid-row-height;
   &:hover {
-    box-shadow: inset 0 -3px 0 @sk-white;
+    box-shadow: inset 0 -2px 0 @sk-white;
   }
 }

--- a/react/Button/Button.demo.js
+++ b/react/Button/Button.demo.js
@@ -4,8 +4,8 @@ import styles from './Button.less';
 import classnames from 'classnames';
 
 export default {
-  route: '/buttons',
-  title: 'Buttons',
+  route: '/button',
+  title: 'Button',
   component: Button,
   initialProps: {
     children: 'Hello world',

--- a/react/MonthPicker/MonthPicker.demo.js
+++ b/react/MonthPicker/MonthPicker.demo.js
@@ -41,7 +41,7 @@ class MonthPickerContainer extends Component {
 
 export default {
   route: '/monthpicker',
-  title: 'Month picker',
+  title: 'Month Picker',
   component: MonthPicker,
   container: MonthPickerContainer,
   initialProps: {

--- a/react/SlideToggle/SlideToggle.demo.js
+++ b/react/SlideToggle/SlideToggle.demo.js
@@ -1,8 +1,8 @@
 import SlideToggle from './SlideToggle';
 
 export default {
-  route: '/slide-toggle',
-  title: 'Slide toggle',
+  route: '/slidetoggle',
+  title: 'Slide Toggle',
   component: SlideToggle,
   initialProps: {
     onChange: () => {},

--- a/react/Text/Text.demo.js
+++ b/react/Text/Text.demo.js
@@ -1,8 +1,8 @@
 import Text from './Text';
 
 export default {
-  route: '/typography',
-  title: 'Typography',
+  route: '/text',
+  title: 'Text',
   component: Text,
   initialProps: {
     children: 'Living Style Guide',

--- a/react/TextField/TextField.demo.js
+++ b/react/TextField/TextField.demo.js
@@ -53,8 +53,8 @@ class TextFieldContainer extends Component {
 }
 
 export default {
-  route: '/textfields',
-  title: 'Textfields',
+  route: '/textfield',
+  title: 'Text Field',
   component: TextField,
   container: TextFieldContainer,
   initialProps: {


### PR DESCRIPTION
## Commit Message for Review

This change is paving the way for more documentation by providing some basic structure to the IA. As part of this change, I've standardised the page titles and URLs for component demo pages to strictly match the name of the component (e.g. `Text` instead of `Typography`, especially since we're likely to write a high level guide to typography at some point)