### PR TITLE
 feat(Button): Add ghost button styles

### DIFF
--- a/react/Button/Button.demo.js
+++ b/react/Button/Button.demo.js
@@ -50,6 +50,13 @@ export default {
             ...props,
             fullWidth: true
           })
+        },
+        {
+          label: 'Ghost',
+          transformProps: props => ({
+            ...props,
+            ghost: true
+          })
         }
       ]
     },
@@ -90,6 +97,13 @@ export default {
           transformProps: props => ({
             ...props,
             color: 'pink'
+          })
+        },
+        {
+          label: 'White',
+          transformProps: props => ({
+            ...props,
+            color: 'white'
           })
         },
         {

--- a/react/Button/Button.js
+++ b/react/Button/Button.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import classnames from 'classnames';
-import { capitalize } from 'lodash';
+import capitalize from 'lodash/capitalize';
 
 export default class Button extends Component {
   static displayName = 'Button';

--- a/react/Button/Button.js
+++ b/react/Button/Button.js
@@ -11,7 +11,7 @@ export default class Button extends Component {
 
   static propTypes = {
     color: PropTypes.oneOf([
-      'pink', 'blue', 'gray', 'transparent'
+      'pink', 'blue', 'gray', 'transparent', 'white'
     ]).isRequired,
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.node),

--- a/react/Button/Button.js
+++ b/react/Button/Button.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import classnames from 'classnames';
+import { capitalize } from 'lodash';
 
 export default class Button extends Component {
   static displayName = 'Button';
@@ -21,40 +22,34 @@ export default class Button extends Component {
       PropTypes.func,
       PropTypes.string
     ]),
+    ghost: PropTypes.bool,
     loading: PropTypes.bool,
     fullWidth: PropTypes.bool
   };
 
   static defaultProps = {
     className: '',
+    ghost: false,
     loading: false,
     fullWidth: false,
     component: 'button'
   };
 
-  constructor() {
-    super();
-
-    this.storeButtonReference = this.storeButtonReference.bind(this);
-  }
-
-  storeButtonReference(button) {
+  storeButtonReference = button => {
     if (button !== null) {
       this.button = button;
     }
   }
 
   render() {
-    const { color, className, loading, fullWidth, children, component, ...restProps } = this.props;
+    const { color, ghost, className, loading, fullWidth, children, component, ...restProps } = this.props;
 
     const combinedProps = {
       className: classnames(styles.root, className, {
         [styles.loading]: loading,
         [styles.fullWidth]: fullWidth,
-        [styles.root_isPink]: color === 'pink',
-        [styles.root_isBlue]: color === 'blue',
-        [styles.root_isGray]: color === 'gray',
-        [styles.root_isTransparent]: color === 'transparent'
+        [styles.root_isGhost]: ghost,
+        [styles[`root_is${capitalize(color)}`]]: color
       }),
       disabled: loading,
       ref: this.storeButtonReference,

--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -42,7 +42,7 @@
 
   .hoverState({
     color: @textHoverColor;
-  });  
+  });
 }
 
 .root {
@@ -88,7 +88,8 @@
   .buttonColor(@sk-black, @sk-mid-gray-light);
 }
 
-.root_isGhost, .root_isTransparent {
+.root_isGhost,
+.root_isTransparent {
   background-color: transparent;
   box-shadow: none;
 }

--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -92,6 +92,7 @@
 .root_isTransparent {
   background-color: transparent;
   box-shadow: none;
+  line-height: 0;
 }
 
 .root_isGhost {

--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -36,12 +36,16 @@
   });
 }
 
-.ghostColor(@color, @textHoverColor) {
+.ghostColor(@color) {
   border-color: @color;
   color: @color;
 
   .hoverState({
-    color: @textHoverColor;
+    background-color: lighten(@color, 56%);
+  });
+
+  .activeState({
+    background-color: lighten(@color, 51%);
   });
 }
 
@@ -76,10 +80,6 @@
   .buttonColor(@sk-white, @sk-pink);
 }
 
-.root_isWhite {
-  .buttonColor(@sk-white, @sk-white);
-}
-
 .root_isBlue {
   .buttonColor(@sk-white, @sk-highlight);
 }
@@ -92,23 +92,25 @@
 .root_isTransparent {
   background-color: transparent;
   box-shadow: none;
-  line-height: 0;
 }
 
 .root_isGhost {
   border: 2px solid;
-}
-
-.root_isPink.root_isGhost {
-  .ghostColor(@sk-pink, @sk-white)
+  font-weight: @sk-bold;
+  line-height: 0;
 }
 
 .root_isBlue.root_isGhost {
-  .ghostColor(@sk-highlight, @sk-white)
+  .ghostColor(@sk-link)
 }
 
 .root_isWhite.root_isGhost {
   border-color: @sk-white;
+  color: @sk-white;
+
+  .hoverState({
+    background-color: rgba(255, 255, 255, 0.2);
+  });
 }
 
 .root_isTransparent {

--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -106,7 +106,7 @@
 .root_isGhost {
   border: 2px solid;
   font-weight: @sk-bold;
-  line-height: 0;
+  line-height: normal;
 }
 
 .root_isBlue.root_isGhost {

--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -37,6 +37,11 @@
 }
 
 .ghostColor(@color) {
+
+  .activeBackground() {
+    background-color: lighten(@color, 51%);
+  }
+
   border-color: @color;
   color: @color;
 
@@ -45,7 +50,11 @@
   });
 
   .activeState({
-    background-color: lighten(@color, 51%);
+    .activeBackground;
+  });
+
+  .focusState({
+    .activeBackground;
   });
 }
 
