### PR TITLE
Removing label props to show the warning message

### DIFF
--- a/react/Autosuggest/Autosuggest.demo.js
+++ b/react/Autosuggest/Autosuggest.demo.js
@@ -63,7 +63,6 @@ export default {
   container: AutosuggestContainer,
   initialProps: {
     id: 'jobTitles',
-    label: 'Job Titles',
     autosuggestProps: {
       suggestions: ['Developer', 'Product manager', 'Iteration manager', 'Designer'],
       onSuggestionsFetchRequested: () => {},


### PR DESCRIPTION
The bellow warning appears when label props are not specified for autosuggest label

Warning: Failed prop type: Specifying `labelProps` is redundant when `label` is not specified in FieldLabel.