### PR TITLE
docs(readme): Add missing StyleGuideProvider import in Setup code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Wrap your app with the `StyleGuideProvider` component to use any of the style gu
 
 ```js
 import React, { Component } from 'react';
+import { StyleGuideProvider } from 'seek-style-guide/react';
 
 export default class App extends Component {
   render() {


### PR DESCRIPTION
Following the sample code, I had a compile error.

Adding this import should make it easier for new people to get started.