### PR TITLE
chore(theme): Use palette blues rather than incorrect use of elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ The following colors are provided:
 @sk-link
 @sk-link-visited
 @sk-focus
-@sk-highlight
 @sk-footer
 @sk-background
 @sk-form-accent

--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -114,7 +114,7 @@
 }
 
 .root_isBlue.root_isGhost {
-  .ghostColor(@sk-link)
+  .ghostColor(@sk-blue-lighter)
 }
 
 .root_isWhite.root_isGhost {

--- a/react/Header/NewBadge/NewBadge.less
+++ b/react/Header/NewBadge/NewBadge.less
@@ -8,7 +8,7 @@
   font-size: 12px;
   font-weight: @sk-medium;
   color: @sk-white;
-  background-color: @sk-link;
+  background-color: @sk-blue-lighter;
   height: @height;
   line-height: @height;
   padding: 0 6px;

--- a/react/Header/UserAccountMenu/UserAccountMenu.less
+++ b/react/Header/UserAccountMenu/UserAccountMenu.less
@@ -76,10 +76,10 @@
   }
 }
 
-.icon.jobSearch { color: @sk-highlight; }
+.icon.jobSearch { color: @sk-blue-lighter; }
 .icon.profile { color: @sk-purple; }
 .icon.saveJobs { color: @sk-pink; }
-.icon.saveSearches { color: @sk-highlight; }
+.icon.saveSearches { color: @sk-blue-lighter; }
 .icon.recommendedJobs { color: @sk-green-light; }
 
 .iconSpacer {


### PR DESCRIPTION
Since [the introduction of the blue variants](https://github.com/seek-oss/seek-style-guide/pull/439), we can now more semantically reference shades of directly from the palette as opposed to using `sk-link` out of context of an actual link.

Also migrating away from using `sk-highlight` as this will be deprecated in the future in favour of using the palette or element colours specifically.