### PR TITLE
fix(components): Use prop-types for PropType declarations

### DIFF
--- a/react/Logo/LogoIcon.js
+++ b/react/Logo/LogoIcon.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const LogoIcon = ({ iconClass }) => (
   <path

--- a/react/Logo/LogoText.js
+++ b/react/Logo/LogoText.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const LogoText = ({ textClass }) => (
   <g className={textClass}>

--- a/react/LogoRainbow/LogoRainbowIcon.js
+++ b/react/LogoRainbow/LogoRainbowIcon.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const RainbowLogoIcon = () => (
   <g transform="translate(2.5,2.5), scale(1.02)">

--- a/react/LogoRainbow/LogoRainbowText.js
+++ b/react/LogoRainbow/LogoRainbowText.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const RainbowLogoText = ({ textClass }) => (
   <g className={textClass}>


### PR DESCRIPTION
Recent changes to React depreciated the use of PropTypes as a sub-package of React, suggesting the use of a dedicated prop-types dependency.

https://facebook.github.io/react/warnings/dont-call-proptypes.html

Builds using React 16 will no-longer fail to render in non-production builds.

## Commit Message For Review

Remove all uses of PropTypes as part of react package and use the dedicated prop-types package

REASON FOR CHANGE:

React 16 no-longer provides prop-types directly. Using React 16 with Seek Style Guide may lead to errors when checking propTypes in development builds.