### PR TITLE
docs(site): Add Card and CardGroup demos

### DIFF
--- a/docs/src/demoSpecs.js
+++ b/docs/src/demoSpecs.js
@@ -1,4 +1,6 @@
 import Text from 'seek-style-guide/react/Text/Text.demo';
+import Card from 'seek-style-guide/react/Card/Card.demo';
+import CardGroup from 'seek-style-guide/react/CardGroup/CardGroup.demo';
 import Button from 'seek-style-guide/react/Button/Button.demo';
 import ButtonGroup from 'seek-style-guide/react/ButtonGroup/ButtonGroup.demo';
 import TextField from 'seek-style-guide/react/TextField/TextField.demo';
@@ -16,6 +18,8 @@ import Logo from 'seek-style-guide/react/Logo/Logo.demo';
 
 export default [
   Text,
+  Card,
+  CardGroup,
   Button,
   ButtonGroup,
   TextField,

--- a/react/Card/Card.demo.js
+++ b/react/Card/Card.demo.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Card, Text, PageBlock, Section } from 'seek-style-guide/react';
+
+const CardContainer = ({ component: DemoComponent, componentProps }) => (
+  <PageBlock>
+    <Section>
+      <DemoComponent {...componentProps} />
+    </Section>
+  </PageBlock>
+);
+CardContainer.propTypes = {
+  component: PropTypes.any,
+  componentProps: PropTypes.object.isRequired
+};
+
+export default {
+  route: '/card',
+  title: 'Card',
+  component: Card,
+  container: CardContainer,
+  block: true,
+  initialProps: {
+    children: (
+      <Section>
+        <Text heading>Living Style Guide</Text>
+        <Text>This is some text inside a card.</Text>
+      </Section>
+    )
+  },
+  options: [
+    {
+      label: 'States',
+      type: 'checkbox',
+      states: [
+        {
+          label: 'Transparent',
+          transformProps: props => ({
+            ...props,
+            transparent: true
+          })
+        }
+      ]
+    }
+  ]
+};

--- a/react/CardGroup/CardGroup.demo.js
+++ b/react/CardGroup/CardGroup.demo.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CardGroup, Card, Text, PageBlock, Section } from 'seek-style-guide/react';
+
+const CardGroupContainer = ({ component: DemoComponent, componentProps }) => (
+  <PageBlock>
+    <Section>
+      <DemoComponent {...componentProps} />
+    </Section>
+  </PageBlock>
+);
+CardGroupContainer.propTypes = {
+  component: PropTypes.any,
+  componentProps: PropTypes.object.isRequired
+};
+
+export default {
+  route: '/card-group',
+  title: 'Card Group',
+  component: CardGroup,
+  container: CardGroupContainer,
+  block: true,
+  initialProps: {
+    children: [
+      <Card key="1">
+        <Section>
+          <Text heading>Living Style Guide</Text>
+        </Section>
+      </Card>,
+      <Card key="2">
+        <Section>
+          <Text heading>Living Style Guide</Text>
+        </Section>
+      </Card>,
+      <Card key="3">
+        <Section>
+          <Text heading>Living Style Guide</Text>
+        </Section>
+      </Card>
+    ]
+  },
+  options: []
+};


### PR DESCRIPTION
These were a glaring omission, highlighted by a conversation I had today. We'll add the rest of the outstanding demos soon, but this is an important start.

Side note—the component list in the main navigation has finally crossed the line and become too long. I'll break it up into more digestible sections, but I'll leave this for a later PR.