### PR TITLE
feat(Hidden): Add ability to accept a component that will wrap children

### DIFF
--- a/react/Hidden/Hidden.js
+++ b/react/Hidden/Hidden.js
@@ -5,11 +5,12 @@ import classNames from 'classnames';
 
 import styles from './Hidden.less';
 
-const Hidden = ({ children, component, className, print, screen, mobile, desktop }) => {
+const Hidden = ({ children, component, className, print, screen, mobile, desktop, ...restprops }) => {
   const Component = component ? component : 'span';
 
   return (
     <Component
+      {...restprops}
       className={classNames({
         [className]: className,
         [styles.desktop]: desktop,

--- a/react/Hidden/Hidden.js
+++ b/react/Hidden/Hidden.js
@@ -24,7 +24,7 @@ const Hidden = ({ children, component, className, print, screen, mobile, desktop
 };
 
 Hidden.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   component: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.string

--- a/react/Hidden/Hidden.js
+++ b/react/Hidden/Hidden.js
@@ -5,21 +5,29 @@ import classNames from 'classnames';
 
 import styles from './Hidden.less';
 
-const Hidden = ({ children, className, print, screen, mobile, desktop }) => (
-  <span
-    className={classNames(
-      className,
-      {
+const Hidden = ({ children, component, className, print, screen, mobile, desktop }) => {
+  const Component = component ? component : 'span';
+
+  return (
+    <Component
+      className={classNames({
+        [className]: className,
         [styles.desktop]: desktop,
         [styles.mobile]: mobile,
         [styles.print]: print,
         [styles.screen]: screen
-      }
-    )}>{children}</span>
-);
+      })}>
+      {children}
+    </Component>
+  );
+};
 
 Hidden.propTypes = {
   children: PropTypes.node.isRequired,
+  component: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string
+  ]),
   className: PropTypes.string,
   desktop: PropTypes.bool,
   mobile: PropTypes.bool,
@@ -29,6 +37,7 @@ Hidden.propTypes = {
 
 Hidden.defaultProps = {
   className: '',
+  component: 'span',
   desktop: false,
   mobile: false,
   print: false,

--- a/react/Hidden/Hidden.js
+++ b/react/Hidden/Hidden.js
@@ -6,21 +6,18 @@ import classNames from 'classnames';
 import styles from './Hidden.less';
 
 const Hidden = ({ children, component, className, print, screen, mobile, desktop, ...restprops }) => {
-  const Component = component ? component : 'span';
+  const props = {
+    ...restprops,
+    className: classNames({
+      [className]: className,
+      [styles.desktop]: desktop,
+      [styles.mobile]: mobile,
+      [styles.print]: print,
+      [styles.screen]: screen
+    })
+  };
 
-  return (
-    <Component
-      {...restprops}
-      className={classNames({
-        [className]: className,
-        [styles.desktop]: desktop,
-        [styles.mobile]: mobile,
-        [styles.print]: print,
-        [styles.screen]: screen
-      })}>
-      {children}
-    </Component>
-  );
+  return React.createElement(component, props, children);
 };
 
 Hidden.propTypes = {

--- a/react/Hidden/Hidden.test.js
+++ b/react/Hidden/Hidden.test.js
@@ -14,6 +14,11 @@ describe('components/grid/hidden', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should render with component', () => {
+    const wrapper = shallow(<Hidden component="li">Text</Hidden>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('should render with screen', () => {
     const wrapper = shallow(<Hidden screen>Text</Hidden>);
     expect(wrapper).toMatchSnapshot();

--- a/react/Hidden/Hidden.test.js
+++ b/react/Hidden/Hidden.test.js
@@ -19,6 +19,11 @@ describe('components/grid/hidden', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should render with props', () => {
+    const wrapper = shallow(<Hidden data-automation="foo">Text</Hidden>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('should render with screen', () => {
     const wrapper = shallow(<Hidden screen>Text</Hidden>);
     expect(wrapper).toMatchSnapshot();

--- a/react/Hidden/Hidden.test.js
+++ b/react/Hidden/Hidden.test.js
@@ -5,7 +5,7 @@ import Hidden from './Hidden';
 
 describe('components/grid/hidden', () => {
   it('should render without children', () => {
-    const wrapper = shallow(<Hidden/>);
+    const wrapper = shallow(<Hidden />);
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/react/Hidden/Hidden.test.js
+++ b/react/Hidden/Hidden.test.js
@@ -4,6 +4,11 @@ import { shallow } from 'enzyme';
 import Hidden from './Hidden';
 
 describe('components/grid/hidden', () => {
+  it('should render without children', () => {
+    const wrapper = shallow(<Hidden/>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('should render with children', () => {
     const wrapper = shallow(<Hidden>Text</Hidden>);
     expect(wrapper).toMatchSnapshot();

--- a/react/Hidden/__snapshots__/Hidden.test.js.snap
+++ b/react/Hidden/__snapshots__/Hidden.test.js.snap
@@ -48,6 +48,15 @@ exports[`components/grid/hidden should render with print 1`] = `
 </span>
 `;
 
+exports[`components/grid/hidden should render with props 1`] = `
+<span
+  className=""
+  data-automation="foo"
+>
+  Text
+</span>
+`;
+
 exports[`components/grid/hidden should render with screen 1`] = `
 <span
   className="screen"

--- a/react/Hidden/__snapshots__/Hidden.test.js.snap
+++ b/react/Hidden/__snapshots__/Hidden.test.js.snap
@@ -64,3 +64,9 @@ exports[`components/grid/hidden should render with screen 1`] = `
   Text
 </span>
 `;
+
+exports[`components/grid/hidden should render without children 1`] = `
+<span
+  className=""
+/>
+`;

--- a/react/Hidden/__snapshots__/Hidden.test.js.snap
+++ b/react/Hidden/__snapshots__/Hidden.test.js.snap
@@ -16,6 +16,14 @@ exports[`components/grid/hidden should render with classname 1`] = `
 </span>
 `;
 
+exports[`components/grid/hidden should render with component 1`] = `
+<li
+  className=""
+>
+  Text
+</li>
+`;
+
 exports[`components/grid/hidden should render with desktop 1`] = `
 <span
   className="desktop"


### PR DESCRIPTION
## Commit Message For Review

feat(Hidden): Add ability to pass down a component that will wrap children

RFC URL: None

REASON FOR CHANGE:

Additional unnecessary markup should be avoided when using hidden, because it might lead to semantically incorrect markup such as li items wrapped in spans, etc.

EXAMPLE USAGE:

```js
<Hidden component='li'>foo</Hidden>
```