### PR TITLE
chore(github): Streamline RFC and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,66 +1,11 @@
-NOTE: This template is also available at https://github.com/seek-oss/seek-style-guide/blob/master/.github/ISSUE_TEMPLATE.md if you'd like to refer to it later.
-
-
-RFC TEMPLATE
-============
-
-NOTE: For complete examples, have a look at Yarn's list of accepted RFCs - https://github.com/yarnpkg/rfcs/tree/master/accepted
-
-
-Issue title:
-
-RFC: {{ Name of proposal }}
-
-
-Issue body:
-
-# Summary
-
-One paragraph explanation of the feature.
-
 # Motivation
 
-Why are we doing this? What use cases does it support? What is the expected
-outcome?
+{{ Why are we proposing an API change? }}
 
-Please focus on explaining the motivation so that if this RFC is not accepted,
-the motivation could be used to develop alternative solutions. In other words,
-enumerate the constraints you are trying to solve without coupling them too
-closely to the solution you have in mind.
+# Proposed solution with API example(s)
 
-# Detailed design
-
-This is the bulk of the RFC. Explain the design in enough detail for somebody
-familiar with the style guide to understand, and for somebody familiar with the
-implementation to implement. This should get into specifics and corner-cases,
-and include examples of how the feature is used. Any new terminology should be
-defined here.
-
-# How We Teach This
-
-What names and terminology work best for these concepts and why? How is this
-idea best presented? As a continuation of existing style guide
-patterns, or as a wholly new one?
-
-Would the acceptance of this proposal mean the style guide documentation must be
-re-organized or altered? Does it change how the style guide is taught to new users
-at any level?
-
-How should this feature be introduced and taught to existing style guide users?
-
-# Drawbacks
-
-Why should we *not* do this? Please consider the impact on teaching people to
-use the style guide, on the integration of this feature with other existing and planned
-features, on the impact of churn on existing users.
-
-There are tradeoffs to choosing any path, please attempt to identify them here.
-
-# Alternatives
-
-What other designs have been considered? What is the impact of not doing this?
+{{ What does your proposed API look like and why? }}
 
 # Unresolved questions
 
-Optional, but suggested for first drafts. What parts of the design are still
-TBD?
+{{ Is there anything else that needs to be discussed? }}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,6 @@
-ARE YOU PLANNING TO CHANGE THE STYLE GUIDE'S PUBLIC API? If so, please make sure you've first gone through the RFC approval process by opening a new issue and using the provided template.
+** Please provide as much detail as possible, but feel free to remove irrelevant sections **
 
-IMPORTANT
-=========
-
-Please ensure that, when eventually merging this PR to master, you copy the completed "Commit Message For Review" section below into your final commit body. This allows us to review our release notes, validating that they're clear enough for consumers to follow.
-
-Don't forget that what's written here forms the upgrade guide for consumers, and upgrading can easily become a long and arduous process. To counter this, please be as descriptive as possible, explaining the reasoning behind the change, and showing a clear usage example or migration guide where appropriate. Since there are many different consumers, changes should be documented from the perspective of the style guide itself, so avoid making specific reference to the application you're working on.
-
-
-Major release template
-======================
-
-
-## Commit Message For Review
+{{ Reason for change }}
 
 BREAKING CHANGE:
 
@@ -20,11 +8,7 @@ BREAKING CHANGE:
 
 RFC URL:
 
-{{ URL of associated RFC }}
-
-REASON FOR CHANGE:
-
-{{ Reason for change }}
+{{ URL of associated RFC for API change }}
 
 MIGRATION GUIDE:
 
@@ -40,47 +24,8 @@ After:
 {{ New code }}
 ```
 
-
-Minor release template
-======================
-
-
-## Commit Message For Review
-
-{{ Optional description of change }}
-
-RFC URL:
-
-{{ URL of associated RFC }}
-
-REASON FOR CHANGE:
-
-{{ Reason for change }}
-
 EXAMPLE USAGE:
 
 ```js
 {{ Code }}
 ```
-
-
-Patch release template
-======================
-
-
-## Commit Message For Review
-
-{{ Optional description of change }}
-
-REASON FOR CHANGE:
-
-{{ Reason for change }}
-
-
-Non-release template
-====================
-
-
-## Commit Message For Review
-
-{{ Optional description of change }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ $ npm install
 
 ## Before Starting
 
-If you're planning to change the public API, please [open a new issue](https://github.com/seek-oss/seek-style-guide/issues/new) and follow the provided RFC template.
+If you're planning to change the public API, please [open a new issue](https://github.com/seek-oss/seek-style-guide/issues/new) and follow the provided RFC template. If you think it's a more straightforward API change and doesn't require a formal RFC, feel free to raise it in Slack first to see what others think.
 
 ## Workflow
 


### PR DESCRIPTION
As discussed, trying to make the process of proposing changes and issuing pull requests a bit easier for consumers, without sacrificing the benefits of the existing approach.