### PR TITLE
feat(Button): Add ghost buttons

### DIFF
--- a/react/Button/Button.js
+++ b/react/Button/Button.js
@@ -48,7 +48,7 @@ export default class Button extends Component {
       className: classnames(styles.root, className, {
         [styles.loading]: loading,
         [styles.fullWidth]: fullWidth,
-        [styles.root_isGhost]: ghost,
+        [styles.root_isGhost]: ghost && color !== 'transparent',
         [styles[`root_is${capitalize(color)}`]]: color
       }),
       disabled: loading,

--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -138,12 +138,15 @@
   color: @sk-link;
   padding-left: 0;
   padding-right: 0;
+
   .hoverState({
     text-decoration: underline;
   });
+
   .activeState({
     transform: none;
   });
+
   @media @desktop {
     .touchableText(@standard-type-scale);
   }

--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -104,11 +104,11 @@
 }
 
 .root_isGhost {
-  @border-thickness: 2px;
+  @border-width: 2px;
 
-  border: @border-thickness solid;
+  border: @border-width solid;
   font-weight: @sk-bold;
-  line-height: @touchableTextHeight - 2 * @border-thickness;
+  line-height: @touchableTextHeight - (@border-width * 2);
 }
 
 .root_isBlue.root_isGhost {

--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -104,9 +104,11 @@
 }
 
 .root_isGhost {
-  border: 2px solid;
+  @border-thickness: 2px;
+
+  border: @border-thickness solid;
   font-weight: @sk-bold;
-  line-height: normal;
+  line-height: @touchableTextHeight - 2 * @border-thickness;
 }
 
 .root_isBlue.root_isGhost {

--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -146,7 +146,6 @@
   .activeState({
     transform: none;
   });
-
   @media @desktop {
     .touchableText(@standard-type-scale);
   }


### PR DESCRIPTION
This PR:
- adds a non-required `ghost` prop to the Button
- adds ghost blue button styles
- adds ghost white button style
- if both transparent and ghost attributes applied, ghost gets ignored
- bug fix for button line height
- triggers unreleased changes from the previous PR for ghost buttons #377 

Example usage:
```
<Button color="white" ghost {...restProps} />
<Button color="blue" ghost {...restProps} />
```