### PR TITLE
fix(Icon): Add missing subheading styles

### DIFF
--- a/docs/src/components/Playground/Playground.js
+++ b/docs/src/components/Playground/Playground.js
@@ -3,6 +3,8 @@ import styles from './Playground.less';
 import React, { Component } from 'react';
 import capitalize from 'lodash/capitalize';
 
+import { sizes as typographySizes } from '../../../../react/private/withTextProps';
+
 import {
   TextField,
   Button,
@@ -492,15 +494,7 @@ export default class Playground extends Component {
             {[StarIcon, ProfileIcon, HeartIcon, ThumbsUpIcon].map((IconComponent, index) => (
               <Card key={index}>
                 <Section>
-                  {[
-                    'small',
-                    'substandard',
-                    'standard',
-                    'superstandard',
-                    'heading',
-                    'headline',
-                    'hero'
-                  ].map(size => (
+                  {typographySizes.map(size => (
                     <div key={size}>
                       <Text size={size}>
                         <IconComponent size={size} /> {capitalize(size)}
@@ -541,15 +535,7 @@ export default class Playground extends Component {
           </Section>
           <Card>
             <Section>
-              {[
-                'small',
-                'substandard',
-                'standard',
-                'superstandard',
-                'heading',
-                'headline',
-                'hero'
-              ].map(size => (
+              {typographySizes.map(size => (
                 <div key={size}>
                   <Text {...{ [size]: true }}>Lorem ipsum <StarIcon {...{ [size]: true }} /> dolor sit amet, <ThumbsUpIcon {...{ [size]: true }} /> consectetur adipiscing <HeartIcon {...{ [size]: true }} /> elit. Nam vel sapien lorem.</Text>
                   <br />

--- a/react/private/Icon/Icon.less
+++ b/react/private/Icon/Icon.less
@@ -24,6 +24,13 @@
   );
 }
 
+.subheadingSvg {
+  .iconSize(
+    @typography-scale: @subheading-type-scale,
+    @typography-scale-mobile: @subheading-type-scale-mobile
+  );
+}
+
 .headingSvg {
   .iconSize(
     @typography-scale: @heading-type-scale,

--- a/react/private/withTextProps.js
+++ b/react/private/withTextProps.js
@@ -10,11 +10,11 @@ import forEach from 'lodash/forEach';
 export const sizes = [
   'small',
   'substandard',
-  'superstandard',
   'standard',
+  'superstandard',
   'subheading',
-  'headline',
   'heading',
+  'headline',
   'hero'
 ];
 


### PR DESCRIPTION
```
<SomeIcon subheading /> or <SomeIcon size="subheading" />
```

was not styling icon correctly as per subheading size so size was fallbacking to default 16px.

PR fixes it.

Plus playground cleanup