### PR TITLE
feat(FieldLabel): Update FieldLabel label PropTypes to type node

### DIFF
--- a/react/private/FieldLabel/FieldLabel.js
+++ b/react/private/FieldLabel/FieldLabel.js
@@ -30,7 +30,7 @@ export default class FieldLabel extends Component {
       }
     },
     /* eslint-enable consistent-return */
-    label: PropTypes.string,
+    label: PropTypes.node,
     /* eslint-disable consistent-return */
     labelProps: (props, propName, componentName) => {
       const { id, label, labelProps } = props;

--- a/react/private/FieldLabel/FieldLabel.test.js
+++ b/react/private/FieldLabel/FieldLabel.test.js
@@ -58,6 +58,12 @@ describe('FieldLabel', () => {
       expect(labelText.props.children).to.equal('First Name');
     });
 
+    it('should be able to pass a node to `label`', () => {
+      render(<FieldLabel id="firstName" label={<span>First Name</span>} />);
+      expect(labelText.props.children.type).to.equal('span');
+      expect(labelText.props.children.props.children).to.equal('First Name');
+    });
+
     it('should error if `id` is not specified but `label` is', () => {
       render(<FieldLabel label="First Name" />);
       expect(errors[0]).to.match(/have an `id`/);


### PR DESCRIPTION
The FieldLabel components label PropTypes was previously type string. This has been updated to type node to increase component flexibility.

The use case that prompted this change was for a screen reader only TextField label. Now that the label allows PropTypes type node, the ScreenReaderOnly component could be used with the label prop.

EXAMPLE USAGE:

```js
<TextField
  id="firstName"
  inputProps={{
    onChange: function a(){},
    value: '...'
  }}
  label={<ScreenReaderOnly>First Name</ScreenReaderOnly>}
  message="e.g. Olivia"
  onClear
```
