### PR TITLE
docs(site): Tidy up generated code samples

### DIFF
--- a/docs/src/components/Demo/Code/Code.js
+++ b/docs/src/components/Demo/Code/Code.js
@@ -53,12 +53,12 @@ export default class Code extends Component {
       })
       .replace(/\={true}/ig, '')
       .replace(/svgClassName=".*?"/ig, 'svgClassName="..."')
-      .replace(/function noRefCheck\(\) \{\}/ig, '() => {...}');
+      .replace(/function noRefCheck\(\) \{\}/ig, '() => {...}')
+      .replace('<MockContent />', 'Lorem ipsum');
 
       const componentNames = uniq(
         (componentCode.match(/<([A-Z]\w*)(?=[\s>])/g) || [])
           .map(x => x.replace('<', ''))
-          .filter(x => !/mock/i.test(x))
       );
 
       code = `import {\n  ${componentNames.join(',\n  ')}\n} from 'seek-style-guide/react';\n\n\n${componentCode}`;

--- a/docs/src/components/Demo/Code/Code.js
+++ b/docs/src/components/Demo/Code/Code.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 import { Section, Text } from 'seek-style-guide/react';
 import debounce from 'lodash/debounce';
+import uniq from 'lodash/uniq';
 import jsxToString from 'react-element-to-jsx-string';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
@@ -47,12 +48,20 @@ export default class Code extends Component {
     if (jsx) {
       const componentCode = jsxToString(jsx, {
         showDefaultProps: false,
-        filterProps: ['className'],
+        filterProps: ['className', 'style'],
         useBooleanShorthandSyntax: false
-      }).replace(/svgClassName=".*?"/ig, 'svgClassName="..."')
+      })
+      .replace(/\={true}/ig, '')
+      .replace(/svgClassName=".*?"/ig, 'svgClassName="..."')
       .replace(/function noRefCheck\(\) \{\}/ig, '() => {...}');
 
-      code = `import { ${jsx.type.displayName || jsx.type.name} } from 'seek-style-guide/react';\n\n\n${componentCode}`;
+      const componentNames = uniq(
+        (componentCode.match(/<([A-Z]\w*)(?=[\s>])/g) || [])
+          .map(x => x.replace('<', ''))
+          .filter(x => !/mock/i.test(x))
+      );
+
+      code = `import {\n  ${componentNames.join(',\n  ')}\n} from 'seek-style-guide/react';\n\n\n${componentCode}`;
     } else if (less) {
       code = `@import (reference) "~seek-style-guide/theme";\n\n\n.element {\n  .${less}\n}`;
     }

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "react-baseline": "^1.0.1",
     "react-copy-to-clipboard": "4.2.1",
     "react-dom": "^15.3.1",
-    "react-element-to-jsx-string": "^6.2.0",
+    "react-element-to-jsx-string": "^12.0.0",
     "react-helmet": "^3.2.2",
     "react-hot-loader": "^3.0.0-beta.2",
     "react-isolated-scroll": "^0.1.0",

--- a/react/Text/Text.demo.js
+++ b/react/Text/Text.demo.js
@@ -84,48 +84,40 @@ export default {
         },
         {
           label: 'Headline',
-          transformProps: props => ({
+          transformProps: ({ hero, ...props }) => ({
             ...props,
-            hero: false,
             headline: true
           })
         },
         {
           label: 'Heading',
-          transformProps: props => ({
+          transformProps: ({ hero, ...props }) => ({
             ...props,
-            hero: false,
             heading: true
           })
         },
         {
           label: 'Subheading',
-          transformProps: props => ({
+          transformProps: ({ hero, ...props }) => ({
             ...props,
-            hero: false,
             subheading: true
           })
         },
         {
           label: 'Superstandard',
-          transformProps: props => ({
+          transformProps: ({ hero, ...props }) => ({
             ...props,
-            hero: false,
             superstandard: true
           })
         },
         {
           label: 'Standard',
-          transformProps: props => ({
-            ...props,
-            hero: false
-          })
+          transformProps: ({ hero, ...props }) => props
         },
         {
           label: 'Substandard',
-          transformProps: props => ({
+          transformProps: ({ hero, ...props }) => ({
             ...props,
-            hero: false,
             substandard: true
           })
         }


### PR DESCRIPTION
Code samples are automatically generated, but this has led to a few quirks that make them differ from how you'd actually write the code in practice. To fix this, this commit makes the following changes:
- Replace all instances of `prop={true}` with `prop`, while leaving `prop={false}`, e.g. `<Text hero={true}>` becomes `<Text hero>`
- Hide any custom styling via the `style` prop, which is used purely for visual purposes on the style guide demo site, e.g. `<Section style={{ background: 'blue' }}>` becomes `<Section>`
- Detect and display *all* style guide components in import statements, not just the root component, e.g. `import { Card } from 'seek-style-guide/react'; <Card><Section>...` becomes `import { Card, Section } from 'seek-style-guide/react'; <Card><Section>...`
- Use multiline import statements to better support smaller screens and multiple imports

## Commit Message For Review

N/A