### PR TITLE
fix(Columns): Remove implied min-width for Columns

### DIFF
--- a/react/Columns/Columns.js
+++ b/react/Columns/Columns.js
@@ -8,12 +8,13 @@ const renderColumn = (el, index) => (
   <div key={index} className={styles.column}>{el}</div>
 );
 
-export default function Columns({ children, tight }) {
+export default function Columns({ children, tight, flexible }) {
   return (
     <div
       className={classnames({
         [styles.columns]: true,
-        [styles.columns_tight]: tight
+        [styles.columns_tight]: tight,
+        [styles.columns_flexible]: flexible
       })}>
       {children.map(renderColumn)}
     </div>
@@ -22,5 +23,6 @@ export default function Columns({ children, tight }) {
 
 Columns.propTypes = {
   children: PropTypes.array.isRequired,
-  tight: PropTypes.bool
+  tight: PropTypes.bool,
+  flexible: PropTypes.bool
 };

--- a/react/Columns/Columns.less
+++ b/react/Columns/Columns.less
@@ -10,6 +10,12 @@
   @media @desktop {
     flex-basis: 0;
     flex-grow: 1;
+
+    min-width: 0;
+    .columns_flexible & {
+        min-width: auto;
+    }
+
     padding: 0 (@grid-gutter-width / 2);
     .columns_tight & {
       padding: 0 (@grid-gutter-width / 4);


### PR DESCRIPTION
## Reason for change
At the moment the columns allow flexing based on content.
E.g Column 1 with wide content might be at 60% while Column 2 with thin content might be at 40%.
This may not be ideal default behavior.

From [MDN min-width](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width)
> auto
> The default minimum width for flex items, providing a more reasonable default than 0 for other layouts.

## Change
This change will ensure column widths default to 1fr and do not change based on content.

#### Before change
Note: In both cases 'overflow-wrap: break-word;' is applied to the text
<img width="1015" alt="screen shot 2017-10-11 at 2 16 58 pm" src="https://user-images.githubusercontent.com/13903378/31420732-06b2ef08-ae8f-11e7-9fa0-08805cebba3e.png">

#### With change
<img width="1015" alt="screen shot 2017-10-11 at 2 16 38 pm" src="https://user-images.githubusercontent.com/13903378/31420717-f109e012-ae8e-11e7-9c4d-df3b27d12060.png">

## Migration Guide
The default behaviour of columns will now be remain equal widths even when content would attempt to push one column wider.
To enable the previous behaviour use the flexible prop.
``` javascript
<Columns flexible={true}>
 ...
</Columns>
```

## Commit comment for review
fix(Columns): Remove implied min-width for Columns

Columns component will no-longer flex based on content width

BREAKING CHANGE: Columns no-longer flexible by default. Use `flexible` prop to enable previous behaviour.