### PR TITLE
fix(transparentBackground): Setting a max width on desktop

### DIFF
--- a/theme/mixins/backdrop.less
+++ b/theme/mixins/backdrop.less
@@ -7,6 +7,11 @@
   transition: opacity 0.3s;
   z-index: @z-index-backdrop;
   opacity: 0;
+  @media @desktop {
+    // This is required as otherwise on desktop the backdrop
+    // Overflows the page.
+    max-width: 100vw;
+  }
 }
 
 .backdrop() {


### PR DESCRIPTION
## Purpose

On desktop (firefox) the backdrop currently overflows the page as it's a fixed
position.

## Approach

For desktop, setting a max-width to 100vw resolves the issue and has no impact
on functionality.

![image](https://user-images.githubusercontent.com/11851685/35786028-a2ce6422-0a78-11e8-8c41-f78be3da8a7a.png)
