### PR TITLE
fix(standalone): Revert rainbow logo for standalone header

### DIFF
--- a/standalone/header-footer/src/client.js
+++ b/standalone/header-footer/src/client.js
@@ -1,9 +1,8 @@
 import makeStandalone from './makeStandalone';
 import Header from 'seek-style-guide/react/Header/Header';
 import Footer from 'seek-style-guide/react/Footer/Footer';
-import LogoRainbow from 'seek-style-guide/react/LogoRainbow/LogoRainbow';
 
-export const renderHeader = makeStandalone(Header, { logoComponent: LogoRainbow });
+export const renderHeader = makeStandalone(Header);
 export const renderFooter = makeStandalone(Footer);
 
 // Allow standalone header consumers to create React elements


### PR DESCRIPTION
## Commit Message For Review

Revert back to original seek logo from rainbow logo

REASON FOR CHANGE:

Rainbow logo was a temporary change
