### PR TITLE
ci(puppeteer): Fix Puppeteer sandbox issue on Travis CI

### DIFF
--- a/docs/html-sketchapp.config.js
+++ b/docs/html-sketchapp.config.js
@@ -6,5 +6,9 @@ module.exports = {
     'Desktop': '1024x768',
     'Mobile Plus': '414x736',
     'Mobile': '320x568'
-  }
+  },
+  puppeteerArgs: [
+    '--no-sandbox',
+    '--disable-setuid-sandbox'
+  ].join(' ')
 };

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "gh-pages": "^1.0.0",
     "hex-rgb": "^1.0.0",
     "html-minifier": "^3.5.6",
-    "html-sketchapp-cli": "0.0.2",
+    "html-sketchapp-cli": "0.0.4",
     "html-webpack-plugin": "^2.30.1",
     "husky": "^0.14.3",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
This fixes an issue where our tests are failing on Travis CI due to browser sandbox issues:

```
Error: Failed to launch chrome!
[0111/021400.561758:FATAL:zygote_host_impl_linux.cc(126)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
```

Since we're only running this tool against a style guide documentation page that is fully under our control, disabling the sandbox seemed like a reasonable workaround.