### PR TITLE
fix(ButtonGroup): Ensure grouped buttons align to grid

### DIFF
--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -116,6 +116,7 @@
   width: 100%;
 
   .root {
+    vertical-align: top;
     @media only screen and (max-width: 500px) {
       width: 100%;
     }


### PR DESCRIPTION
Original:
![screen shot 2017-09-20 at 10 33 18 am](https://user-images.githubusercontent.com/696693/30621574-2eb51f4a-9def-11e7-8df8-359d48f91280.png)

Fixed:
![screen shot 2017-09-20 at 10 34 14 am](https://user-images.githubusercontent.com/696693/30621596-4e66f93a-9def-11e7-93a7-6b8ecf8c5c2f.png)


## Commit Message For Review

REASON FOR CHANGE:

When using multiple buttons in a group, it added an extra 2 vertical pixels, knocking it off grid.