### PR TITLE
fix(transparentBackdrop): Removing -999px left, top, right

### DIFF
--- a/theme/mixins/backdrop.less
+++ b/theme/mixins/backdrop.less
@@ -1,9 +1,9 @@
 .transparentBackdrop() {
   position: fixed;
-  top: -999px;
-  left: -999px;
-  right: -999px;
-  bottom: -9999px;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
   transition: opacity 0.3s;
   z-index: @z-index-backdrop;
   opacity: 0;


### PR DESCRIPTION
## Purpose

In trying to debug a firefox issue in discover, we found that the
transparentBackgroup mixin really needed a lil refactor.

## Approach

We are setting just top and left to 0 and then setting the width and height to
the viewport (minus 1 for an issue with firefox see the comments).

This then standardished, for discover at least the placement of the backdrops,
which have an altered stacking context. We can therefore adjust these with JS
for now until we get around updating the searchBar not to use transforms (if
possible).

## Notes
This shouldn't impact other styleguide consumers, but if you do have an issue
whereby your stacking context changes it might be good to double check this does
not break your UI in subtle ways.

