### PR TITLE
feat(Columns): New reverse prop added

### DIFF
--- a/react/Columns/Columns.demo.js
+++ b/react/Columns/Columns.demo.js
@@ -59,7 +59,7 @@ export default {
       ]
     },
     {
-      label: 'Reverse',
+      label: 'States',
       type: 'checklist',
       states: [
         {

--- a/react/Columns/Columns.demo.js
+++ b/react/Columns/Columns.demo.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Columns, PageBlock, Card, Section, Text } from 'seek-style-guide/react';
+import classnames from 'classnames';
+import styles from './Columns.less';
 
 const ColumnsContainer = ({ component: DemoComponent, componentProps }) => (
   <PageBlock>
@@ -52,6 +54,36 @@ export default {
           transformProps: props => ({
             ...props,
             children: makeColumns(4)
+          })
+        }
+      ]
+    },
+    {
+      label: 'Reverse',
+      type: 'checklist',
+      states: [
+        {
+          label: 'Flexible',
+          transformProps: props => ({
+            ...props,
+            flexible: true,
+            className: classnames(styles.columns, styles.columns_flexible)
+          })
+        },
+        {
+          label: 'Tight',
+          transformProps: props => ({
+            ...props,
+            tight: true,
+            className: classnames(styles.columns, styles.columns_tight)
+          })
+        },
+        {
+          label: 'Reverse',
+          transformProps: props => ({
+            ...props,
+            reverse: true,
+            className: classnames(styles.columns, styles.columns_reverse)
           })
         }
       ]

--- a/react/Columns/Columns.js
+++ b/react/Columns/Columns.js
@@ -8,13 +8,14 @@ const renderColumn = (el, index) => (
   <div key={index} className={styles.column}>{el}</div>
 );
 
-export default function Columns({ children, tight, flexible }) {
+export default function Columns({ children, tight, flexible, reverse }) {
   return (
     <div
       className={classnames({
         [styles.columns]: true,
         [styles.columns_tight]: tight,
-        [styles.columns_flexible]: flexible
+        [styles.columns_flexible]: flexible,
+        [styles.columns_reverse]: reverse
       })}>
       {children.map(renderColumn)}
     </div>
@@ -24,5 +25,6 @@ export default function Columns({ children, tight, flexible }) {
 Columns.propTypes = {
   children: PropTypes.array.isRequired,
   tight: PropTypes.bool,
-  flexible: PropTypes.bool
+  flexible: PropTypes.bool,
+  reverse: PropTypes.bool
 };

--- a/react/Columns/Columns.js
+++ b/react/Columns/Columns.js
@@ -28,3 +28,9 @@ Columns.propTypes = {
   flexible: PropTypes.bool,
   reverse: PropTypes.bool
 };
+
+Columns.defaultProps = {
+  tight: false,
+  flexible: false,
+  reverse: false
+};

--- a/react/Columns/Columns.less
+++ b/react/Columns/Columns.less
@@ -3,6 +3,9 @@
 .columns {
   @media @desktop {
     display: flex;
+    &.columns_reverse {
+      flex-direction: row-reverse;
+    }
   }
 }
 
@@ -20,11 +23,17 @@
     .columns_tight & {
       padding: 0 (@gutter-width / 4);
     }
-    &:first-child {
+    .columns:not(.columns_reverse) &:first-child {
       padding-left: 0 !important;
     }
-    &:last-child {
+    .columns:not(.columns_reverse) &:last-child {
       padding-right: 0 !important;
+    }
+    .columns_reverse &:first-child {
+      padding-right: 0 !important;
+    }
+    .columns_reverse &:last-child {
+      padding-left: 0 !important;
     }
   }
 }

--- a/react/Columns/Columns.less
+++ b/react/Columns/Columns.less
@@ -23,17 +23,13 @@
     .columns_tight & {
       padding: 0 (@gutter-width / 4);
     }
-    .columns:not(.columns_reverse) &:first-child {
-      padding-left: 0 !important;
-    }
-    .columns:not(.columns_reverse) &:last-child {
-      padding-right: 0 !important;
-    }
-    .columns_reverse &:first-child {
-      padding-right: 0 !important;
-    }
+    .columns:not(.columns_reverse) &:first-child,
     .columns_reverse &:last-child {
       padding-left: 0 !important;
+    }
+    .columns:not(.columns_reverse) &:last-child,
+    .columns_reverse &:first-child {
+      padding-right: 0 !important;
     }
   }
 }

--- a/react/Columns/Columns.test.js
+++ b/react/Columns/Columns.test.js
@@ -30,4 +30,13 @@ describe('Columns:', () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+  it('should render columns in reverse', () => {
+    const wrapper = shallow(
+      <Columns reverse>
+        <div id="1" />
+        <div id="2" />
+      </Columns>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/react/Columns/__snapshots__/Columns.test.js.snap
+++ b/react/Columns/__snapshots__/Columns.test.js.snap
@@ -19,6 +19,29 @@ exports[`Columns: should render columns 1`] = `
 </div>
 `;
 
+exports[`Columns: should render columns in reverse 1`] = `
+<div
+  className="columns columns_reverse"
+>
+  <div
+    className="column"
+    key="0"
+  >
+    <div
+      id="1"
+    />
+  </div>
+  <div
+    className="column"
+    key="1"
+  >
+    <div
+      id="2"
+    />
+  </div>
+</div>
+`;
+
 exports[`Columns: should render flexible columns 1`] = `
 <div
   className="columns columns_flexible"


### PR DESCRIPTION
New reverse prop allows consumers to flip the order of the children of the Columns component

When using the Columns component to replicate a fairly common UI pattern of Image on left with content on right, the pattern also offer the reverse of Content on left and Image on right.

Seeing as the Columns component does not accept a classNames prop to control this in the form of a CSS override, after discussing the problem with fellow contributors, the better option seemed to add a new prop that, if passed in, flips the ordering of the items within the columns component.

### Changes
- added new `reverse` prop to Columns component
- updated existing styles to enable reversal of columns' children
- added unit test for reverse prop
- updated demo to include missing prop options with new prop option (flexible, tight & reverse)
- added missing default props to `Columns` component

EXAMPLE USAGE:

```js
<Columns reverse>
    <Card>Item 1</Card>
    <Card>Item 2</Card>
</Columns>
```
