### PR TITLE
fix(Checkbox): Avoid shrinking checkbox in limited space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node_modules
 dist
-npm-debug.log
+*.log
 yarn.lock
 package-lock.json
 flow-typed/*.generated.*
-

--- a/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
+++ b/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
@@ -28,7 +28,6 @@ exports[`Autosuggest should render with label 1`] = `
       <input
         aria-autocomplete="list"
         aria-expanded="false"
-        aria-haspopup="false"
         aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
@@ -93,7 +92,6 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
       <input
         aria-autocomplete="list"
         aria-expanded="false"
-        aria-haspopup="false"
         aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
@@ -139,7 +137,6 @@ exports[`Autosuggest should render with simple props 1`] = `
       <input
         aria-autocomplete="list"
         aria-expanded="false"
-        aria-haspopup="false"
         aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
@@ -184,7 +181,6 @@ exports[`Autosuggest should render with suggestions 1`] = `
       <input
         aria-autocomplete="list"
         aria-expanded="true"
-        aria-haspopup="true"
         aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"

--- a/react/Checkbox/Checkbox.less
+++ b/react/Checkbox/Checkbox.less
@@ -27,13 +27,11 @@
 }
 
 .standard {
-  .touchableText(@standard-type-scale-mobile);
+  .touchableText(@standard-type-scale);
+  height: 100%;
   cursor: pointer;
   display: flex;
   align-items: center;
-  @media @desktop {
-    .touchableText(@standard-type-scale);
-  }
 }
 
 .checkBox {
@@ -42,6 +40,7 @@
   background-color: @sk-white;
   width: @row-height * 5;
   height: @row-height * 5;
+  flex: 0 0 (@row-height * 5);
   border: @field-border-width solid @sk-mid-gray-light;
   border-radius: @field-border-radius;
   margin-right: @field-gutter-width;


### PR DESCRIPTION
When the checkbox text becomes too long for the space available it may attempt to wrap.
This causes the checkbox to shrink as it is a peer to the text content.

This change stops the checkbox 'box' area from shrinking or growing with the space available.

In addition this change will ensure the outer hit-box that handles the on-click will always encompass the text inside it, currently if text overflows it wont increase the hit-box.