### PR TITLE
fix(standalone): Default standalone header to rainbow logo

### DIFF
--- a/standalone/header-footer/src/client.js
+++ b/standalone/header-footer/src/client.js
@@ -1,8 +1,9 @@
 import makeStandalone from './makeStandalone';
 import Header from 'seek-style-guide/react/Header/Header';
 import Footer from 'seek-style-guide/react/Footer/Footer';
+import LogoRainbow from 'seek-style-guide/react/LogoRainbow/LogoRainbow';
 
-export const renderHeader = makeStandalone(Header);
+export const renderHeader = makeStandalone(Header, { logoComponent: LogoRainbow });
 export const renderFooter = makeStandalone(Footer);
 
 // Allow standalone header consumers to create React elements

--- a/standalone/header-footer/src/makeStandalone.js
+++ b/standalone/header-footer/src/makeStandalone.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'react-dom';
 import StandaloneProvider from './StandaloneProvider/StandaloneProvider';
 
-export default (Component, defaultProps) => (el, initialProps) => {
+export default (Component, defaultProps = {}) => (el, initialProps) => {
   let updateProps;
 
   const registerPropsUpdater = propsUpdater => {

--- a/standalone/header-footer/src/makeStandalone.js
+++ b/standalone/header-footer/src/makeStandalone.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'react-dom';
 import StandaloneProvider from './StandaloneProvider/StandaloneProvider';
 
-export default Component => (el, initialProps) => {
+export default (Component, defaultProps) => (el, initialProps) => {
   let updateProps;
 
   const registerPropsUpdater = propsUpdater => {
@@ -12,7 +12,7 @@ export default Component => (el, initialProps) => {
   render(
     <StandaloneProvider
       component={Component}
-      initialProps={initialProps}
+      initialProps={{...defaultProps, ...initialProps }}
       registerPropsUpdater={registerPropsUpdater}
     />
   , el);

--- a/standalone/header-footer/src/makeStandalone.js
+++ b/standalone/header-footer/src/makeStandalone.js
@@ -12,7 +12,7 @@ export default (Component, defaultProps) => (el, initialProps) => {
   render(
     <StandaloneProvider
       component={Component}
-      initialProps={{...defaultProps, ...initialProps }}
+      initialProps={{ ...defaultProps, ...initialProps }}
       registerPropsUpdater={registerPropsUpdater}
     />
   , el);


### PR DESCRIPTION
## Commit Message For Review

Default the standalone `Header` to use `LogoRainbow`.

REASON FOR CHANGE:

Currently no other way to do this, have discussed with @markdalgleish and this is temporary. 