### PR TITLE
fix(Alert): Ensure close icon is right aligned

### DIFF
--- a/docs/src/client-render.js
+++ b/docs/src/client-render.js
@@ -1,6 +1,7 @@
 // Polyfills
 import 'core-js/fn/array/fill';
 import 'core-js/fn/array/includes';
+import 'core-js/fn/array/from';
 import 'core-js/fn/string/ends-with';
 import 'core-js/fn/string/includes';
 import 'core-js/fn/string/starts-with';

--- a/react/Alert/Alert.demo.js
+++ b/react/Alert/Alert.demo.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Card, Section } from 'seek-style-guide/react';
 import { LEVEL, TONE } from '../Section/Section';
+import * as sketch from './Alert.sketch';
 
 const Container = ({ component: DemoComponent, componentProps }) => (
   <Card style={{ width: '500px' }}>
@@ -22,6 +23,7 @@ export default {
   category: 'Form',
   component: Alert,
   container: Container,
+  sketch,
   initialProps: {
     tone: TONE.POSITIVE,
     level: LEVEL.PRIMARY,

--- a/react/Alert/Alert.js
+++ b/react/Alert/Alert.js
@@ -71,8 +71,6 @@ export default class Alert extends Component {
 
     const rootClasses = classnames({
       [styles.root]: true,
-      [styles.hideIcon]: hideIcon,
-      [styles.showCloseButton]: onClose,
       [styles[tone]]: tone && isTertiary
     });
 

--- a/react/Alert/Alert.less
+++ b/react/Alert/Alert.less
@@ -11,10 +11,6 @@
 .alert {
   display: flex;
   align-items: center;
-
-  &.hideIcon.showCloseButton {
-    justify-content: space-between;
-  }
 }
 
 .positive {
@@ -41,20 +37,7 @@
 .text {
   display: inline-block;
   vertical-align: middle;
-  max-width: ~"calc(100% - (@{icon-width} + @{alert-gutter}))";
   flex-grow: 1;
-
-  .hideIcon & {
-    max-width: none;
-  }
-
-  .showCloseButton & {
-    max-width: ~"calc(100% - ((@{icon-width} * 2) + (@{alert-gutter} * 2)))";
-  }
-
-  .hideIcon.showCloseButton & {
-    max-width: none;
-  }
 }
 
 .icon {
@@ -62,6 +45,7 @@
   text-align: center;
   width: @icon-width;
   height: @icon-width;
+  flex-shrink: 0;
   margin-right: @alert-gutter;
   @media @mobile {
     vertical-align: top;
@@ -80,6 +64,7 @@
 .close {
   width: @icon-width;
   height: @icon-width;
+  flex-shrink: 0;
   border: none;
   padding: 0;
   background-color: transparent;

--- a/react/Alert/Alert.less
+++ b/react/Alert/Alert.less
@@ -42,6 +42,7 @@
   display: inline-block;
   vertical-align: middle;
   max-width: ~"calc(100% - (@{icon-width} + @{alert-gutter}))";
+  flex-grow: 1;
 
   .hideIcon & {
     max-width: none;

--- a/react/Alert/Alert.sketch.js
+++ b/react/Alert/Alert.sketch.js
@@ -10,7 +10,7 @@ export const symbols = {
       <Alert message="Message" tone="positive" level="primary" />
     </SketchFieldContainer>
   ),
-  'Alert/1. Positive/1. Primary/2. Dismissable': (
+  'Alert/1. Positive/1. Primary/2. With Close Button': (
     <SketchFieldContainer>
       <Alert message="Message" tone="positive" level="primary" onClose={noop} />
     </SketchFieldContainer>
@@ -20,7 +20,7 @@ export const symbols = {
       <Alert message="Message" tone="positive" level="secondary" />
     </SketchFieldContainer>
   ),
-  'Alert/1. Positive/2. Secondary/2. Dismissable': (
+  'Alert/1. Positive/2. Secondary/2. With Close Button': (
     <SketchFieldContainer>
       <Alert message="Message" tone="positive" level="secondary" onClose={noop} />
     </SketchFieldContainer>
@@ -30,7 +30,7 @@ export const symbols = {
       <Alert message="Message" tone="positive" level="tertiary" />
     </SketchFieldContainer>
   ),
-  'Alert/1. Positive/3. Tertiary/2. Dismissable': (
+  'Alert/1. Positive/3. Tertiary/2. With Close Button': (
     <SketchFieldContainer>
       <Alert message="Message" tone="positive" level="tertiary" onClose={noop} />
     </SketchFieldContainer>
@@ -41,7 +41,7 @@ export const symbols = {
       <Alert message="Message" tone="critical" level="primary" />
     </SketchFieldContainer>
   ),
-  'Alert/2. Critical/1. Primary/2. Dismissable': (
+  'Alert/2. Critical/1. Primary/2. With Close Button': (
     <SketchFieldContainer>
       <Alert message="Message" tone="critical" level="primary" onClose={noop} />
     </SketchFieldContainer>
@@ -51,7 +51,7 @@ export const symbols = {
       <Alert message="Message" tone="critical" level="tertiary" />
     </SketchFieldContainer>
   ),
-  'Alert/2. Critical/2. Tertiary/2. Dismissable': (
+  'Alert/2. Critical/2. Tertiary/2. With Close Button': (
     <SketchFieldContainer>
       <Alert message="Message" tone="critical" level="tertiary" onClose={noop} />
     </SketchFieldContainer>
@@ -62,7 +62,7 @@ export const symbols = {
       <Alert message="Message" tone="info" level="primary" />
     </SketchFieldContainer>
   ),
-  'Alert/3. Info/1. Primary/2. Dismissable': (
+  'Alert/3. Info/1. Primary/2. With Close Button': (
     <SketchFieldContainer>
       <Alert message="Message" tone="info" level="primary" onClose={noop} />
     </SketchFieldContainer>
@@ -72,7 +72,7 @@ export const symbols = {
       <Alert message="Message" tone="info" level="secondary" />
     </SketchFieldContainer>
   ),
-  'Alert/3. Info/2. Secondary/2. Dismissable': (
+  'Alert/3. Info/2. Secondary/2. With Close Button': (
     <SketchFieldContainer>
       <Alert message="Message" tone="info" level="secondary" onClose={noop} />
     </SketchFieldContainer>
@@ -82,7 +82,7 @@ export const symbols = {
       <Alert message="Message" tone="info" level="tertiary" />
     </SketchFieldContainer>
   ),
-  'Alert/3. Info/3. Tertiary/2. Dismissable': (
+  'Alert/3. Info/3. Tertiary/2. With Close Button': (
     <SketchFieldContainer>
       <Alert message="Message" tone="info" level="tertiary" onClose={noop} />
     </SketchFieldContainer>
@@ -93,7 +93,7 @@ export const symbols = {
       <Alert message="Message" tone="help" level="primary" />
     </SketchFieldContainer>
   ),
-  'Alert/4. Help/1. Primary/2. Dismissable': (
+  'Alert/4. Help/1. Primary/2. With Close Button': (
     <SketchFieldContainer>
       <Alert message="Message" tone="help" level="primary" onClose={noop} />
     </SketchFieldContainer>
@@ -103,7 +103,7 @@ export const symbols = {
       <Alert message="Message" tone="help" level="tertiary" />
     </SketchFieldContainer>
   ),
-  'Alert/4. Help/2. Tertiary/2. Dismissable': (
+  'Alert/4. Help/2. Tertiary/2. With Close Button': (
     <SketchFieldContainer>
       <Alert message="Message" tone="help" level="tertiary" onClose={noop} />
     </SketchFieldContainer>

--- a/react/Alert/Alert.sketch.js
+++ b/react/Alert/Alert.sketch.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import Alert from './Alert';
+import SketchFieldContainer from '../private/SketchFieldContainer/SketchFieldContainer';
+
+const noop = () => {};
+
+export const symbols = {
+  'Alert/1. Positive/1. Primary/1. Standard': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="positive" level="primary" />
+    </SketchFieldContainer>
+  ),
+  'Alert/1. Positive/1. Primary/2. Dismissable': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="positive" level="primary" onClose={noop} />
+    </SketchFieldContainer>
+  ),
+  'Alert/1. Positive/2. Secondary/1. Standard': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="positive" level="secondary" />
+    </SketchFieldContainer>
+  ),
+  'Alert/1. Positive/2. Secondary/2. Dismissable': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="positive" level="secondary" onClose={noop} />
+    </SketchFieldContainer>
+  ),
+  'Alert/1. Positive/3. Tertiary/1. Standard': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="positive" level="tertiary" />
+    </SketchFieldContainer>
+  ),
+  'Alert/1. Positive/3. Tertiary/2. Dismissable': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="positive" level="tertiary" onClose={noop} />
+    </SketchFieldContainer>
+  ),
+
+  'Alert/2. Critical/1. Primary/1. Standard': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="critical" level="primary" />
+    </SketchFieldContainer>
+  ),
+  'Alert/2. Critical/1. Primary/2. Dismissable': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="critical" level="primary" onClose={noop} />
+    </SketchFieldContainer>
+  ),
+  'Alert/2. Critical/2. Tertiary/1. Standard': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="critical" level="tertiary" />
+    </SketchFieldContainer>
+  ),
+  'Alert/2. Critical/2. Tertiary/2. Dismissable': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="critical" level="tertiary" onClose={noop} />
+    </SketchFieldContainer>
+  ),
+
+  'Alert/3. Info/1. Primary/1. Standard': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="info" level="primary" />
+    </SketchFieldContainer>
+  ),
+  'Alert/3. Info/1. Primary/2. Dismissable': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="info" level="primary" onClose={noop} />
+    </SketchFieldContainer>
+  ),
+  'Alert/3. Info/2. Secondary/1. Standard': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="info" level="secondary" />
+    </SketchFieldContainer>
+  ),
+  'Alert/3. Info/2. Secondary/2. Dismissable': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="info" level="secondary" onClose={noop} />
+    </SketchFieldContainer>
+  ),
+  'Alert/3. Info/3. Tertiary/1. Standard': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="info" level="tertiary" />
+    </SketchFieldContainer>
+  ),
+  'Alert/3. Info/3. Tertiary/2. Dismissable': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="info" level="tertiary" onClose={noop} />
+    </SketchFieldContainer>
+  ),
+
+  'Alert/4. Help/1. Primary/1. Standard': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="help" level="primary" />
+    </SketchFieldContainer>
+  ),
+  'Alert/4. Help/1. Primary/2. Dismissable': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="help" level="primary" onClose={noop} />
+    </SketchFieldContainer>
+  ),
+  'Alert/4. Help/2. Tertiary/1. Standard': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="help" level="tertiary" />
+    </SketchFieldContainer>
+  ),
+  'Alert/4. Help/2. Tertiary/2. Dismissable': (
+    <SketchFieldContainer>
+      <Alert message="Message" tone="help" level="tertiary" onClose={noop} />
+    </SketchFieldContainer>
+  )
+};

--- a/react/Alert/__snapshots__/Alert.test.js.snap
+++ b/react/Alert/__snapshots__/Alert.test.js.snap
@@ -118,7 +118,7 @@ exports[`Alert: should pass through additional props 1`] = `
 
 exports[`Alert: should render a close button 1`] = `
 <Section
-  className="root showCloseButton"
+  className="root"
   header={false}
   level="primary"
   pullout={false}
@@ -184,7 +184,7 @@ exports[`Alert: should render the pullout style 1`] = `
 
 exports[`Alert: should render with a hidden icon 1`] = `
 <Section
-  className="root hideIcon"
+  className="root"
   header={false}
   level="primary"
   pullout={false}


### PR DESCRIPTION
If the provided message isn't long enough to wrap onto multiple lines, the close icon is no longer right aligned, instead being rendered immediately after the text:

<img width="452" alt="screen shot 2018-02-09 at 11 41 11 am" src="https://user-images.githubusercontent.com/696693/36005956-5f2d5f34-0d8e-11e8-9cc1-8f6524ef38aa.png">

I discovered this issue while creating Sketch symbols for the Alert component, which is why they're also included in this PR.

Also, while ensuring this fix also worked in IE11, I discovered a polyfill on the demo site, which I've also included in this PR.