### PR TITLE
fix(Text): Add display name to Text component

### DIFF
--- a/react/Text/Text.js
+++ b/react/Text/Text.js
@@ -49,6 +49,8 @@ const Text = ({
   </span>
 );
 
+Text.displayName = 'Text';
+
 Text.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,


### PR DESCRIPTION
Due to decorating while shallow render snapshots are getting `<DecoratedComponent />` rendered instead of `<Text />`

This PR fixes the issue.