### PR TITLE
fix(Checkbox): Remove grey tick from checkbox focus styles

### DIFF
--- a/react/Checkbox/Checkbox.less
+++ b/react/Checkbox/Checkbox.less
@@ -83,7 +83,6 @@
   &.checkMarkSvg_isHover {
     fill: @sk-gray-light;
 
-    .input:focus:not(:checked) + .label &,
     .input:hover:not(:checked) + .label & {
       opacity: 1;
     }


### PR DESCRIPTION
Currently, when you untick the checkbox, the hover styles hang around until you blur it. This PR tweaks the styles so that the greyed-out tick is only visible on hover.