@@ -108,8 +117,20 @@
   border-color: @sk-white;
   color: @sk-white;
 
-  .hoverState({
+  .activeBackground() {
     background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .activeState({
+    .activeBackground;
+  });
+
+  .hoverState({
+    .activeBackground;
+  });
+
+  .focusState({
+    .activeBackground;
   });
 }
 

--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -36,6 +36,15 @@
   });
 }
 
+.ghostColor(@color, @textHoverColor) {
+  border-color: @color;
+  color: @color;
+
+  .hoverState({
+    color: @textHoverColor;
+  });  
+}
+
 .root {
   .touchableText();
   display: inline-block;
@@ -67,6 +76,10 @@
   .buttonColor(@sk-white, @sk-pink);
 }
 
+.root_isWhite {
+  .buttonColor(@sk-white, @sk-white);
+}
+
 .root_isBlue {
   .buttonColor(@sk-white, @sk-highlight);
 }
@@ -75,10 +88,29 @@
   .buttonColor(@sk-black, @sk-mid-gray-light);
 }
 
-.root_isTransparent {
-  color: @sk-link;
+.root_isGhost, .root_isTransparent {
   background-color: transparent;
   box-shadow: none;
+}
+
+.root_isGhost {
+  border: 2px solid;
+}
+
+.root_isPink.root_isGhost {
+  .ghostColor(@sk-pink, @sk-white)
+}
+
+.root_isBlue.root_isGhost {
+  .ghostColor(@sk-highlight, @sk-white)
+}
+
+.root_isWhite.root_isGhost {
+  border-color: @sk-white;
+}
+
+.root_isTransparent {
+  color: @sk-link;
   padding-left: 0;
   padding-right: 0;
   .hoverState({

--- a/react/Button/Button.test.js
+++ b/react/Button/Button.test.js
@@ -23,6 +23,11 @@ describe('Button:', () => {
       const wrapper = shallow(<Button color="transparent">SEEK</Button>);
       expect(wrapper).toMatchSnapshot();
     });
+
+    it('should render white ghost button', () => {
+      const wrapper = shallow(<Button color="white" ghost>SEEK</Button>);
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
   it('should render with node', () => {

--- a/react/Button/__snapshots__/Button.test.js.snap
+++ b/react/Button/__snapshots__/Button.test.js.snap
@@ -36,6 +36,15 @@ exports[`Button: color variants: should render transparent button 1`] = `
 </button>
 `;
 
+exports[`Button: color variants: should render white ghost button 1`] = `
+<button
+  className="root root_isGhost root_isWhite"
+  disabled={false}
+>
+  SEEK
+</button>
+`;
+
 exports[`Button: should render as an anchor with href="https://www.seek.com.au" 1`] = `
 <a
   className="root root_isPink"

--- a/react/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/react/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -9,6 +9,7 @@ exports[`ButtonGroup: should combine className when passed in 1`] = `
     color="blue"
     component="button"
     fullWidth={false}
+    ghost={false}
     loading={false}
   >
     <h5>
@@ -27,6 +28,7 @@ exports[`ButtonGroup: should render a button group with node 1`] = `
     color="blue"
     component="button"
     fullWidth={false}
+    ghost={false}
     loading={false}
   >
     <h5>


### PR DESCRIPTION
This PR: 
- adds a non-required `ghost` prop to the Button
- adds styles to ghost blue buttons
- adds style to ghost white button

Example:

blue
<img width="159" alt="screen shot 2017-11-23 at 8 02 19 pm" src="https://user-images.githubusercontent.com/15971854/33165194-fa72348e-d089-11e7-9713-0b81d7b17ba0.png"><img width="159" alt="screen shot 2017-11-23 at 8 02 35 pm" src="https://user-images.githubusercontent.com/15971854/33165189-fa05e0cc-d089-11e7-86c2-f6348ee2273a.png"><img width="154" alt="screen shot 2017-11-23 at 8 02 44 pm" src="https://user-images.githubusercontent.com/15971854/33165186-f99833b0-d089-11e7-98cf-a06c4c8ee7f6.png">

transparrent white
<img width="175" alt="screen shot 2017-11-23 at 8 04 49 pm" src="https://user-images.githubusercontent.com/15971854/33165195-fac46556-d089-11e7-97e5-300a332d6fd1.png"><img width="164" alt="screen shot 2017-11-23 at 8 04 56 pm" src="https://user-images.githubusercontent.com/15971854/33165191-fa3db006-d089-11e7-864a-33540c305d32.png"><img width="157" alt="screen shot 2017-11-23 at 8 05 04 pm" src="https://user-images.githubusercontent.com/15971854/33165187-f9cfe36e-d089-11e7-9919-ca1a32d2f8c4.png">

Example usage:
```
<Button color="white" ghost {...restProps} />
```