### PR TITLE
docs(site): Clean up form element demos

### DIFF
--- a/react/Textarea/Textarea.demo.js
+++ b/react/Textarea/Textarea.demo.js
@@ -71,13 +71,6 @@ export default {
           })
         },
         {
-          label: 'Secondary Label',
-          transformProps: props => ({
-            ...props,
-            secondaryLabel: '(secondary)'
-          })
-        },
-        {
           label: 'Show Count',
           transformProps: props => ({
             ...props,

--- a/react/private/FieldMessage/FieldMessage.demo.js
+++ b/react/private/FieldMessage/FieldMessage.demo.js
@@ -1,18 +1,5 @@
 export default [
   {
-    label: 'Secondary',
-    type: 'checklist',
-    states: [
-      {
-        label: 'Secondary message',
-        transformProps: props => ({
-          ...props,
-          messageProps: { secondary: true }
-        })
-      }
-    ]
-  },
-  {
     label: 'Message',
     type: 'radio',
     states: [


### PR DESCRIPTION
Some form element demos were starting to collect a few too many options, but some of them were either an edge case or completely redundant.