### PR TITLE
docs(site): Add AsidedLayout and Columns demos

### DIFF
--- a/react/AsidedLayout/AsidedLayout.demo.js
+++ b/react/AsidedLayout/AsidedLayout.demo.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { AsidedLayout, PageBlock, Card, Section, Text } from 'seek-style-guide/react';
+
+const AsidedLayoutContainer = ({ component: DemoComponent, componentProps }) => (
+  <PageBlock>
+    <DemoComponent {...componentProps} />
+  </PageBlock>
+);
+AsidedLayoutContainer.propTypes = {
+  component: PropTypes.any,
+  componentProps: PropTypes.object.isRequired
+};
+
+export default {
+  route: '/asided-layout',
+  title: 'Asided Layout',
+  component: AsidedLayout,
+  container: AsidedLayoutContainer,
+  block: true,
+  initialProps: {
+    size: '30%',
+    renderAside: () => (
+      <Card transparent>
+        <Section>
+          <Text heading>Aside</Text>
+          <Text>This card is provided via the 'renderAside' prop.</Text>
+        </Section>
+      </Card>
+    ),
+    children: [
+      <Card key="1">
+        <Section>
+          <Text heading>Main Content</Text>
+          <Text>This card is provided as children.</Text>
+        </Section>
+      </Card>,
+      <Card key="2">
+        <Section>
+          <Text heading>Another Card</Text>
+          <Text>Here's another card for good measure.</Text>
+        </Section>
+      </Card>
+    ]
+  },
+  options: [
+    {
+      label: 'Order',
+      type: 'checkbox',
+      states: [
+        {
+          label: 'Reverse on mobile',
+          transformProps: props => ({
+            ...props,
+            reverse: true
+          })
+        }
+      ]
+    },
+    {
+      label: 'Size',
+      type: 'radio',
+      states: [
+        {
+          label: '30%',
+          transformProps: props => ({
+            ...props,
+            size: '30%'
+          })
+        },
+        {
+          label: '40%',
+          transformProps: props => ({
+            ...props,
+            size: '40%'
+          })
+        },
+        {
+          label: '200px',
+          transformProps: props => ({
+            ...props,
+            size: '200px'
+          })
+        }
+      ]
+    }
+  ]
+};

--- a/react/Columns/Columns.demo.js
+++ b/react/Columns/Columns.demo.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Columns, PageBlock, Card, Section, Text } from 'seek-style-guide/react';
+
+const ColumnsContainer = ({ component: DemoComponent, componentProps }) => (
+  <PageBlock>
+    <DemoComponent {...componentProps} />
+  </PageBlock>
+);
+ColumnsContainer.propTypes = {
+  component: PropTypes.any,
+  componentProps: PropTypes.object.isRequired
+};
+
+const makeColumns = count => [...new Array(count)].map((x, i) => (
+  <Card key={i}>
+    <Section>
+      <Text heading>Column {i + 1}</Text>
+      <Text>This card is currently acting as a column.</Text>
+    </Section>
+  </Card>
+));
+
+export default {
+  route: '/columns',
+  title: 'Columns',
+  component: Columns,
+  container: ColumnsContainer,
+  block: true,
+  initialProps: {
+    children: makeColumns(2)
+  },
+  options: [
+    {
+      label: 'Number of Columns',
+      type: 'radio',
+      states: [
+        {
+          label: 'Two Columns',
+          transformProps: props => props
+        },
+        {
+          label: 'Three Columns',
+          transformProps: props => ({
+            ...props,
+            children: makeColumns(3)
+          })
+        },
+        {
+          label: 'Four Columns',
+          transformProps: props => ({
+            ...props,
+            children: makeColumns(4)
+          })
+        }
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
Just adding a couple of glaring omissions from our component list.

Thanks to the previous change where we removed the need to maintain a centralised component demo list, all we have to do in this PR is add a couple of demo files! 🙌 