### PR TITLE
fix(Section): Fix overflow issues on Section components

### DIFF
--- a/react/Section/Section.less
+++ b/react/Section/Section.less
@@ -4,7 +4,7 @@
 
 .root {
   overflow-x: hidden;
-  -ms-overflow-style: -ms-autohiding-scrollbar;
+  -ms-overflow-style: none;
   padding: (@grid-row-height * 2) @grid-gutter-width;
   @media only screen and (min-width: (@grid-container-width + (@grid-gutter-width * 2))) {
     padding-left: (@grid-gutter-width * 1.5);

--- a/react/Section/Section.less
+++ b/react/Section/Section.less
@@ -4,6 +4,7 @@
 
 .root {
   overflow-x: hidden;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
   padding: (@grid-row-height * 2) @grid-gutter-width;
   @media only screen and (min-width: (@grid-container-width + (@grid-gutter-width * 2))) {
     padding-left: (@grid-gutter-width * 1.5);

--- a/react/Section/Section.less
+++ b/react/Section/Section.less
@@ -1,20 +1,19 @@
 @import (reference) "~seek-style-guide/theme";
 
-@gutter-adjustment: @grid-gutter-width + 50px;
+@gutter-breakpoint: %(~"only screen and (min-width: %s)", (@grid-container-width + (@grid-gutter-width * 2)));
 
 .root {
-  overflow-x: hidden;
-  -ms-overflow-style: none;
   padding: (@grid-row-height * 2) @grid-gutter-width;
-  @media only screen and (min-width: (@grid-container-width + (@grid-gutter-width * 2))) {
+  @media @gutter-breakpoint {
     padding-left: (@grid-gutter-width * 1.5);
     padding-right: (@grid-gutter-width * 1.5);
   }
 
   &.pullout {
-    margin: 0 (-@gutter-adjustment);
-    padding-left: @gutter-adjustment;
-    padding-right: @gutter-adjustment;
+    margin: 0 (-@grid-gutter-width);
+    @media @gutter-breakpoint {
+      margin: 0 (-@grid-gutter-width * 1.5);
+    }
   }
 
   &.slim {

--- a/theme/mixins/backdrop.less
+++ b/theme/mixins/backdrop.less
@@ -1,9 +1,9 @@
 .transparentBackdrop() {
   position: fixed;
-  top: -999px;
-  left: -999px;
-  right: -999px;
-  bottom: -9999px;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
   transition: opacity 0.3s;
   z-index: @z-index-backdrop;
   opacity: 0;


### PR DESCRIPTION
Recent changes to the `<Section>` component introduced `overflow-x: hidden` to accomodate the pullout style for the `<Alert>` component. In IE, setting overflow-x creates a greyed out vertical scrollbar (screenshot below). 

![screen shot 2018-02-07 at 9 56 00 am](https://user-images.githubusercontent.com/1896277/35888875-712b3942-0bed-11e8-96f9-380317a32615.png)

Advertiser also has some issues with overflow being on `<Section>`

![screen shot 2018-02-07 at 10 14 03 am](https://user-images.githubusercontent.com/1896277/35892693-a7d447de-0bfe-11e8-9a0f-0a3e5d309518.png)

This problem is being fixed by removing overflow and adjusting the negative margin used in the pullout style to be exactly the same width as the gutter. This means overflow is not necessary because the pullout style no longer breaks out of a Section