### PR TITLE
docs(site): Configure router basename

### DIFF
--- a/docs/src/Router.js
+++ b/docs/src/Router.js
@@ -1,6 +1,11 @@
 import React from 'react';
-import { Router, browserHistory } from 'react-router';
+import { Router } from 'react-router';
+import { createHistory } from 'history';
 import routes from './Routes';
+
+const browserHistory = createHistory({
+  basename: process.env.BASE_HREF
+});
 
 export default function RouterComponent() {
   return (

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "gh-pages": "^0.11.0",
     "glob": "^7.1.1",
     "hex-rgb": "^1.0.0",
+    "history": "^3.3.0",
     "html-webpack-plugin": "^2.28.0",
     "husky": "^0.12.0",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
## Commit Message For Review

Upgrading React Router seems to have broken the docs on GitHub Pages, even though they work on Surge. It seems likely to be caused by deprecation of transparent base href tag support, but regardless of whether this is the actual cause of the issue or not, we now need to explicitly provide the basename to our history instance.