### PR TITLE
fix(Radio): Fix hidden input focus for VoiceOver

### DIFF
--- a/react/Radio/Radio.less
+++ b/react/Radio/Radio.less
@@ -2,7 +2,9 @@
 @circumference: @row-height * 5;
 
 .root {
-  display: inline-block;
+  .touchableText(@standard-type-scale);
+  display: inline-flex;
+  align-items: center;
 }
 
 .input {
@@ -11,14 +13,12 @@
   width: @circumference;
   height: @circumference;
   border: none;
-  margin: @row-height 0 0;
+  margin: 0;
 }
 
 .label {
-  .touchableText(@standard-type-scale);
   display: flex;
   cursor: pointer;
-  position: relative;
   align-items: center;
 }
 


### PR DESCRIPTION
Last minute changes on padding vs height broke the hidden input focus state which is used in osx voice over. This also makes more sense in that a hidden input does not need a top margin set.