### PR TITLE
feat(Header): Rename ‘Advice & Tips’ to ‘Career Advice’ in AU

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "pad-left": "^2.1.0",
     "prop-types": "^15.6.0",
     "react-autosuggest": "^9.3.2",
-    "react-isolated-scroll": "^0.1.1",
-    "react-scrolllock": "^2.0.1"
+    "react-isolated-scroll": "^0.1.1"
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",

--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -101,7 +101,7 @@ exports[`Footer: should render when authenticated 1`] = `
                   data-analytics="toolbar:advice+tips"
                   href="/career-advice/"
                 >
-                  Advice & tips
+                  Career Advice
                 </a>
               </li>
               <li
@@ -901,7 +901,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                   data-analytics="toolbar:advice+tips"
                   href="/career-advice/"
                 >
-                  Advice & tips
+                  Career Advice
                 </a>
               </li>
               <li
@@ -1701,7 +1701,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                   data-analytics="toolbar:advice+tips"
                   href="/career-advice/"
                 >
-                  Advice & tips
+                  Career Advice
                 </a>
               </li>
               <li
@@ -2501,7 +2501,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                   data-analytics="toolbar:advice+tips"
                   href="/career-advice/"
                 >
-                  Advice & tips
+                  Career Advice
                 </a>
               </li>
               <li
@@ -3301,7 +3301,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                   data-analytics="toolbar:advice+tips"
                   href="/career-advice/"
                 >
-                  Advice & tips
+                  Advice & Tips
                 </a>
               </li>
               <li

--- a/react/Footer/data/tools.js
+++ b/react/Footer/data/tools.js
@@ -30,9 +30,16 @@ export default [
     analytics: 'toolbar:applied'
   },
   {
-    name: 'Advice & tips',
+    name: 'Career Advice',
     href: '/career-advice/',
-    analytics: 'toolbar:advice+tips'
+    analytics: 'toolbar:advice+tips',
+    specificLocale: 'AU'
+  },
+  {
+    name: 'Advice & Tips',
+    href: '/career-advice/',
+    analytics: 'toolbar:advice+tips',
+    specificLocale: 'NZ'
   },
   {
     name: 'Company reviews',

--- a/react/Header/Header.demo.js
+++ b/react/Header/Header.demo.js
@@ -72,6 +72,7 @@ export default {
         'Saved & Applied Jobs',
         'Recommended Jobs',
         'Company Reviews',
+        'Career Advice',
         'Advice & Tips'
       ].map(activeTab => ({
         label: activeTab || 'No active tab',
@@ -93,6 +94,7 @@ export default {
         'Saved & Applied Jobs',
         'Recommended Jobs',
         'Company Reviews',
+        'Career Advice',
         'Advice & Tips'
       ].map(newBadgeTab => {
         let label = newBadgeTab;

--- a/react/Header/Header.js
+++ b/react/Header/Header.js
@@ -16,6 +16,18 @@ import employerLinkForLocale from './employerLinkForLocale';
 import StructuredDataSchema from './StructuredDataSchema/StructuredDataSchema';
 import { AUTHENTICATED, UNAUTHENTICATED, AUTH_PENDING } from '../private/authStatusTypes';
 
+const defaultNewBadgeTabForLocale = locale => (
+  locale === 'AU' ?
+    'Career Advice' :
+    'Profile'
+);
+
+const handleLegacyTabName = tabName => (
+  tabName === 'Advice & Tips' ?
+    'Career Advice' :
+    tabName
+);
+
 const defaultLinkRenderer = props => (<a {...props} />);
 const tabNames = [
   'Job Search',
@@ -24,7 +36,8 @@ const tabNames = [
   'Saved & Applied Jobs',
   'Recommended Jobs',
   'Company Reviews',
-  'Advice & Tips'
+  'Career Advice',
+  'Advice & Tips' // Backwards compatible name for 'Career Advice'
 ];
 const allowedBadgeTabs = [
   ...tabNames,
@@ -32,17 +45,23 @@ const allowedBadgeTabs = [
 ];
 export default function Header({
   logoComponent: LogoComponent,
+  newBadgeTab: newBadgeTabProp,
+  activeTab: activeTabProp,
   locale,
   authenticationStatus,
   userName,
   userEmail,
   linkRenderer,
-  activeTab,
-  newBadgeTab,
   divider,
   returnUrl,
   onMenuToggle = () => {}
 }) {
+  const activeTab = handleLegacyTabName(activeTabProp);
+
+  const newBadgeTab = typeof newBadgeTabProp === 'undefined' ?
+    defaultNewBadgeTabForLocale(locale) :
+    handleLegacyTabName(newBadgeTabProp);
+
   const isAuthenticated = (authenticationStatus === AUTHENTICATED && (userName || userEmail));
   const isUnauthenticated = (authenticationStatus === UNAUTHENTICATED);
 
@@ -152,7 +171,7 @@ Header.defaultProps = {
   linkRenderer: defaultLinkRenderer,
   authenticationStatus: AUTH_PENDING,
   activeTab: null,
-  newBadgeTab: 'Profile',
+  newBadgeTab: undefined,
   divider: true,
   userEmail: ''
 };

--- a/react/Header/Navigation/Navigation.js
+++ b/react/Header/Navigation/Navigation.js
@@ -34,7 +34,7 @@ const items = [
     specificLocale: 'AU'
   },
   {
-    name: 'Advice & Tips',
+    name: 'Career Advice',
     href: '/career-advice/',
     analytics: 'header:advice'
   }
@@ -68,7 +68,7 @@ export default function Navigation({ locale, linkRenderer, activeTab, newBadgeTa
                   {
                     linkRenderer({
                       children: [
-                        name,
+                        name === 'Career Advice' && locale === 'NZ' ? 'Advice & Tips' : name,
                         name === newBadgeTab && (
                           <NewBadge
                             key={name}

--- a/react/Header/UserAccount/UserAccount.js
+++ b/react/Header/UserAccount/UserAccount.js
@@ -1,11 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import ScrollLock from 'react-scrolllock';
 import ChevronIcon from '../../ChevronIcon/ChevronIcon';
 import ScreenReaderOnly from '../../ScreenReaderOnly/ScreenReaderOnly';
 import UserAccountMenu from '../UserAccountMenu/UserAccountMenu';
 import { AUTHENTICATED, UNAUTHENTICATED, AUTH_PENDING } from '../../private/authStatusTypes';
-import smallDeviceOnly from '../../private/smallDeviceOnly';
 import styles from './UserAccount.less';
 
 const calculateMobileMenuLabel = (authenticationStatus, userName) => {
@@ -75,8 +73,6 @@ export default class UserAccount extends Component {
         <ScreenReaderOnly>
           <h1 id="UserMenu">User menu</h1>
         </ScreenReaderOnly>
-
-        {this.state.menuOpen && smallDeviceOnly() ? <ScrollLock /> : null }
 
         <input
           id="user-account-menu-toggle"

--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -214,7 +214,26 @@ export default function UserAccountMenu({ locale, authenticationStatus, linkRend
         })()}
       </Hidden>
 
-      <Hidden desktop component="li" className={styles.firstItemInGroup}>
+      {
+        locale === 'NZ' ? null : (
+          <Hidden desktop component="li" className={classnames(activeTab === 'Career Advice' && styles.activeTab, styles.firstItemInGroup)}>
+            {
+              linkRenderer({
+                'data-analytics': 'header:advice',
+                className: styles.item,
+                href: '/career-advice/',
+                children: [
+                  newBadgeTab === 'Career Advice' && <NewBadge key="new" className={styles.newBadge} />,
+                  'Career Advice',
+                  <div key="iconSpacer" className={styles.iconSpacer} />
+                ]
+              })
+            }
+          </Hidden>
+        )
+      }
+
+      <Hidden desktop component="li" className={classnames(locale === 'NZ' && styles.firstItemInGroup)}>
         {
           linkRenderer({
             'data-analytics': 'header:employer+site',

--- a/react/Header/UserAccountMenu/UserAccountMenu.less
+++ b/react/Header/UserAccountMenu/UserAccountMenu.less
@@ -10,10 +10,6 @@
     border-radius: 2px;
     padding: (@grid-row-height - @border-width) 0;
   }
-  @media @mobile {
-    overflow: auto;
-    height: ~"calc(100vh - @{headerHeightMobile})";
-  }
 }
 
 .activeTab {
@@ -117,13 +113,14 @@
 }
 
 .firstItemInGroup {
+  @padding-height: @grid-row-height * 2;
   @media @mobile {
-    padding-top: @grid-row-height * 4;
+    padding-top: @padding-height;
     position: relative;
     &::before {
       content: '';
       position: absolute;
-      top: @grid-row-height * 2;
+      top: ceil(@padding-height / 2);
       width: 100%;
       height: 1px;
       background: @sk-white;

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -172,11 +172,6 @@ exports[`Header: should append returnUrl to signin and register links if present
                       data-analytics="header:profile"
                       href="/profile/"
                     >
