### PR TITLE
fix(standalone): Update seek-style-guide-webpack package so css prefix works

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "react-test-renderer": "^16.0.0",
     "rewrite-files": "^1.0.1",
     "rimraf": "^2.6.2",
-    "seek-style-guide-webpack": "^2.1.0",
+    "seek-style-guide-webpack": "^2.1.1",
     "semantic-release": "^8.1.2",
     "sinon": "^4.0.1",
     "sinon-chai": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "react-test-renderer": "^16.0.0",
     "rewrite-files": "^1.0.1",
     "rimraf": "^2.6.2",
-    "seek-style-guide-webpack": "^2.0.1",
+    "seek-style-guide-webpack": "^2.1.0",
     "semantic-release": "^8.1.2",
     "sinon": "^4.0.1",
     "sinon-chai": "^2.14.0",


### PR DESCRIPTION
Standalone header & footer has been broken since https://github.com/seek-oss/seek-style-guide/releases/tag/v31.0.0 as `seek-style-guide-webpack` didn't support cssSelectorPrefix until https://github.com/seek-oss/seek-style-guide-webpack/releases/tag/v2.1.0. This PR bumps the version of seek-style-guide-webpack to 2.1.0.