### PR TITLE
fix(Text): Upgrade basekick to v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
-    "basekick": "2.0.1",
+    "basekick": "3.0.0",
     "chalk": "1.1.3",
     "css-loader": "0.28.0",
     "enzyme": "^2.8.2",


### PR DESCRIPTION
## Commit Message For Review

Upgrades Basekick to the latest v3.0.0 release.

REASON FOR CHANGE:

Refining the Basekick module has resulted in `line-height` no longer needing to be expressed as a scale, rather as a pixel value that is the result of the type row span times the grid row height. This simplifies the output CSS to use pixels for `font-size` and `line-height` and only express the `transform` as a scale (in `em` units).
