### PR TITLE
docs(site): Provide ‘BASE_HREF’ env var to static build client

### DIFF
--- a/docs/webpack.static.client.config.js
+++ b/docs/webpack.static.client.config.js
@@ -64,9 +64,8 @@ const config = {
 
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production')
-      }
+      'process.env.NODE_ENV': JSON.stringify('production'),
+      'process.env.BASE_HREF': JSON.stringify(process.env.BASE_HREF)
     }),
     appCss,
     new webpack.optimize.UglifyJsPlugin({

--- a/docs/webpack.static.render.config.js
+++ b/docs/webpack.static.render.config.js
@@ -57,10 +57,8 @@ const config = {
 
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production'),
-        BASE_HREF: JSON.stringify(process.env.BASE_HREF)
-      }
+      'process.env.NODE_ENV': JSON.stringify('production'),
+      'process.env.BASE_HREF': JSON.stringify(process.env.BASE_HREF)
     }),
     new StaticSiteGeneratorPlugin({
       crawl: true,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf dist && rm -rf docs/dist && mkdir -p dist && mkdir -p docs/dist",
     "compile": "npm run compile-render && npm run compile-client && npm run compile-header-footer",
     "compile-render": "NODE_ENV=production BASE_HREF=${BASE_HREF:-/} webpack --config docs/webpack.static.render.config.js && rm docs/dist/render.js",
-    "compile-client": "NODE_ENV=production webpack --config docs/webpack.static.client.config.js",
+    "compile-client": "NODE_ENV=production BASE_HREF=${BASE_HREF:-/} webpack --config docs/webpack.static.client.config.js",
     "compile-header-footer": "NODE_ENV=production webpack --config standalone/header-footer/webpack.config.js",
     "build": "npm run clean && npm run compile",
     "build-gh-pages": "BASE_HREF=/seek-style-guide/ npm run build",


### PR DESCRIPTION
## Commit Message For Review

The client code now depends on the BASE_HREF environment variable, but it wasn’t provided within our webpack config, which meant that it resolved to ‘undefined’.