### PR TITLE
chore(commitmsg): standardise on conventional commit message format

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -12,7 +12,7 @@ groups:
     approve_by_comment:
       enabled: false
     always_rejected:
-      title_regex: '^((?!: ).)*$'
+      title_regex: '^(?!(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+\))?\:\s(\S+)).*$'
       explanation: 'Invalid title. Please read the contribution guide: https://github.com/seek-oss/seek-style-guide/blob/master/CONTRIBUTING.md'
     reset_on_push:
       enabled: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ $ git add .
 
 Before continuing, consider the scope of your changes according to [semantic versioning](http://semver.org), noting whether this is a breaking change, a feature release or a patch.
 
-New versions are published automatically from [Travis CI](https://travis-ci.org) using [semantic-release](https://github.com/semantic-release/semantic-release). In order to automatically increment version numbers correctly, commit messages must follow our [semantic commit message convention](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines). If your commit includes a breaking change, be sure to prefix your commit body with `BREAKING CHANGE: `. To make this process easier, we have a commit script (powered by [commitizen](https://github.com/commitizen/cz-cli)) to help guide you through the commit process:
+New versions are published automatically from [Travis CI](https://travis-ci.org) using [semantic-release](https://github.com/semantic-release/semantic-release). In order to automatically increment version numbers correctly, commit messages must follow the [conventional commit message format](https://github.com/marionebl/commitlint/tree/master/%40commitlint/config-conventional). If your commit includes a breaking change, be sure to prefix your commit body with `BREAKING CHANGE: `. To make this process easier, we have a commit script (powered by [commitizen](https://github.com/commitizen/cz-cli)) to help guide you through the commit process:
 
 ```bash
 $ npm run commit

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "deploy-gh-pages": "node scripts/deploy-gh-pages.js",
     "deploy-surge": "surge -p ./docs/dist",
     "commit": "git-cz",
-    "commitmsg": "validate-commit-msg",
+    "commitmsg": "commitlint -e -x '@commitlint/config-conventional'",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "sketch-to-git": "node scripts/sketch-to-git",
     "git-to-sketch": "node scripts/git-to-sketch"
@@ -62,6 +62,8 @@
     "react-helmet": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^5.2.8",
+    "@commitlint/config-conventional": "^5.2.3",
     "autoprefixer": "^7.1.5",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
@@ -78,7 +80,7 @@
     "chalk": "^2.1.0",
     "commitizen": "^2.9.6",
     "css-loader": "^0.28.7",
-    "cz-conventional-changelog": "^2.0.0",
+    "cz-conventional-changelog": "^2.1.0",
     "dedent": "^0.7.0",
     "ejs": "^2.5.7",
     "enzyme": "^3.1.0",
@@ -128,18 +130,19 @@
     "static-site-generator-webpack-plugin": "^3.4.1",
     "string-replace-loader": "^1.3.0",
     "style-loader": "^0.19.0",
-    "stylelint": "^8.2.0",
+    "stylelint": "^8.4.0",
     "stylelint-config-css-modules": "^1.1.0",
     "stylelint-config-standard": "^18.0.0",
     "surge": "^0.19.0",
     "svgo": "^1.0.0",
     "svgo-loader": "^2.0.0",
-    "validate-commit-msg": "^2.14.0",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1"
   },
   "greenkeeper": {
     "ignore": [
+      "@commitlint/cli",
+      "@commitlint/config-conventional",
       "autoprefixer",
       "babel-core",
       "babel-eslint",
@@ -207,7 +210,6 @@
       "surge",
       "svgo",
       "svgo-loader",
-      "validate-commit-msg",
       "webpack",
       "webpack-dev-server"
     ]


### PR DESCRIPTION
This PR looks to tidy up a number of things around commit messages, hopefully reducing the chances of merging PRs with commit messages that do not conform/don't trigger a release.

Changes include:
- `validate-commit-msg` is deprecated in favour of `commitlint`
- Adopt conventional message format for linting to be consistent with commitizen setup.
- Update PullApprove to enforce PR titles conform with commit conventional format. This should reduce the chance of merge commits not having the correct message.
- Upgrade `stylelint` to [fix linting issue](https://github.com/stylelint/stylelint/issues/3042)