### PR TITLE
fix(Radio): Fix dropped click events on elements inside label in IE11

### DIFF
--- a/docs/webpack.dev.config.js
+++ b/docs/webpack.dev.config.js
@@ -16,6 +16,7 @@ const appPaths = [
 
 const config = decorateClientConfig({
   entry: [
+    'core-js/modules/es6.symbol',
     'react-hot-loader/patch',
     'webpack-dev-server/client?http://localhost:3000',
     'webpack/hot/only-dev-server',

--- a/react/Radio/Radio.less
+++ b/react/Radio/Radio.less
@@ -14,12 +14,17 @@
   height: @circumference;
   border: none;
   margin: 0;
+  cursor: pointer;
 }
 
 .label {
   display: flex;
   cursor: pointer;
   align-items: center;
+
+  :global(*) {
+    pointer-events: none;
+  }
 }
 
 .labelText {


### PR DESCRIPTION
Right now, in IE11, clicks on the radio button often fail. Turns out it's because the click event isn't bubbling up to the label correctly. This PR fixes it by disabling pointer events on all children of the label, ensuring that clicks are always registered against the label directly.