### PR TITLE
feat(Theme): Added new color sk-orange

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The following colors are provided:
 @sk-green-light
 @sk-yellow
 @sk-yellow-light
+@sk-orange
 @sk-footer
 @sk-background
 @sk-yellow

--- a/theme/palette/elements.less
+++ b/theme/palette/elements.less
@@ -6,6 +6,7 @@
 @sk-green-light: #5bc252;
 @sk-yellow: #ffc600;
 @sk-yellow-light: #fffce3;
+@sk-orange: #f57c00;
 @sk-footer: @sk-mid-gray-light;
 @sk-background: @sk-gray-light;
 @sk-form-accent: @sk-focus;


### PR DESCRIPTION
Adds (#f57c00) @sk-orange variable to the pallette color.

@sk-orange may become a replacement for current uses of @sk-yellow.
@sk-orange provides more contrast for smaller icons on light backgrounds than @sk-yellow.