### PR TITLE
docs(site): Use history v3 basename API

### DIFF
--- a/docs/src/Router.js
+++ b/docs/src/Router.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Router } from 'react-router';
-import { createHistory } from 'history';
+import { createHistory, useBasename } from 'history';
 import routes from './Routes';
 
-const browserHistory = createHistory({
+const browserHistory = useBasename(createHistory)({
   basename: process.env.BASE_HREF
 });
 


### PR DESCRIPTION
## Commit Message For Review

I was accidentally using the v4 basename API, which doesn’t throw any errors but has no effect in v3.