### PR TITLE
fix(Header): Remove #favourite from myactivity

### DIFF
--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -63,7 +63,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 <a
                   class="link"
                   data-analytics="toolbar:my+activity"
-                  href="/myactivity#favourite"
+                  href="/myactivity"
                   rel="nofollow"
                 >
                   Saved searches
@@ -863,7 +863,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 <a
                   class="link"
                   data-analytics="toolbar:my+activity"
-                  href="/myactivity#favourite"
+                  href="/myactivity"
                   rel="nofollow"
                 >
                   Saved searches
@@ -1663,7 +1663,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 <a
                   class="link"
                   data-analytics="toolbar:my+activity"
-                  href="/myactivity#favourite"
+                  href="/myactivity"
                   rel="nofollow"
                 >
                   Saved searches
@@ -2463,7 +2463,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 <a
                   class="link"
                   data-analytics="toolbar:my+activity"
-                  href="/myactivity#favourite"
+                  href="/myactivity"
                   rel="nofollow"
                 >
                   Saved searches
@@ -3263,7 +3263,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 <a
                   class="link"
                   data-analytics="toolbar:my+activity"
-                  href="/myactivity#favourite"
+                  href="/myactivity"
                   rel="nofollow"
                 >
                   Saved searches

--- a/react/Footer/data/tools.js
+++ b/react/Footer/data/tools.js
@@ -11,7 +11,7 @@ export default [
   },
   {
     name: 'Saved searches',
-    href: '/myactivity#favourite',
+    href: '/myactivity',
     rel: 'nofollow',
     analytics: 'toolbar:my+activity'
   },

--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -69,7 +69,7 @@ export default function UserAccountMenu({ locale, authenticationStatus, linkRend
           linkRenderer({
             'data-analytics': 'header:saved+searches',
             className: `${styles.item} ${styles.subItem}`,
-            href: '/myactivity#favourite',
+            href: '/myactivity',
             children: [
               <span key="label">Saved Searches</span>,
               <HeartIcon

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -193,7 +193,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                     <a
                       class="item subItem"
                       data-analytics="header:saved+searches"
-                      href="/myactivity#favourite"
+                      href="/myactivity"
                     >
                       <span>
                         Saved Searches
@@ -780,7 +780,7 @@ exports[`Header: should render first part of email address when username isn't p
                     <a
                       class="item subItem"
                       data-analytics="header:saved+searches"
-                      href="/myactivity#favourite"
+                      href="/myactivity"
                     >
                       <span>
                         Saved Searches
@@ -1367,7 +1367,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                     <a
                       class="item subItem"
                       data-analytics="header:saved+searches"
-                      href="/myactivity#favourite"
+                      href="/myactivity"
                     >
                       <span>
                         Saved Searches
@@ -1954,7 +1954,7 @@ exports[`Header: should render when authenticated 1`] = `
                     <a
                       class="item subItem"
                       data-analytics="header:saved+searches"
-                      href="/myactivity#favourite"
+                      href="/myactivity"
                     >
                       <span>
                         Saved Searches
@@ -2541,7 +2541,7 @@ exports[`Header: should render when authenticated but username and email is not 
                     <a
                       class="item subItem"
                       data-analytics="header:saved+searches"
-                      href="/myactivity#favourite"
+                      href="/myactivity"
                     >
                       <span>
                         Saved Searches
@@ -3128,7 +3128,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                     <a
                       class="item subItem"
                       data-analytics="header:saved+searches"
-                      href="/myactivity#favourite"
+                      href="/myactivity"
                     >
                       <span>
                         Saved Searches
@@ -3713,7 +3713,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                     <a
                       class="item subItem"
                       data-analytics="header:saved+searches"
-                      href="/myactivity#favourite"
+                      href="/myactivity"
                     >
                       <span>
                         Saved Searches
@@ -4272,7 +4272,7 @@ exports[`Header: should render with a custom logo 1`] = `
                     <a
                       class="item subItem"
                       data-analytics="header:saved+searches"
-                      href="/myactivity#favourite"
+                      href="/myactivity"
                     >
                       <span>
                         Saved Searches
@@ -4855,7 +4855,7 @@ exports[`Header: should render with locale of AU 1`] = `
                     <a
                       class="item subItem"
                       data-analytics="header:saved+searches"
-                      href="/myactivity#favourite"
+                      href="/myactivity"
                     >
                       <span>
                         Saved Searches
@@ -5438,7 +5438,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                     <a
                       class="item subItem"
                       data-analytics="header:saved+searches"
-                      href="/myactivity#favourite"
+                      href="/myactivity"
                     >
                       <span>
                         Saved Searches
@@ -5984,7 +5984,7 @@ exports[`Header: should render with no divider 1`] = `
                     <a
                       class="item subItem"
                       data-analytics="header:saved+searches"
-                      href="/myactivity#favourite"
+                      href="/myactivity"
                     >
                       <span>
                         Saved Searches


### PR DESCRIPTION
The myactivity page used to have a lot of content not related to saved
searches. To make navigation easier we linked the "Saved Searches" menu
item to the `#favourites` anchor just above saved searches.

Now that almost everything else has been removed from the page this just
awkwardly scrolls partially down the page. Fix by removing the
`#favourites` completely.