### PR TITLE
feat(CardGroup): Add CardGroup

### DIFF
--- a/docs/src/components/PageLayout/PageLayout.js
+++ b/docs/src/components/PageLayout/PageLayout.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { PageBlock, AsidedLayout, Card, Section, Paragraph, Text, TextLink, Strong } from 'seek-style-guide/react';
+import { PageBlock, AsidedLayout, Card, CardGroup, Section, Paragraph, Text, TextLink, Strong } from 'seek-style-guide/react';
 import Demo from '../Demo/Demo';
 
 const BackgroundContainer = ({ component: DemoComponent, componentProps }) => (
@@ -284,7 +284,7 @@ export default () => (
               <Section header>
                 <Text headline>Lorem ipsum</Text>
               </Section>
-              <Card group>
+              <CardGroup>
                 <Card>
                   <Section>
                     <Text heading>Lorem ipsum</Text>
@@ -303,7 +303,7 @@ export default () => (
                     <Text>{loremIpsum}</Text>
                   </Section>
                 </Card>
-              </Card>
+              </CardGroup>
             </div>
           )
         },

--- a/docs/src/components/Playground/Playground.js
+++ b/docs/src/components/Playground/Playground.js
@@ -12,6 +12,7 @@ import {
   AsidedLayout,
   Columns,
   Card,
+  CardGroup,
   Text,
   Positive,
   Critical,
@@ -242,7 +243,7 @@ export default class Playground extends Component {
           </Section>
 
           <AsidedLayout reverse renderAside={renderAsideRecommendedJobs} size="240px">
-            <Card group>
+            <CardGroup>
               {
                 [0, 1, 2, 3].map(n => (
                   <Card key={n}>
@@ -254,7 +255,7 @@ export default class Playground extends Component {
                   </Card>
                 ))
               }
-            </Card>
+            </CardGroup>
           </AsidedLayout>
         </PageBlock>
 
@@ -265,7 +266,7 @@ export default class Playground extends Component {
             <Tab>Applied</Tab>
           </Section>
 
-          <Card group>
+          <CardGroup>
             {
               [0, 1, 2, 3].map(n => (
                 <Card key={n}>
@@ -287,7 +288,7 @@ export default class Playground extends Component {
                 </Card>
               ))
             }
-          </Card>
+          </CardGroup>
         </PageBlock>
 
         <PageBlock>
@@ -300,7 +301,7 @@ export default class Playground extends Component {
           </Section>
 
           <AsidedLayout reverse renderAside={renderJobDetailMetadata} size="360px">
-            <Card group>
+            <CardGroup>
               <Card>
                 <Section>
                   <Text>
@@ -315,7 +316,7 @@ export default class Playground extends Component {
                   <Text>You must have the <Strong>right to live and work</Strong> in this location to apply for this job.</Text>
                 </Section>
               </Card>
-            </Card>
+            </CardGroup>
           </AsidedLayout>
         </PageBlock>
 
@@ -395,7 +396,7 @@ export default class Playground extends Component {
           <Section header>
             <Text hero>Text variants</Text>
           </Section>
-          <Card group>
+          <CardGroup>
             <Card>
               <Section>
                 <Text heading>Text component modifiers</Text>
@@ -414,7 +415,7 @@ export default class Playground extends Component {
                 <Text><Strong>Strong text</Strong></Text>
               </Section>
             </Card>
-          </Card>
+          </CardGroup>
         </PageBlock>
 
         <Footer linkRenderer={dummyLinkRenderer} />

--- a/react/CardGroup/CardGroup.js
+++ b/react/CardGroup/CardGroup.js
@@ -2,16 +2,14 @@ import Card from '../Card/Card';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function CardGroup({ className, children, transparent, ...restProps }) {
+export default function CardGroup({ children, ...restProps }) {
   return (
-    <Card {...restProps} group className={className} transparent={transparent}>
+    <Card {...restProps} group>
       {children}
     </Card>
   );
 }
 
 CardGroup.propTypes = {
-  className: PropTypes.string,
-  children: PropTypes.node.isRequired,
-  transparent: PropTypes.bool
+  children: PropTypes.node.isRequired
 };

--- a/react/CardGroup/CardGroup.js
+++ b/react/CardGroup/CardGroup.js
@@ -1,0 +1,17 @@
+import Card from '../Card/Card';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function CardGroup({ className, children, transparent, ...restProps }) {
+  return (
+    <Card {...restProps} group className={className} transparent={transparent}>
+      {children}
+    </Card>
+  );
+}
+
+CardGroup.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  transparent: PropTypes.bool
+};

--- a/react/CardGroup/CardGroup.js
+++ b/react/CardGroup/CardGroup.js
@@ -1,15 +1,8 @@
 import Card from '../Card/Card';
 import React from 'react';
-import PropTypes from 'prop-types';
 
-export default function CardGroup({ children, ...restProps }) {
+export default function CardGroup(props) {
   return (
-    <Card {...restProps} group>
-      {children}
-    </Card>
+    <Card group {...props} />
   );
 }
-
-CardGroup.propTypes = {
-  children: PropTypes.node.isRequired
-};

--- a/react/index.js
+++ b/react/index.js
@@ -22,6 +22,7 @@ export { default as TextLink } from './TextLink/TextLink';
 // Layout
 export { default as AsidedLayout } from './AsidedLayout/AsidedLayout';
 export { default as Card } from './Card/Card';
+export { default as CardGroup } from './CardGroup/CardGroup';
 export { default as Columns } from './Columns/Columns';
 export { default as Hidden } from './Hidden/Hidden';
 export { default as PageBlock } from './PageBlock/PageBlock';


### PR DESCRIPTION
## Commit Message For Review

Added `CardGroup` component to support a more future proofed API for grouping components of the same type. `CardGroup` is just a implementation of `<Card group />` so at the time of writing this is a non breaking change.

RFC URL:

https://github.com/seek-oss/seek-style-guide/issues/321

REASON FOR CHANGE:

While working on `ButtonGroup` it became evident the keeping the same interface, that being `<Card group/>` & `<Button group />` didn't make sense for the component `Button`.

MIGRATION GUIDE:

Before:

```js
<Card group>
  <Card {...} />
  <Card {...} />
</Card>
```

After:

```js
<CardGroup>
  <Card {...} />
  <Card {...} />
</CardGroup>
```