### PR TITLE
chore(sketch): Export colour palette as Sketch symbol

### DIFF
--- a/docs/src/components/SketchExports/SketchExports.js
+++ b/docs/src/components/SketchExports/SketchExports.js
@@ -112,15 +112,17 @@ export default class SketchExports extends Component {
           </Section>
         </PageBlock>
         <PageBlock style={{ background: 'white' }}>
-          <Section>
-            <div className={styles.colors}>
-              {
-                map(colors, (color, name) => (
-                  <SketchColor key={name} name={name} value={color} />
-                ))
-              }
-            </div>
-          </Section>
+          <SketchSymbol name="colours">
+            <Section>
+              <div className={styles.colors}>
+                {
+                  map(colors, (color, name) => (
+                    <SketchColor key={name} name={name} value={color} />
+                  ))
+                }
+              </div>
+            </Section>
+          </SketchSymbol>
         </PageBlock>
         <PageBlock>
           <Section header>


### PR DESCRIPTION
Since Sketch libraries don't yet expose document colours, I figured it would be worthwhile to use the same workaround that we used for text styles.

In this PR, we're now exporting a `colours` symbol with the full colour palette available. This way, designers are able to drop the palette into their document and use the eyedropper tool to select the colours they need.

It's available in the library like any other symbol:

<img width="352" alt="screen shot 2018-01-02 at 5 00 44 pm" src="https://user-images.githubusercontent.com/696693/34475271-946d25c6-efde-11e7-87c3-4c6a9daf3631.png">

Once placed in the Sketch document, it looks like this:

<img width="1174" alt="screen shot 2018-01-02 at 4 59 35 pm" src="https://user-images.githubusercontent.com/696693/34475256-5ff2198c-efde-11e7-9722-5caa348a9e28.png">
