### PR TITLE
fix(Footer): Add Spark Hire link to Partner Services

### DIFF
--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -550,6 +550,17 @@ exports[`Footer: should render when authenticated 1`] = `
                       Ximble
                     </a>
                   </li>
+                  <li
+                    class=""
+                  >
+                    <a
+                      class="link"
+                      data-analytics="toolbar:sparkhire"
+                      href="https://anz.sparkhire.com/"
+                    >
+                      Spark Hire
+                    </a>
+                  </li>
                 </ul>
               </li>
             </ul>
@@ -1337,6 +1348,17 @@ exports[`Footer: should render when authentication is pending 1`] = `
                       href="https://www.ximble.com"
                     >
                       Ximble
+                    </a>
+                  </li>
+                  <li
+                    class=""
+                  >
+                    <a
+                      class="link"
+                      data-analytics="toolbar:sparkhire"
+                      href="https://anz.sparkhire.com/"
+                    >
+                      Spark Hire
                     </a>
                   </li>
                 </ul>
@@ -2128,6 +2150,17 @@ exports[`Footer: should render when unauthenticated 1`] = `
                       Ximble
                     </a>
                   </li>
+                  <li
+                    class=""
+                  >
+                    <a
+                      class="link"
+                      data-analytics="toolbar:sparkhire"
+                      href="https://anz.sparkhire.com/"
+                    >
+                      Spark Hire
+                    </a>
+                  </li>
                 </ul>
               </li>
             </ul>
@@ -2915,6 +2948,17 @@ exports[`Footer: should render with locale of AU 1`] = `
                       href="https://www.ximble.com"
                     >
                       Ximble
+                    </a>
+                  </li>
+                  <li
+                    class=""
+                  >
+                    <a
+                      class="link"
+                      data-analytics="toolbar:sparkhire"
+                      href="https://anz.sparkhire.com/"
+                    >
+                      Spark Hire
                     </a>
                   </li>
                 </ul>

--- a/react/Footer/data/company.js
+++ b/react/Footer/data/company.js
@@ -126,5 +126,10 @@ export const services = [
     name: 'Ximble',
     href: 'https://www.ximble.com',
     analytics: 'toolbar:ximble'
+  },
+  {
+    name: 'Spark Hire',
+    href: 'https://anz.sparkhire.com/',
+    analytics: 'toolbar:sparkhire'
   }
 ];


### PR DESCRIPTION
New partner for SEEK Video Screen, Spark Hire, to be added into the Partner Services dropdown on our footer.
