### PR TITLE
fix(deps): Upgrade dependencies, use caret version ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,14 +46,14 @@
   },
   "homepage": "https://github.com/seek-oss/seek-style-guide#readme",
   "dependencies": {
-    "basekick": "3.0.0",
+    "basekick": "^3.0.0",
     "classnames": "^2.2.5",
-    "lodash": "4.17.4",
+    "lodash": "^4.17.4",
     "pad-left": "^2.1.0",
     "prop-types": "^15.6.0",
-    "react-autosuggest": "9.3.1",
-    "react-isolated-scroll": "^0.1.0",
-    "react-scrolllock": "1.0.8"
+    "react-autosuggest": "^9.3.2",
+    "react-isolated-scroll": "^0.1.1",
+    "react-scrolllock": "^1.0.9"
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",


### PR DESCRIPTION
This gets all of our dependencies up to date. Some of our dependencies used caret version ranges while others didn't, so I figured it makes sense to standardise it. I opted for using carets to reduce churn on the style guide, especially since yarn is gaining in popularity, and later versions of npm produce a lockfile by default.

## Commit message for review

Since we're relaxing the version ranges of some dependencies, this is probably a good time to remind you that, if your app isn't using using yarn or an npm lockfile, it probably should.