### PR TITLE
feat(MonthPicker): Make year options configurable

### DIFF
--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
@@ -4,23 +4,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import classnames from 'classnames';
-import range from 'lodash/range';
 
+import getYearOptions from './getYearOptions';
 import Dropdown from '../../Dropdown/Dropdown';
-
-const getYearOptions = () => {
-  const maxYear = new Date().getFullYear();
-  const minYear = maxYear - 100;
-
-  return range(maxYear, minYear - 1).map(value => {
-    const stringValue = String(value);
-
-    return {
-      value: stringValue,
-      label: stringValue
-    };
-  });
-};
 
 const months = [
   { value: '1', label: 'Jan' },
@@ -36,7 +22,6 @@ const months = [
   { value: '11', label: 'Nov' },
   { value: '12', label: 'Dec' }
 ];
-const years = getYearOptions();
 
 export default class CustomMonthPicker extends Component {
   static displayName = 'CustomMonthPicker';
@@ -50,7 +35,10 @@ export default class CustomMonthPicker extends Component {
     }),
     valid: PropTypes.bool,
     className: PropTypes.string,
-    id: PropTypes.string
+    id: PropTypes.string,
+    minYear: PropTypes.number.isRequired,
+    maxYear: PropTypes.number.isRequired,
+    ascendingYears: PropTypes.bool.isRequired
   };
 
   static defaultProps = {
@@ -58,7 +46,7 @@ export default class CustomMonthPicker extends Component {
     className: ''
   };
 
-  constructor() {
+  constructor({ minYear, maxYear, ascendingYears }) {
     super();
 
     this.handleMonthChange = this.handleMonthChange.bind(this);
@@ -67,6 +55,22 @@ export default class CustomMonthPicker extends Component {
     this.storeYearReference = this.storeYearReference.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
     this.blurIfNotFocussed = this.blurIfNotFocussed.bind(this);
+
+    this.yearOptions = getYearOptions(minYear, maxYear, ascendingYears);
+  }
+
+  componentWillUpdate(newProps) {
+    if (
+      ['minYear', 'maxYear', 'ascendingYears'].filter(
+        key => newProps[key] !== this.props[key]
+      )
+    ) {
+      this.yearOptions = getYearOptions(
+        newProps.minYear,
+        newProps.maxYear,
+        newProps.ascendingYears
+      );
+    }
   }
 
   storeMonthReference(input) {
@@ -156,7 +160,7 @@ export default class CustomMonthPicker extends Component {
           }}
         />
         <Dropdown
-          options={years}
+          options={this.yearOptions}
           className={styles.dropdown}
           valid={valid}
           message={false}

--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.test.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.test.js
@@ -41,8 +41,12 @@ describe('CustomMonthPicker', () => {
   function renderToDom(jsx) {
     element = jsx;
     monthPicker = renderIntoDocument(element);
-    monthDropdown = scryRenderedDOMComponentsWithClass(monthPicker, 'dropdownInput')[0] || null;
-    yearDropdown = scryRenderedDOMComponentsWithClass(monthPicker, 'dropdownInput')[1] || null;
+    monthDropdown =
+      scryRenderedDOMComponentsWithClass(monthPicker, 'dropdownInput')[0] ||
+      null;
+    yearDropdown =
+      scryRenderedDOMComponentsWithClass(monthPicker, 'dropdownInput')[1] ||
+      null;
   }
 
   it('should have a displayName', () => {
@@ -65,7 +69,14 @@ describe('CustomMonthPicker', () => {
     const onChange = newValue => {
       value = newValue;
     };
-    renderToDom(<CustomMonthPicker onChange={onChange} value={{ month: 6, year: 2010 }} />);
+    renderToDom(
+      <CustomMonthPicker
+        minYear={2000}
+        maxYear={2010}
+        onChange={onChange}
+        value={{ month: 6, year: 2010 }}
+      />
+    );
     monthDropdown.value = '11';
     Simulate.change(monthDropdown);
     expect(value).to.deep.equal({
@@ -78,7 +89,14 @@ describe('CustomMonthPicker', () => {
     const onChange = newValue => {
       value = newValue;
     };
-    renderToDom(<CustomMonthPicker onChange={onChange} value={{ month: 6, year: 2010 }} />);
+    renderToDom(
+      <CustomMonthPicker
+        minYear={1990}
+        maxYear={2010}
+        onChange={onChange}
+        value={{ month: 6, year: 2010 }}
+      />
+    );
     yearDropdown.value = '1999';
     Simulate.change(yearDropdown);
     expect(value).to.deep.equal({

--- a/react/MonthPicker/CustomMonthPicker/getYearOptions.js
+++ b/react/MonthPicker/CustomMonthPicker/getYearOptions.js
@@ -1,0 +1,15 @@
+import range from 'lodash/range';
+
+export default (min, max, ascending) => {
+  const start = ascending ? min : max;
+  const end = ascending ? max + 1 : min - 1;
+
+  return range(start, end).map(value => {
+    const stringValue = String(value);
+
+    return {
+      value: stringValue,
+      label: stringValue
+    };
+  });
+};

--- a/react/MonthPicker/CustomMonthPicker/getYearOptions.test.js
+++ b/react/MonthPicker/CustomMonthPicker/getYearOptions.test.js
@@ -1,0 +1,57 @@
+import getYearOptions from './getYearOptions';
+
+describe('getYearOptions', () => {
+  it('should return years in descending order', () => {
+    expect(getYearOptions(2000, 2005, false)).toEqual([
+      {
+        value: '2005',
+        label: '2005'
+      },
+      {
+        value: '2004',
+        label: '2004'
+      },
+      {
+        value: '2003',
+        label: '2003'
+      },
+      {
+        value: '2002',
+        label: '2002'
+      },
+      {
+        value: '2001',
+        label: '2001'
+      },
+      {
+        value: '2000',
+        label: '2000'
+      }
+    ]);
+  });
+
+  it('should return years in ascending order', () => {
+    expect(getYearOptions(2021, 2025, true)).toEqual([
+      {
+        value: '2021',
+        label: '2021'
+      },
+      {
+        value: '2022',
+        label: '2022'
+      },
+      {
+        value: '2023',
+        label: '2023'
+      },
+      {
+        value: '2024',
+        label: '2024'
+      },
+      {
+        value: '2025',
+        label: '2025'
+      }
+    ]);
+  });
+});

--- a/react/MonthPicker/MonthPicker.demo.js
+++ b/react/MonthPicker/MonthPicker.demo.js
@@ -47,10 +47,7 @@ export default {
   initialProps: {
     id: 'startMonth',
     label: 'Start Month',
-    message: '',
-    // Documentation only:
-    onChange: () => {},
-    value: { month: 11, year: 1955 }
+    message: ''
   },
   options: [
     {
@@ -62,6 +59,61 @@ export default {
           transformProps: props => ({
             ...props,
             native: true
+          })
+        },
+        {
+          label: 'Ascending years',
+          transformProps: props => ({
+            ...props,
+            ascendingYears: true
+          })
+        }
+      ]
+    },
+    {
+      label: 'Min year',
+      type: 'radio',
+      states: [
+        {
+          label: 'Min year',
+          transformProps: ({ minYear, ...restProps }) => restProps
+        },
+        {
+          label: '1984',
+          transformProps: props => ({
+            ...props,
+            minYear: 1984
+          })
+        },
+        {
+          label: '2000',
+          transformProps: props => ({
+            ...props,
+            minYear: 2000
+          })
+        }
+      ]
+    },
+    {
+      label: 'Max year',
+      type: 'radio',
+      states: [
+        {
+          label: 'Max year',
+          transformProps: ({ maxYear, ...restProps }) => restProps
+        },
+        {
+          label: '2001',
+          transformProps: props => ({
+            ...props,
+            maxYear: 2001
+          })
+        },
+        {
+          label: '2048',
+          transformProps: props => ({
+            ...props,
+            maxYear: 2048
           })
         }
       ]

--- a/react/MonthPicker/MonthPicker.js
+++ b/react/MonthPicker/MonthPicker.js
@@ -11,6 +11,8 @@ import NativeMonthPicker from './NativeMonthPicker/NativeMonthPicker';
 import FieldMessage from '../private/FieldMessage/FieldMessage';
 import FieldLabel from '../private/FieldLabel/FieldLabel';
 
+const currYear = new Date().getFullYear();
+
 export default class MonthPicker extends Component {
   static displayName = 'MonthPicker';
 
@@ -20,7 +22,9 @@ export default class MonthPicker extends Component {
       const { id } = props;
 
       if (typeof id !== 'string') {
-        return new Error(`Invalid prop \`id\` of type \`${typeof id}\` supplied to \`${componentName}\`, expected \`string\`.`);
+        return new Error(
+          `Invalid prop \`id\` of type \`${typeof id}\` supplied to \`${componentName}\`, expected \`string\`.`
+        );
       }
     },
     className: PropTypes.string,
@@ -32,13 +36,19 @@ export default class MonthPicker extends Component {
     }),
     native: PropTypes.bool,
     onChange: PropTypes.func,
-    onBlur: PropTypes.func
+    onBlur: PropTypes.func,
+    minYear: PropTypes.number,
+    maxYear: PropTypes.number,
+    ascendingYears: PropTypes.bool
   };
 
   static defaultProps = {
     id: '',
     className: '',
-    native: false
+    native: false,
+    maxYear: currYear,
+    minYear: currYear - 100,
+    ascendingYears: false
   };
 
   constructor() {
@@ -48,20 +58,33 @@ export default class MonthPicker extends Component {
   }
 
   renderInput() {
-    const { id, value, onChange, native, valid, onBlur } = this.props;
+    const {
+      id,
+      value,
+      onChange,
+      native,
+      valid,
+      onBlur,
+      minYear,
+      maxYear,
+      ascendingYears
+    } = this.props;
     const monthPickerProps = {
       className: styles.input,
       ...(id ? { id } : {}),
       value,
       onChange,
       onBlur,
-      valid
+      valid,
+      minYear,
+      maxYear,
+      ascendingYears
     };
 
-    return (
-      native ?
-        <NativeMonthPicker {...monthPickerProps} /> :
-        <CustomMonthPicker {...monthPickerProps} />
+    return native ? (
+      <NativeMonthPicker {...monthPickerProps} />
+    ) : (
+      <CustomMonthPicker {...monthPickerProps} />
     );
   }
 
@@ -72,14 +95,31 @@ export default class MonthPicker extends Component {
       [className]: className
     });
 
-    // eslint-disable-next-line react/prop-types
-    const { id, label, labelProps, secondaryLabel, tertiaryLabel, invalid, help, helpProps, valid, message, messageProps } = this.props;
+    /* eslint-disable react/prop-types */
+    const {
+      id,
+      label,
+      labelProps,
+      secondaryLabel,
+      tertiaryLabel,
+      invalid,
+      help,
+      helpProps,
+      valid,
+      message,
+      messageProps
+    } = this.props;
+    /* eslint-enable react/prop-types */
 
     return (
       <div className={classNames}>
-        <FieldLabel {...{ id, label, labelProps, secondaryLabel, tertiaryLabel }} />
+        <FieldLabel
+          {...{ id, label, labelProps, secondaryLabel, tertiaryLabel }}
+        />
         {this.renderInput()}
-        <FieldMessage {...{ invalid, help, helpProps, valid, message, messageProps }} />
+        <FieldMessage
+          {...{ invalid, help, helpProps, valid, message, messageProps }}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Add min & max year options to MonthPicker. Also, add sort order options (ascending/descending).

Currently, the `MonthPicker` has a static list of year options which is the current year going back 100 years. This PR makes the years configurable including which direction they are sorted. There are no breaking changes as the default props invoke the old behaviour. 

**Warning**: This change only affects the `CustomMonthPicker` which utilizes browser dropdowns. The `NativeMonthPicker` behaviour remains unchanged. Do not rely on these props for validation purposes as they do not ensure the data returned from the component in native mode. 

EXAMPLE USAGE:

```js
<MonthPicker
  id="startMonth"
  label="Start Month"
  maxYear={2048}
  minYear={2000}
  ascendingYears={true} // default is false
/>
```
