### PR TITLE
refactor(flowtype): Added flowtype

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,11 @@
   "plugins": [
     "babel",
     "react",
-    "jest"
+    "jest",
+    "flowtype"
+  ],
+  "extends": [
+    "plugin:flowtype/recommended"
   ],
   "rules": {
     "comma-dangle": 2,

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,18 @@
+[ignore]
+.*/node_modules/react-element-to-jsx-string/.*
+.*/node_modules/stylelint/.*
+.*/node_modules/config-chain/.*
+.*/node_modules/jsx-to-string/.*
+.*/node_modules/immutable/.*
+.*/node_modules/npmconf/.*
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+module.name_mapper.extension='less' -> '<PROJECT_ROOT>/config/no-declarations.js.flow'
+
+[strict]

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npm run test-unit && npm run lint && npm run build && npm run html-sketchapp",
     "test-unit": "BABEL_ENV=test jest --config ./jest.config.json",
     "update-snapshot": "npm run test-unit -- --updateSnapshot",
-    "lint": "npm run lint-js && npm run lint-less",
+    "lint": "npm run lint-js && npm run lint-less && npm run flow",
     "lint-js": "eslint app standalone/*/src docs/src react test",
     "lint-less": "stylelint '{theme,react,standalone,docs}/**/*.less'",
     "clean": "rm -rf dist && rm -rf docs/dist && mkdir -p dist && mkdir -p docs/dist",
@@ -30,7 +30,8 @@
     "commitmsg": "commitlint --edit --extends seek",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "sketch-to-git": "node scripts/sketch-to-git",
-    "git-to-sketch": "node scripts/git-to-sketch"
+    "git-to-sketch": "node scripts/git-to-sketch",
+    "flow": "flow focus-check ."
   },
   "config": {
     "commitizen": {
@@ -90,9 +91,11 @@
     "enzyme-to-json": "^3.1.2",
     "eslint": "^4.8.0",
     "eslint-plugin-babel": "^4.1.2",
+    "eslint-plugin-flowtype": "^2.41.0",
     "eslint-plugin-jest": "^21.2.0",
     "eslint-plugin-react": "^7.4.0",
     "extract-text-webpack-plugin": "^3.0.1",
+    "flow-bin": "^0.63.1",
     "gh-pages": "^1.0.0",
     "hex-rgb": "^1.0.0",
     "html-minifier": "^3.5.6",


### PR DESCRIPTION
## Background

In discussions in the past there has been some desire for integrating flow type in the style guide so that it can be utilised on an ad-hoc basis. This may have changed and the desire may have waned, but if not this PR sets up the minimum requirements to begin incrementally working towards some types.

## Approach

I just wanted to add a minimal flow config and also a npm script that will allow users to run flow-type at their discretion. It has been integrated into the build pipeline but won't be reporting any errors until we start adding `@flow` declarations to files:

https://flow.org/en/docs/usage/#toc-prepare-your-code-for-flow

## Using

```shell
npm run flow
```

