### PR TITLE
Month picker accessibility

### DIFF
--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
@@ -132,7 +132,7 @@ export default class CustomMonthPicker extends Component {
   }
 
   render() {
-    const { value, className, valid, id } = this.props;
+    const { value, className, valid, id, label } = this.props;
     const { month, year } = value;
     const monthValue = String(month || '');
     const yearValue = String(year || '');
@@ -157,7 +157,7 @@ export default class CustomMonthPicker extends Component {
             value: monthValue,
             className: styles.dropdownInput,
             ref: this.storeMonthReference,
-            'aria-label': 'Month'
+            'aria-label': label ? `${label} Month` : 'Month'
           }}
         />
         <Dropdown
@@ -172,7 +172,7 @@ export default class CustomMonthPicker extends Component {
             value: yearValue,
             className: styles.dropdownInput,
             ref: this.storeYearReference,
-            'aria-label': 'Year'
+            'aria-label': label ? `${label} Year` : 'Year'
           }}
         />
       </div>

--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
@@ -157,7 +157,7 @@ export default class CustomMonthPicker extends Component {
             value: monthValue,
             className: styles.dropdownInput,
             ref: this.storeMonthReference,
-            'aria-label': "Month"
+            'aria-label': 'Month'
           }}
         />
         <Dropdown
@@ -172,7 +172,7 @@ export default class CustomMonthPicker extends Component {
             value: yearValue,
             className: styles.dropdownInput,
             ref: this.storeYearReference,
-            'aria-label': "Year"
+            'aria-label': 'Year'
           }}
         />
       </div>

--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
@@ -156,7 +156,8 @@ export default class CustomMonthPicker extends Component {
             onChange: this.handleMonthChange,
             value: monthValue,
             className: styles.dropdownInput,
-            ref: this.storeMonthReference
+            ref: this.storeMonthReference,
+            'aria-label': "Month"
           }}
         />
         <Dropdown
@@ -170,7 +171,8 @@ export default class CustomMonthPicker extends Component {
             onChange: this.handleYearChange,
             value: yearValue,
             className: styles.dropdownInput,
-            ref: this.storeYearReference
+            ref: this.storeYearReference,
+            'aria-label': "Year"
           }}
         />
       </div>

--- a/react/MonthPicker/MonthPicker.demo.js
+++ b/react/MonthPicker/MonthPicker.demo.js
@@ -47,7 +47,7 @@ export default {
   container: MonthPickerContainer,
   initialProps: {
     id: 'startMonth',
-    label: 'Start Month',
+    label: 'Started',
     message: ''
   },
   options: [

--- a/react/MonthPicker/MonthPicker.js
+++ b/react/MonthPicker/MonthPicker.js
@@ -113,13 +113,17 @@ export default class MonthPicker extends Component {
 
     return (
       <div className={classNames}>
-        <FieldLabel
-          {...{ id, label, labelProps, secondaryLabel, tertiaryLabel }}
-        />
-        {this.renderInput()}
-        <FieldMessage
-          {...{ invalid, help, helpProps, valid, message, messageProps }}
-        />
+        <fieldset>
+          <legend>
+            <FieldLabel
+              {...{ id, label, labelProps, secondaryLabel, tertiaryLabel }}
+            />
+          </legend>
+          {this.renderInput()}
+          <FieldMessage
+            {...{ invalid, help, helpProps, valid, message, messageProps }}
+          />
+        </fieldset>
       </div>
     );
   }

--- a/react/MonthPicker/MonthPicker.js
+++ b/react/MonthPicker/MonthPicker.js
@@ -67,7 +67,8 @@ export default class MonthPicker extends Component {
       onBlur,
       minYear,
       maxYear,
-      ascendingYears
+      ascendingYears,
+      label
     } = this.props;
     const monthPickerProps = {
       className: styles.input,
@@ -78,7 +79,8 @@ export default class MonthPicker extends Component {
       valid,
       minYear,
       maxYear,
-      ascendingYears
+      ascendingYears,
+      label
     };
 
     return native ? (
@@ -113,17 +115,13 @@ export default class MonthPicker extends Component {
 
     return (
       <div className={classNames}>
-        <fieldset>
-          <legend>
-            <FieldLabel
-              {...{ id, label, labelProps, secondaryLabel, tertiaryLabel }}
-            />
-          </legend>
-          {this.renderInput()}
-          <FieldMessage
-            {...{ invalid, help, helpProps, valid, message, messageProps }}
-          />
-        </fieldset>
+        <FieldLabel
+          {...{ id, label, labelProps, secondaryLabel, tertiaryLabel }}
+        />
+        {this.renderInput()}
+        <FieldMessage
+          {...{ invalid, help, helpProps, valid, message, messageProps }}
+        />
       </div>
     );
   }

--- a/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.js
+++ b/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.js
@@ -69,7 +69,7 @@ export default class NativeMonthPicker extends Component {
   }
 
   render() {
-    const { value, className, valid, id } = this.props;
+    const { value, className, valid, id, label } = this.props;
 
     const inputValue = makeMonthString(value);
 
@@ -93,7 +93,7 @@ export default class NativeMonthPicker extends Component {
           value={inputValue}
           onChange={this.handleChange}
           onBlur={this.handleBlur}
-          aria-label="Month Year"
+          aria-label={label ? `${label} Month Year` : "Month Year"}
         />
       </div>
     );

--- a/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.js
+++ b/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.js
@@ -93,6 +93,7 @@ export default class NativeMonthPicker extends Component {
           value={inputValue}
           onChange={this.handleChange}
           onBlur={this.handleBlur}
+          aria-label = "Month Year"
         />
       </div>
     );

--- a/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.js
+++ b/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.js
@@ -93,7 +93,7 @@ export default class NativeMonthPicker extends Component {
           value={inputValue}
           onChange={this.handleChange}
           onBlur={this.handleBlur}
-          aria-label = "Month Year"
+          aria-label="Month Year"
         />
       </div>
     );


### PR DESCRIPTION
This hopes to improve screen reader/voice over accessibility for our month picker's. Pretty straight forward that being add aria-label's on each field ('Month' & 'Year') and prefix the label if it exists. Aria-labeling was chosen over fieldset and legend as I feel fieldset and legend is something the consumer should have full control of. Also the aria-label is not read out in OSX as it seems to conflict with something else but it already has a sensible default so the focus really is just when using JAWS.