-                      <span
-                        class="root newBadge"
-                      >
-                        New
-                      </span>
                       <span>
                         Profile
                       </span>
@@ -318,6 +313,25 @@ exports[`Header: should append returnUrl to signin and register links if present
                   >
                     <a
                       class="item"
+                      data-analytics="header:advice"
+                      href="/career-advice/"
+                    >
+                      <span
+                        class="root newBadge"
+                      >
+                        New
+                      </span>
+                      Career Advice
+                      <div
+                        class="iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="desktop"
+                  >
+                    <a
+                      class="item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
@@ -439,11 +453,6 @@ exports[`Header: should append returnUrl to signin and register links if present
               href="/profile/"
             >
               Profile
-              <span
-                class="root newBadge newBadge_isShort"
-              >
-                New
-              </span>
             </a>
           </li>
           <li
@@ -465,7 +474,12 @@ exports[`Header: should append returnUrl to signin and register links if present
               data-analytics="header:advice"
               href="/career-advice/"
             >
-              Advice & Tips
+              Career Advice
+              <span
+                class="root newBadge"
+              >
+                New
+              </span>
             </a>
           </li>
         </ul>
@@ -759,11 +773,6 @@ exports[`Header: should render first part of email address when username isn't p
                       data-analytics="header:profile"
                       href="/profile/"
                     >
-                      <span
-                        class="root newBadge"
-                      >
-                        New
-                      </span>
                       <span>
                         Profile
                       </span>
@@ -892,6 +901,25 @@ exports[`Header: should render first part of email address when username isn't p
                   </li>
                   <li
                     class="firstItemInGroup desktop"
+                  >
+                    <a
+                      class="item"
+                      data-analytics="header:advice"
+                      href="/career-advice/"
+                    >
+                      <span
+                        class="root newBadge"
+                      >
+                        New
+                      </span>
+                      Career Advice
+                      <div
+                        class="iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="desktop"
                   >
                     <a
                       class="item"
@@ -1030,11 +1058,6 @@ exports[`Header: should render first part of email address when username isn't p
               href="/profile/"
             >
               Profile
-              <span
-                class="root newBadge newBadge_isShort"
-              >
-                New
-              </span>
             </a>
           </li>
           <li
@@ -1056,7 +1079,12 @@ exports[`Header: should render first part of email address when username isn't p
               data-analytics="header:advice"
               href="/career-advice/"
             >
-              Advice & Tips
+              Career Advice
+              <span
+                class="root newBadge"
+              >
+                New
+              </span>
             </a>
           </li>
         </ul>
@@ -1346,11 +1374,6 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                       data-analytics="header:profile"
                       href="/profile/"
                     >
-                      <span
-                        class="root newBadge"
-                      >
-                        New
-                      </span>
                       <span>
                         Profile
                       </span>
@@ -1492,6 +1515,25 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                   >
                     <a
                       class="item"
+                      data-analytics="header:advice"
+                      href="/career-advice/"
+                    >
+                      <span
+                        class="root newBadge"
+                      >
+                        New
+                      </span>
+                      Career Advice
+                      <div
+                        class="iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="desktop"
+                  >
+                    <a
+                      class="item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
@@ -1613,11 +1655,6 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
               href="/profile/"
             >
               Profile
-              <span
-                class="root newBadge newBadge_isShort"
-              >
-                New
-              </span>
             </a>
           </li>
           <li
@@ -1639,7 +1676,12 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
               data-analytics="header:advice"
               href="/career-advice/"
             >
-              Advice & Tips
+              Career Advice
+              <span
+                class="root newBadge"
+              >
+                New
+              </span>
             </a>
           </li>
         </ul>
@@ -1933,11 +1975,6 @@ exports[`Header: should render when authenticated 1`] = `
                       data-analytics="header:profile"
                       href="/profile/"
                     >
-                      <span
-                        class="root newBadge"
-                      >
-                        New
-                      </span>
                       <span>
                         Profile
                       </span>
@@ -2066,6 +2103,25 @@ exports[`Header: should render when authenticated 1`] = `
                   </li>
                   <li
                     class="firstItemInGroup desktop"
+                  >
+                    <a
+                      class="item"
+                      data-analytics="header:advice"
+                      href="/career-advice/"
+                    >
+                      <span
+                        class="root newBadge"
+                      >
+                        New
+                      </span>
+                      Career Advice
+                      <div
+                        class="iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="desktop"
                   >
                     <a
                       class="item"
@@ -2204,11 +2260,6 @@ exports[`Header: should render when authenticated 1`] = `
               href="/profile/"
             >
               Profile
-              <span
-                class="root newBadge newBadge_isShort"
-              >
-                New
-              </span>
             </a>
           </li>
           <li
@@ -2230,7 +2281,12 @@ exports[`Header: should render when authenticated 1`] = `
               data-analytics="header:advice"
               href="/career-advice/"
             >
-              Advice & Tips
+              Career Advice
+              <span
+                class="root newBadge"
+              >
+                New
+              </span>
             </a>
           </li>
         </ul>
@@ -2520,11 +2576,6 @@ exports[`Header: should render when authenticated but username and email is not 
                       data-analytics="header:profile"
                       href="/profile/"
                     >
-                      <span
-                        class="root newBadge"
-                      >
-                        New
-                      </span>
                       <span>
                         Profile
                       </span>
@@ -2653,6 +2704,25 @@ exports[`Header: should render when authenticated but username and email is not 
                   </li>
                   <li
                     class="firstItemInGroup desktop"
+                  >
+                    <a
+                      class="item"
+                      data-analytics="header:advice"
+                      href="/career-advice/"
+                    >
+                      <span
+                        class="root newBadge"
+                      >
+                        New
+                      </span>
+                      Career Advice
+                      <div
+                        class="iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="desktop"
                   >
                     <a
                       class="item"
@@ -2791,11 +2861,6 @@ exports[`Header: should render when authenticated but username and email is not 
               href="/profile/"
             >
               Profile
-              <span
-                class="root newBadge newBadge_isShort"
-              >
-                New
-              </span>
             </a>
           </li>
           <li
@@ -2817,7 +2882,12 @@ exports[`Header: should render when authenticated but username and email is not 
               data-analytics="header:advice"
               href="/career-advice/"
             >
-              Advice & Tips
+              Career Advice
+              <span
+                class="root newBadge"
+              >
+                New
+              </span>
             </a>
           </li>
         </ul>
@@ -3107,11 +3177,6 @@ exports[`Header: should render when authentication is pending 1`] = `
                       data-analytics="header:profile"
                       href="/profile/"
                     >
-                      <span
-                        class="root newBadge"
-                      >
-                        New
-                      </span>
                       <span>
                         Profile
                       </span>
@@ -3253,6 +3318,25 @@ exports[`Header: should render when authentication is pending 1`] = `
                   >
                     <a
                       class="item"
+                      data-analytics="header:advice"
+                      href="/career-advice/"
+                    >
+                      <span
+                        class="root newBadge"
+                      >
+                        New
+                      </span>
+                      Career Advice
+                      <div
+                        class="iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="desktop"
+                  >
+                    <a
+                      class="item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
@@ -3374,11 +3458,6 @@ exports[`Header: should render when authentication is pending 1`] = `
               href="/profile/"
             >
               Profile
-              <span
-                class="root newBadge newBadge_isShort"
-              >
-                New
-              </span>
             </a>
           </li>
           <li
@@ -3400,7 +3479,12 @@ exports[`Header: should render when authentication is pending 1`] = `
               data-analytics="header:advice"
               href="/career-advice/"
             >
-              Advice & Tips
+              Career Advice
+              <span
+                class="root newBadge"
+              >
+                New
+              </span>
             </a>
           </li>
         </ul>
@@ -3692,11 +3776,6 @@ exports[`Header: should render when unauthenticated 1`] = `
                       data-analytics="header:profile"
                       href="/profile/"
                     >
-                      <span
-                        class="root newBadge"
-                      >
-                        New
-                      </span>
                       <span>
                         Profile
                       </span>
@@ -3846,6 +3925,25 @@ exports[`Header: should render when unauthenticated 1`] = `
                   >
                     <a
                       class="item"
+                      data-analytics="header:advice"
+                      href="/career-advice/"
+                    >
+                      <span
+                        class="root newBadge"
+                      >
+                        New
+                      </span>
+                      Career Advice
+                      <div
+                        class="iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="desktop"
+                  >
+                    <a
+                      class="item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
@@ -3967,11 +4065,6 @@ exports[`Header: should render when unauthenticated 1`] = `
               href="/profile/"
             >
               Profile
-              <span
-                class="root newBadge newBadge_isShort"
-              >
-                New
-              </span>
             </a>
           </li>
           <li
@@ -3993,7 +4086,12 @@ exports[`Header: should render when unauthenticated 1`] = `
               data-analytics="header:advice"
               href="/career-advice/"
             >
-              Advice & Tips
+              Career Advice
+              <span
+                class="root newBadge"
+              >
+                New
+              </span>
             </a>
           </li>
         </ul>
@@ -4251,11 +4349,6 @@ exports[`Header: should render with a custom logo 1`] = `
                       data-analytics="header:profile"
                       href="/profile/"
                     >
-                      <span
-                        class="root newBadge"
-                      >
-                        New
-                      </span>
                       <span>
                         Profile
                       </span>
@@ -4397,6 +4490,25 @@ exports[`Header: should render with a custom logo 1`] = `
                   >
                     <a
                       class="item"
+                      data-analytics="header:advice"
+                      href="/career-advice/"
+                    >
+                      <span
+                        class="root newBadge"
+                      >
+                        New
+                      </span>
+                      Career Advice
+                      <div
+                        class="iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="desktop"
+                  >
+                    <a
+                      class="item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
@@ -4518,11 +4630,6 @@ exports[`Header: should render with a custom logo 1`] = `
               href="/profile/"
             >
               Profile
-              <span
-                class="root newBadge newBadge_isShort"
-              >
-                New
-              </span>
             </a>
           </li>
           <li
@@ -4544,7 +4651,12 @@ exports[`Header: should render with a custom logo 1`] = `
               data-analytics="header:advice"
               href="/career-advice/"
             >
-              Advice & Tips
+              Career Advice
+              <span
+                class="root newBadge"
+              >
+                New
+              </span>
             </a>
           </li>
         </ul>
@@ -4834,11 +4946,6 @@ exports[`Header: should render with locale of AU 1`] = `
                       data-analytics="header:profile"
                       href="/profile/"
                     >
-                      <span
-                        class="root newBadge"
-                      >
-                        New
-                      </span>
                       <span>
                         Profile
                       </span>
@@ -4980,6 +5087,25 @@ exports[`Header: should render with locale of AU 1`] = `
                   >
                     <a
                       class="item"
+                      data-analytics="header:advice"
+                      href="/career-advice/"
+                    >
+                      <span
+                        class="root newBadge"
+                      >
+                        New
+                      </span>
+                      Career Advice
+                      <div
+                        class="iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="desktop"
+                  >
+                    <a
+                      class="item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
@@ -5101,11 +5227,6 @@ exports[`Header: should render with locale of AU 1`] = `
               href="/profile/"
             >
               Profile
-              <span
-                class="root newBadge newBadge_isShort"
-              >
-                New
-              </span>
             </a>
           </li>
           <li
@@ -5127,7 +5248,12 @@ exports[`Header: should render with locale of AU 1`] = `
               data-analytics="header:advice"
               href="/career-advice/"
             >
-              Advice & Tips
+              Career Advice
+              <span
+                class="root newBadge"
+              >
+                New
+              </span>
             </a>
           </li>
         </ul>
@@ -5963,11 +6089,6 @@ exports[`Header: should render with no divider 1`] = `
                       data-analytics="header:profile"
                       href="/profile/"
                     >
-                      <span
-                        class="root newBadge"
-                      >
-                        New
-                      </span>
                       <span>
                         Profile
                       </span>
@@ -6109,6 +6230,25 @@ exports[`Header: should render with no divider 1`] = `
                   >
                     <a
                       class="item"
+                      data-analytics="header:advice"
+                      href="/career-advice/"
+                    >
+                      <span
+                        class="root newBadge"
+                      >
+                        New
+                      </span>
+                      Career Advice
+                      <div
+                        class="iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="desktop"
+                  >
+                    <a
+                      class="item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
@@ -6230,11 +6370,6 @@ exports[`Header: should render with no divider 1`] = `
               href="/profile/"
             >
               Profile
-              <span
-                class="root newBadge newBadge_isShort"
-              >
-                New
-              </span>
             </a>
           </li>
           <li
@@ -6256,7 +6391,12 @@ exports[`Header: should render with no divider 1`] = `
               data-analytics="header:advice"
               href="/career-advice/"
             >
-              Advice & Tips
+              Career Advice
+              <span
+                class="root newBadge"
+              >
+                New
+              </span>
             </a>
           </li>
         </ul>

--- a/standalone/header-footer/src/render.js
+++ b/standalone/header-footer/src/render.js
@@ -48,12 +48,14 @@ const renderHtml = (Component, initialProps, options = { preview: false }) => {
   return minify(html, { collapseWhitespace: true });
 };
 
-const renderFileForLocale = (Component, props, locale, fileNameSuffix) => {
+const renderFileForLocale = (Component, props, locale) => {
   if (typeof Component.displayName !== 'string') {
     throw new Error('Component must have a display name');
   }
 
-  const fileName = `${Component.displayName.toLowerCase()}__${locale.toLowerCase()}${fileNameSuffix ? `__${fileNameSuffix}` : ''}`;
+  const tabSuffix = !props.activeTab ? '' :
+    `__${props.activeTab.toLowerCase().replace(/ /g, '_').replace('$', '').replace('&', 'and')}`;
+  const fileName = `${Component.displayName.toLowerCase()}__${locale.toLowerCase()}${tabSuffix}`;
 
   const localeProps = locale !== 'AU' ? { locale } : {};
   const renderProps = { ...props, ...localeProps };
@@ -64,18 +66,16 @@ const renderFileForLocale = (Component, props, locale, fileNameSuffix) => {
   };
 };
 
-const renderFiles = (Component, props = {}, fileNameSuffix) => {
+const renderFiles = (Component, props = {}) => {
   return {
-    ...renderFileForLocale(Component, props, 'AU', fileNameSuffix),
-    ...renderFileForLocale(Component, props, 'NZ', fileNameSuffix)
+    ...renderFileForLocale(Component, props, 'AU'),
+    ...renderFileForLocale(Component, props, 'NZ')
   };
 };
 
 export default () => ({
   ...renderFiles(Header),
-  ...renderFiles(Header, { activeTab: 'Career Advice' }, 'career_advice'),
-  ...renderFiles(Footer),
-
-  // Provide old "advice_and_tips" file for backwards compatibility:
-  ...renderFiles(Header, { activeTab: 'Career Advice' }, 'advice_and_tips')
+  ...renderFiles(Header, { activeTab: 'Career Advice' }),
+  ...renderFiles(Header, { activeTab: 'Advice & Tips' }), // Render old Advice & Tips files to maintain backwards compatibility
+  ...renderFiles(Footer)
 });

--- a/standalone/header-footer/src/render.js
+++ b/standalone/header-footer/src/render.js
@@ -48,14 +48,12 @@ const renderHtml = (Component, initialProps, options = { preview: false }) => {
   return minify(html, { collapseWhitespace: true });
 };
 
-const renderFileForLocale = (Component, props, locale) => {
+const renderFileForLocale = (Component, props, locale, fileNameSuffix) => {
   if (typeof Component.displayName !== 'string') {
     throw new Error('Component must have a display name');
   }
 
-  const tabSuffix = !props.activeTab ? '' :
-    `__${props.activeTab.toLowerCase().replace(/ /g, '_').replace('$', '').replace('&', 'and')}`;
-  const fileName = `${Component.displayName.toLowerCase()}__${locale.toLowerCase()}${tabSuffix}`;
+  const fileName = `${Component.displayName.toLowerCase()}__${locale.toLowerCase()}${fileNameSuffix ? `__${fileNameSuffix}` : ''}`;
 
   const localeProps = locale !== 'AU' ? { locale } : {};
   const renderProps = { ...props, ...localeProps };
@@ -66,15 +64,18 @@ const renderFileForLocale = (Component, props, locale) => {
   };
 };
 
-const renderFiles = (Component, props = {}) => {
+const renderFiles = (Component, props = {}, fileNameSuffix) => {
   return {
-    ...renderFileForLocale(Component, props, 'AU'),
-    ...renderFileForLocale(Component, props, 'NZ')
+    ...renderFileForLocale(Component, props, 'AU', fileNameSuffix),
+    ...renderFileForLocale(Component, props, 'NZ', fileNameSuffix)
   };
 };
 
 export default () => ({
   ...renderFiles(Header),
-  ...renderFiles(Header, { activeTab: 'Advice & Tips' }),
-  ...renderFiles(Footer)
+  ...renderFiles(Header, { activeTab: 'Career Advice' }, 'career_advice'),
+  ...renderFiles(Footer),
+
+  // Provide old "advice_and_tips" file for backwards compatibility:
+  ...renderFiles(Header, { activeTab: 'Career Advice' }, 'advice_and_tips')
 });


### PR DESCRIPTION
This PR makes a few notable changes for AU:
- As the title says, rename "Advice & Tips" to "Career Advice"
- Move the "new" badge from "Profile" to "Career Advice"
- Show the Career Advice menu item on mobile, in the lower section

This PR also makes the following general changes:
- Generate a standalone header build of Career Advice
- Remove `react-scrollock` from the mobile menu, since the menu now requires scrolling on 320x480 phones
- Shrink the whitespace between menu groups on mobile

Note that, to ensure this isn't a breaking change, we still support "Advice & Tips" as a prop for `activeTab` and `newBadgeTab`, converting it to "Career Advice" on the way in.