### PR TITLE
feat(Textarea): Add description prop to Textarea for longer explanations

### DIFF
--- a/react/Textarea/Textarea.demo.js
+++ b/react/Textarea/Textarea.demo.js
@@ -85,6 +85,13 @@ export default {
               count: 500 - value.length
             })
           })
+        },
+        {
+          label: 'Description',
+          transformProps: props => ({
+            ...props,
+            description: 'Describe a descriptive description descriptively'
+          })
         }
       ]
     },

--- a/react/Textarea/Textarea.js
+++ b/react/Textarea/Textarea.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 
 import FieldMessage from '../private/FieldMessage/FieldMessage';
 import FieldLabel from '../private/FieldLabel/FieldLabel';
+import Text from '../Text/Text';
 
 function combineClassNames(props = {}, ...classNames) {
   const { className, ...restProps } = props;
@@ -32,6 +33,7 @@ export default class Textarea extends Component {
     /* eslint-enable consistent-return */
     className: PropTypes.string,
     valid: PropTypes.bool,
+    description: PropTypes.string,
     /* eslint-disable consistent-return */
     inputProps: (props, propName, componentName) => {
       const { id, inputProps } = props;
@@ -63,7 +65,8 @@ export default class Textarea extends Component {
 
   static defaultProps = {
     id: '',
-    className: ''
+    className: '',
+    description: ''
   };
 
   constructor() {
@@ -122,11 +125,15 @@ export default class Textarea extends Component {
     });
 
     // eslint-disable-next-line react/prop-types
-    const { id, label, labelProps, invalid, help, helpProps, message, messageProps, secondaryLabel, tertiaryLabel } = this.props;
+    const { id, label, labelProps, invalid, help, helpProps, message, messageProps, secondaryLabel, tertiaryLabel, description } = this.props;
+    const hasDescription = description.length > 0;
 
     return (
       <div className={classNames}>
-        <FieldLabel {...{ id, label, labelProps, secondaryLabel, tertiaryLabel }} />
+        <FieldLabel {...{ id, label, labelProps, secondaryLabel, tertiaryLabel, raw: hasDescription }} />
+        {
+          hasDescription ? <Text secondary>{description}</Text> : null
+        }
         {this.renderInput()}
         <div className={styles.footer}>
           <FieldMessage {...{ invalid, help, helpProps, valid, message, messageProps }} />

--- a/react/Textarea/Textarea.test.js
+++ b/react/Textarea/Textarea.test.js
@@ -100,6 +100,18 @@ describe('Textarea', () => {
     });
   });
 
+  describe('description', () => {
+    it('should not be rendered by default', () => {
+      render(<Textarea />);
+      expect(textarea.props.children[1]).to.equal(null);
+    });
+
+    it('should render description when specified', () => {
+      render(<Textarea description="test" />);
+      expect(textarea.props.children[1].props.children).to.equal('test');
+    });
+  });
+
   describe('characterCount', () => {
     it('should not be rendered by default', () => {
       render(<Textarea />);

--- a/react/private/FieldLabel/FieldLabel.js
+++ b/react/private/FieldLabel/FieldLabel.js
@@ -51,13 +51,15 @@ export default class FieldLabel extends Component {
     },
     /* eslint-enable consistent-return */
     secondaryLabel: PropTypes.string,
-    tertiaryLabel: PropTypes.node
+    tertiaryLabel: PropTypes.node,
+    raw: PropTypes.bool
   };
 
   static defaultProps = {
     label: '',
     secondaryLabel: '',
-    tertiaryLabel: ''
+    tertiaryLabel: '',
+    raw: false
   };
 
   constructor() {
@@ -95,7 +97,7 @@ export default class FieldLabel extends Component {
   }
 
   render() {
-    const { label } = this.props;
+    const { label, raw } = this.props;
 
     if (!label) {
       return null;
@@ -108,7 +110,7 @@ export default class FieldLabel extends Component {
     };
     return (
       <label {...allLabelProps}>
-        <Text><Strong>{label}</Strong> {this.renderSecondary()}{this.renderTertiary()}</Text>
+        <Text raw={raw}><Strong>{label}</Strong> {this.renderSecondary()}{this.renderTertiary()}</Text>
       </label>
     );
   }


### PR DESCRIPTION
## Commit Message For Review

Add description prop to Textarea for fields that require more explanation

RFC URL: https://github.com/seek-oss/seek-style-guide/issues/325

REASON FOR CHANGE:

See [RFC](https://github.com/seek-oss/seek-style-guide/issues/325)

EXAMPLE USAGE:

```js
import {
  Textarea
} from 'seek-style-guide/react';

<Textarea
  description="Long description of highlights field"
  id="highlights"
  inputProps={{
    onChange: () => {...},
    value: '...'
  }}
  label="Highlights"
/>
```