### PR TITLE
feat(theme): Add new blues and use internally, darken sk-black

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,19 @@ The following colors are provided:
 
 ```less
 // Brand colors
+@sk-blue-darker
+@sk-blue-dark
 @sk-blue
+@sk-blue-light
+@sk-blue-lighter
 @sk-pink
 @sk-green
+@sk-green-light
 @sk-purple
 @sk-teal
+@sk-orange
+@sk-yellow
+@sk-yellow-light
 
 // Partner brand colors
 @sk-business
@@ -137,13 +145,17 @@ The following colors are provided:
 @sk-link-visited
 @sk-focus
 @sk-highlight
-@sk-green-light
-@sk-yellow
-@sk-yellow-light
-@sk-orange
 @sk-footer
 @sk-background
-@sk-yellow
+@sk-form-accent
+@sk-positive-light
+@sk-positive
+@sk-info-light
+@sk-info
+@sk-critical-light
+@sk-critical
+@sk-help-light
+@sk-help
 ```
 
 ### Z-Indexes

--- a/docs/src/components/Home/Hero/ButtonsPreview/ButtonsPreview.js
+++ b/docs/src/components/Home/Hero/ButtonsPreview/ButtonsPreview.js
@@ -9,14 +9,14 @@ export default function ButtonsPreview() {
   return (
     <div className={styles.root}>
       <div className={styles.group}>
-        <Button color="pink" className={styles.button}>Normal</Button>
+        <Button color="pink" className={styles.button}>Button</Button>
         <Button color="pink" className={classnames(styles.button, buttonStyles.rootHover)}>Hover</Button>
-        <Button color="pink" className={classnames(styles.button, buttonStyles.rootActive)}>Pressed</Button>
+        <Button color="pink" className={classnames(styles.button, buttonStyles.rootActive)}>Active</Button>
       </div>
       <div className={styles.group}>
-        <Button color="blue" className={styles.button}>Normal</Button>
+        <Button color="blue" className={styles.button}>Button</Button>
         <Button color="blue" className={classnames(styles.button, buttonStyles.rootHover)}>Hover</Button>
-        <Button color="blue" className={classnames(styles.button, buttonStyles.rootActive)}>Pressed</Button>
+        <Button color="blue" className={classnames(styles.button, buttonStyles.rootActive)}>Active</Button>
       </div>
     </div>
   );

--- a/docs/src/components/Home/Hero/ColorPreview/ColorPreview.js
+++ b/docs/src/components/Home/Hero/ColorPreview/ColorPreview.js
@@ -25,9 +25,7 @@ export default function ColorPreview() {
   return (
     <div>
       {
-        Object.keys(brandValues)
-          .slice(0, 3)
-          .map(getSwatch)
+        ['@sk-blue', '@sk-pink', '@sk-teal'].map(getSwatch)
       }
     </div>
   );

--- a/docs/src/components/Home/Hero/IconPreview/IconPreview.less
+++ b/docs/src/components/Home/Hero/IconPreview/IconPreview.less
@@ -18,7 +18,7 @@
 }
 
 .iconSvg {
-  fill: @sk-highlight;
+  fill: @sk-blue-lighter;
   width: @iconSize;
   height: @iconSize;
 }

--- a/react/Autosuggest/Autosuggest.demo.js
+++ b/react/Autosuggest/Autosuggest.demo.js
@@ -95,6 +95,22 @@ export default {
           })
         },
         {
+          label: 'Grouped',
+          transformProps: ({ autosuggestProps, ...props }) => ({
+            ...props,
+            autosuggestProps: {
+              ...autosuggestProps,
+              multiSection: true,
+              suggestions: [{
+                title: 'RECENT TITLES',
+                suggestions: ['Developer', 'Product manager', 'Iteration manager', 'Designer']
+              }],
+              renderSectionTitle: section => <div>{section.title}</div>,
+              getSectionSuggestions: section => section.suggestions
+            }
+          })
+        },
+        {
           label: 'Show mobile backdrop',
           transformProps: ({ ...props }) => ({
             ...props,

--- a/react/Autosuggest/Autosuggest.less
+++ b/react/Autosuggest/Autosuggest.less
@@ -49,7 +49,7 @@
   line-height: @sectionTitleHeight;
   height: @sectionTitleHeight;
   margin: @row-height (@gutter-width * 0.75) 0;
-  color: @sk-blue-lighter;
+  color: @sk-form-accent;
   font-weight: @sk-bold;
 
   .sectionContainer:first-child & {

--- a/react/Autosuggest/Autosuggest.less
+++ b/react/Autosuggest/Autosuggest.less
@@ -49,7 +49,7 @@
   line-height: @sectionTitleHeight;
   height: @sectionTitleHeight;
   margin: @row-height (@gutter-width * 0.75) 0;
-  color: darken(@sk-highlight, 10%);
+  color: @sk-blue-lighter;
   font-weight: @sk-bold;
 
   .sectionContainer:first-child & {

--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -66,7 +66,7 @@
   user-select: none;
   text-align: center;
   padding: 0 @gutter-width;
-  box-shadow: 0 1px fade(@sk-black, 70%);
+  box-shadow: inset 0 -1px fade(@sk-charcoal, 40%);
   border: 0;
   border-radius: 2px;
   transition:
@@ -91,7 +91,7 @@
 }
 
 .root_isBlue {
-  .buttonColor(@sk-white, @sk-highlight);
+  .buttonColor(@sk-white, @sk-blue-lighter);
 }
 
 .root_isGray {

--- a/react/SlideToggle/SlideToggle.less
+++ b/react/SlideToggle/SlideToggle.less
@@ -19,19 +19,23 @@
   top: 5px;
   margin: 0;
 
-  &:focus ~ .slider {
-    box-shadow: 0 0 10px 0 @sk-focus;
+  &:focus ~ .slider .slideButton::before {
+    border: 1px solid @sk-focus;
   }
 
-  &:active ~ .slider .slideButton::before {
-    transform: scale(1.15, 0.85);
+  @slide-distance: 21px;
+  @anticipation-distance: 4px;
+  &:active ~ .slider .slideButton {
+    transform: translateX(-@anticipation-distance);
   }
-
+  &:checked:active ~ .slider .slideButton {
+    transform: translateX(@slide-distance + @anticipation-distance);
+  }
   &:checked ~ .slider .slideButton {
-    left: 21px;
+    transform: translateX(@slide-distance);
 
     &::before {
-      background-color: @sk-highlight;
+      background-color: @sk-form-accent;
     }
   }
 
@@ -89,6 +93,7 @@
     width: @row-height * 5;
     border-radius: 50%;
     background-color: @sk-mid-gray;
+    box-shadow: inset 0 -2px fade(@sk-black, 10%);
     text-align: center;
   }
 }
@@ -103,7 +108,14 @@
 .svg {
   fill: white;
   opacity: 0;
-  transition: opacity 0.15s;
+  transition: 0.3s;
   position: relative;
   top: 5px;
+  transform: rotate(-25deg);
+  .input:checked:active ~ .slider & {
+    transform: rotate(6deg);
+  }
+  .input:checked ~ .slider & {
+    transform: none;
+  }
 }

--- a/theme/palette/accessible-variants.less
+++ b/theme/palette/accessible-variants.less
@@ -5,4 +5,4 @@
 @sk-pink-on-gray-light: #bd0b67;
 @sk-learning-dark-on-gray-light: #157e00;
 @sk-business-on-gray-light: #0f749f;
-@sk-link-on-mid-gray-light: #005bb6;
+@sk-link-on-mid-gray-light: #2259b7;

--- a/theme/palette/brand.less
+++ b/theme/palette/brand.less
@@ -1,6 +1,14 @@
 // Seek base colors
+@sk-blue-darker: #071d40;
+@sk-blue-dark: #042763;
 @sk-blue: #0d3880;
+@sk-blue-light: #184da8;
+@sk-blue-lighter: #2765cf;
 @sk-pink: #e60278;
 @sk-green: #157e00;
+@sk-green-light: #5bc252;
 @sk-purple: #9556b7;
 @sk-teal: #00a5ad;
+@sk-orange: #f57c00;
+@sk-yellow: #ffc600;
+@sk-yellow-light: #fffce3;

--- a/theme/palette/elements.less
+++ b/theme/palette/elements.less
@@ -1,15 +1,11 @@
 // Seek element colors
-@sk-link: #0066cc;
+@sk-link: @sk-blue-lighter;
 @sk-link-visited: #7e30ab;
 @sk-focus: #1e90ff;
 @sk-highlight: #1d9ede;
-@sk-green-light: #5bc252;
-@sk-yellow: #ffc600;
-@sk-yellow-light: #fffce3;
-@sk-orange: #f57c00;
 @sk-footer: @sk-mid-gray-light;
 @sk-background: @sk-gray-light;
-@sk-form-accent: @sk-focus;
+@sk-form-accent: @sk-blue-lighter;
 @sk-positive-light: #f3f9f2;
 @sk-positive: #169400;
 @sk-info-light: #f9f6fb;

--- a/theme/palette/grays.less
+++ b/theme/palette/grays.less
@@ -1,5 +1,5 @@
 // Seek grays
-@sk-black: #212121;
+@sk-black: #1c1c1c;
 @sk-charcoal: #404040;
 @sk-mid-gray-dark: #747474;
 @sk-mid-gray-medium: #898989;


### PR DESCRIPTION
This adds the following colours:
- `@sk-blue-darker`
- `@sk-blue-dark`
- `@sk-blue-light`
- `@sk-blue-lighter`

The new blues have been applied to links, buttons and form accents.

For accessibility reasons, `@sk-black` has also been darkened slightly.

While revisiting form elements, some visual styling has been tweaked:

- Button shadows are now inset, ensuring they match the button hue
- SlideToggle animations have been polished up a bit