### PR TITLE
ci(travis): Disable Travis CI node modules cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
-cache:
-  directories:
-    - node_modules
 notifications:
   email: false
 before_script:


### PR DESCRIPTION
Travis CI seems to hang on to stale packages due to our semver ranges.

This is an attempt to fix an issue with minified component code snippets on the docs site, which I can't reproduce locally. If it doesn't solve it, I'll close this PR.