### PR TITLE
fix(FormElements): Make id string.isRequired for our form elements

### DIFF
--- a/docs/src/components/Home/Hero/TextFieldPreview/TextFieldPreview.js
+++ b/docs/src/components/Home/Hero/TextFieldPreview/TextFieldPreview.js
@@ -7,9 +7,9 @@ import { TextField } from 'seek-style-guide/react';
 export default function TextFieldPreview() {
   return (
     <div className={styles.root}>
-      <TextField message={false} />
-      <TextField message={false} className={textFieldStyles.rootFocus} />
-      <TextField valid={false} message="Something went wrong" />
+      <TextField id="standard" message={false} />
+      <TextField id="focus" message={false} className={textFieldStyles.rootFocus} />
+      <TextField id="error" valid={false} message="Something went wrong" />
     </div>
   );
 }

--- a/react/Autosuggest/Autosuggest.js
+++ b/react/Autosuggest/Autosuggest.js
@@ -17,7 +17,7 @@ export default class Autosuggest extends Component {
   static displayName = 'Autosuggest';
 
   static propTypes = {
-    id: PropTypes.string,
+    id: PropTypes.string.isRequired,
     inputProps: PropTypes.object.isRequired,
     label: PropTypes.string,
     labelProps: PropTypes.object,
@@ -43,7 +43,6 @@ export default class Autosuggest extends Component {
   };
 
   static defaultProps = {
-    id: '',
     className: '',
     label: '',
     labelProps: {},

--- a/react/Autosuggest/Autosuggest.test.js
+++ b/react/Autosuggest/Autosuggest.test.js
@@ -31,19 +31,19 @@ describe('Autosuggest', () => {
   });
 
   it('should render with simple props', () => {
-    const wrapper = render(<Autosuggest {...getAutosuggestProps()} />);
+    const wrapper = render(<Autosuggest {...getAutosuggestProps()} id="testAutosuggest" />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should render with suggestions', () => {
-    const wrapper = render(<Autosuggest {...getAutosuggestProps(['test', 'test 2'])} />);
+    const wrapper = render(<Autosuggest {...getAutosuggestProps(['test', 'test 2'])} id="testAutosuggest" />);
     const suggestions = wrapper.find('.suggestionsContainer').find('li');
     expect(wrapper).toMatchSnapshot();
     expect(suggestions.length).toEqual(2);
   });
 
   it('should render with label', () => {
-    const wrapper = render(<Autosuggest {...getAutosuggestProps()} id="Foo" label="Foo" />);
+    const wrapper = render(<Autosuggest {...getAutosuggestProps()} id="testAutosuggest" label="Foo" />);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -53,13 +53,13 @@ describe('Autosuggest', () => {
       className: 'LABEL_TEST_CLASS'
     };
 
-    const wrapper = render(<Autosuggest {...props} id="Foo" label="Foo" showMobileBackdrop />);
+    const wrapper = render(<Autosuggest {...props} id="testAutosuggest" label="Foo" showMobileBackdrop />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should error if `suggestionsContainerClassName` is not a string', () => {
     const expectedError = expect.stringMatching(/Invalid prop `suggestionsContainerClassName` of type `boolean` supplied to `Autosuggest`, expected `string/);
-    render(<Autosuggest {...getAutosuggestProps()} suggestionsContainerClassName={true} />);
+    render(<Autosuggest {...getAutosuggestProps()} id="testAutosuggest" suggestionsContainerClassName={true} />);
 
     expect(spy).toBeCalledWith(expectedError);
   });
@@ -71,12 +71,12 @@ describe('Autosuggest', () => {
     };
     const expectedError = expect.stringMatching(/`suggestionsContainerClassName` will be overridden by the `suggestionsContainer` class in autosuggestProps `theme`. Please remove it./);
 
-    render(<Autosuggest {...props} suggestionsContainerClassName="TEST 2" />);
+    render(<Autosuggest {...props} id="testAutosuggest" suggestionsContainerClassName="TEST 2" />);
     expect(spy).toBeCalledWith(expectedError);
   });
 
   it('should focus field when suggestion is clicked', () => {
-    const wrapper = mount(<Autosuggest {...getAutosuggestProps(['test', 'test 2'])} />);
+    const wrapper = mount(<Autosuggest {...getAutosuggestProps(['test', 'test 2'])} id="testAutosuggest" />);
     const firstSuggestion = wrapper.find('li').first();
     const input = wrapper.find('input').html();
     firstSuggestion.simulate('click');

--- a/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
+++ b/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
@@ -8,7 +8,7 @@ exports[`Autosuggest should render with label 1`] = `
     >
       <label
         class=""
-        for="Foo"
+        for="testAutosuggest"
       >
         <span
           class="root standard baseline"
@@ -31,7 +31,7 @@ exports[`Autosuggest should render with label 1`] = `
         aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
-        id="Foo"
+        id="testAutosuggest"
         role="combobox"
         type="text"
         value=""
@@ -72,7 +72,7 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
     >
       <label
         class="isLabelCoveredWithBackdrop LABEL_TEST_CLASS"
-        for="Foo"
+        for="testAutosuggest"
       >
         <span
           class="root standard baseline"
@@ -95,7 +95,7 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
         aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
-        id="Foo"
+        id="testAutosuggest"
         role="combobox"
         type="text"
         value=""
@@ -140,6 +140,7 @@ exports[`Autosuggest should render with simple props 1`] = `
         aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
+        id="testAutosuggest"
         role="combobox"
         type="text"
         value=""
@@ -184,6 +185,7 @@ exports[`Autosuggest should render with suggestions 1`] = `
         aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
+        id="testAutosuggest"
         role="combobox"
         type="text"
         value=""

--- a/react/Checkbox/Checkbox.js
+++ b/react/Checkbox/Checkbox.js
@@ -66,10 +66,10 @@ export default class Checkbox extends Component {
   }
 
   renderLabel() {
-    const { label, id, type } = this.props;
+    const { id, label, type } = this.props;
 
     return (
-      <label className={styles.label} htmlFor={id}>
+      <label htmlFor={id} className={styles.label}>
         {
           type === STANDARD ?
             this.renderStandard(label) :
@@ -80,12 +80,12 @@ export default class Checkbox extends Component {
   }
 
   renderInput() {
-    const { inputProps, id } = this.props;
+    const { id, inputProps } = this.props;
 
     const allInputProps = {
+      id,
       ...combineClassNames(inputProps, styles.input),
-      type: 'checkbox',
-      id
+      type: 'checkbox'
     };
 
     return (

--- a/react/Checkbox/Checkbox.test.js
+++ b/react/Checkbox/Checkbox.test.js
@@ -5,7 +5,7 @@ import Checkbox from './Checkbox';
 
 describe('Checkbox', () => {
   const requiredProps = {
-    id: 'still-in-role',
+    id: 'testCheckbox',
     label: 'Still in role'
   };
 

--- a/react/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/react/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -7,12 +7,12 @@ exports[`Checkbox inputProps should pass through other props to the input 1`] = 
   <input
     className="input"
     data-automation="first-name-field"
-    id="still-in-role"
+    id="testCheckbox"
     type="checkbox"
   />
   <label
     className="label"
-    htmlFor="still-in-role"
+    htmlFor="testCheckbox"
   >
     <div
       className="standard"
@@ -44,12 +44,12 @@ exports[`Checkbox inputProps should render as checked 1`] = `
   <input
     checked={true}
     className="input"
-    id="still-in-role"
+    id="testCheckbox"
     type="checkbox"
   />
   <label
     className="label"
-    htmlFor="still-in-role"
+    htmlFor="testCheckbox"
   >
     <div
       className="standard"
@@ -81,12 +81,12 @@ exports[`Checkbox should render with button style 1`] = `
   <input
     checked={false}
     className="input"
-    id="still-in-role"
+    id="testCheckbox"
     type="checkbox"
   />
   <label
     className="label"
-    htmlFor="still-in-role"
+    htmlFor="testCheckbox"
   >
     <span
       className="button"
@@ -104,12 +104,12 @@ exports[`Checkbox should render with className 1`] = `
   <input
     checked={false}
     className="input"
-    id="still-in-role"
+    id="testCheckbox"
     type="checkbox"
   />
   <label
     className="label"
-    htmlFor="still-in-role"
+    htmlFor="testCheckbox"
   >
     <div
       className="standard"
@@ -141,12 +141,12 @@ exports[`Checkbox should render with simple props 1`] = `
   <input
     checked={false}
     className="input"
-    id="still-in-role"
+    id="testCheckbox"
     type="checkbox"
   />
   <label
     className="label"
-    htmlFor="still-in-role"
+    htmlFor="testCheckbox"
   >
     <div
       className="standard"
@@ -178,12 +178,12 @@ exports[`Checkbox should render with standard checkbox style 1`] = `
   <input
     checked={false}
     className="input"
-    id="still-in-role"
+    id="testCheckbox"
     type="checkbox"
   />
   <label
     className="label"
-    htmlFor="still-in-role"
+    htmlFor="testCheckbox"
   >
     <div
       className="standard"

--- a/react/Dropdown/Dropdown.js
+++ b/react/Dropdown/Dropdown.js
@@ -23,15 +23,7 @@ export default class Dropdown extends Component {
   static displayName = 'Dropdown';
 
   static propTypes = {
-    /* eslint-disable consistent-return */
-    id: (props, propName, componentName) => {
-      const { id } = props;
-
-      if (typeof id !== 'string') {
-        return new Error(`Invalid prop \`id\` of type \`${typeof id}\` supplied to \`${componentName}\`, expected \`string\`.`);
-      }
-    },
-    /* eslint-enable consistent-return */
+    id: PropTypes.string.isRequired,
     className: PropTypes.string,
     valid: PropTypes.bool,
     /* eslint-disable consistent-return */
@@ -68,7 +60,6 @@ export default class Dropdown extends Component {
   };
 
   static defaultProps = {
-    id: '',
     className: '',
     placeholder: '',
     options: []
@@ -89,14 +80,14 @@ export default class Dropdown extends Component {
     </option>);
   }
   renderSelect() {
-    const { inputProps, id, options, placeholder } = this.props;
+    const { id, inputProps, options, placeholder } = this.props;
     const inputStyles = classnames({
       [styles.dropdown]: true,
       [styles.placeholderSelected]: !inputProps.value
     });
     const allInputProps = {
-      ...combineClassNames(inputProps, inputStyles),
-      ...(id ? { id } : {})
+      id,
+      ...combineClassNames(inputProps, inputStyles)
     };
 
     return (
@@ -130,7 +121,7 @@ export default class Dropdown extends Component {
   }
 
   render() {
-    const { className, valid } = this.props;
+    const { id, className, valid } = this.props;
     const classNames = classnames({
       [styles.root]: true,
       [styles.invalid]: valid === false,
@@ -138,7 +129,7 @@ export default class Dropdown extends Component {
     });
 
     // eslint-disable-next-line react/prop-types
-    const { id, label, labelProps, secondaryLabel, tertiaryLabel, invalid, help, helpProps, message, messageProps } = this.props;
+    const { label, labelProps, secondaryLabel, tertiaryLabel, invalid, help, helpProps, message, messageProps } = this.props;
 
     return (
       <div className={classNames}>

--- a/react/Dropdown/Dropdown.test.js
+++ b/react/Dropdown/Dropdown.test.js
@@ -54,13 +54,13 @@ describe('Dropdown', () => {
   }
 
   it('should have a displayName', () => {
-    render(<Dropdown inputProps={{ value: '' }} />);
+    render(<Dropdown id="testDropdown" inputProps={{ value: '' }} />);
     expect(element.type.displayName).to.equal('Dropdown');
   });
 
   describe('id', () => {
     it('should error if `id` is not a string', () => {
-      render(<Dropdown inputProps={{ value: '' }} id={true} />);
+      render(<Dropdown id={true} inputProps={{ value: '' }} />);
       expect(errors[0]).to.match(/Invalid prop `id`/);
     });
   });
@@ -68,7 +68,7 @@ describe('Dropdown', () => {
   describe('options', () => {
     const opt = [{ label: 'suburbs', value: '3130' }];
     it('should render options correctly', () => {
-      render(<Dropdown inputProps={{ value: '' }} options={opt} />);
+      render(<Dropdown id="testDropdown" inputProps={{ value: '' }} options={opt} />);
       expect(option.props.value).to.equal('3130');
     });
   });
@@ -76,7 +76,7 @@ describe('Dropdown', () => {
   describe('Option Group', () => {
     beforeAll(() => {
       const opts = [{ label: 'suburbs', value: [{ label: 'truganina', value: '3029' }, { label: 'wl', value: '3029' }] }];
-      render(<Dropdown inputProps={{ value: '' }} options={opts} />);
+      render(<Dropdown id="testDropdown" inputProps={{ value: '' }} options={opts} />);
     });
     it('should render optgroup correctly', () => {
       expect(optionGroup.props.label).to.equal('suburbs');
@@ -92,48 +92,41 @@ describe('Dropdown', () => {
     });
   });
 
-  describe('input', () => {
-    it('should not have an `id` if it is not specified', () => {
-      render(<Dropdown inputProps={{ value: '' }} />);
-      expect(input.props).not.to.include.keys('id');
-    });
-  });
-
   describe('placeholder', () => {
     it('should render placeholder as first option in list ', () => {
-      render(<Dropdown inputProps={{ value: '' }} options={options} placeholder="test" />);
+      render(<Dropdown id="testDropdown" inputProps={{ value: '' }} options={options} placeholder="test" />);
       expect(placeholderText()).to.equal('test');
     });
   });
 
   describe('inputProps', () => {
     it('should error if `inputProps` is not an object', () => {
-      render(<Dropdown inputProps="hey" />);
+      render(<Dropdown id="testDropdown" inputProps="hey" />);
       expect(errors[0]).to.match(/Invalid prop `inputProps`/);
     });
 
     it('should error if `inputProps.value` is not supplied', () => {
-      render(<Dropdown inputProps={{}} />);
+      render(<Dropdown id="testDropdown" inputProps={{}} />);
       expect(errors[0]).to.match(/Invalid prop `inputProps.value` of type `undefined` supplied to `Dropdown`, expected `string`/);
     });
 
     it('should error if `inputProps.value` is not a string', () => {
-      render(<Dropdown inputProps={{ value: 2 }} />);
+      render(<Dropdown id="testDropdown" inputProps={{ value: 2 }} />);
       expect(errors[0]).to.match(/Invalid prop `inputProps.value` of type `number` supplied to `Dropdown`, expected `string`/);
     });
 
     it('should error if `inputProps`\'s `id` is specified', () => {
-      render(<Dropdown id="firstName" inputProps={{ id: 'ignored', value: '' }} />);
+      render(<Dropdown id="testDropdown" inputProps={{ id: 'ignored', value: '' }} />);
       expect(errors[0]).to.match(/`inputProps.id` will be overridden by `id`/);
     });
 
     it('should pass through className to the input', () => {
-      render(<Dropdown inputProps={{ className: 'first-name-field' }} />);
+      render(<Dropdown id="testDropdown" inputProps={{ className: 'first-name-field' }} />);
       expect(input.props.className).to.match(/first-name-field$/);
     });
 
     it('should pass through other props to the input', () => {
-      render(<Dropdown inputProps={{ id: 'firstName', 'data-automation': 'first-name-field' }} />);
+      render(<Dropdown id="testDropdown" inputProps={{ id: 'firstName', 'data-automation': 'first-name-field' }} />);
       expect(input.props.id).to.equal('firstName');
       expect(input.props['data-automation']).to.equal('first-name-field');
     });
@@ -142,7 +135,7 @@ describe('Dropdown', () => {
   describe('valid', () => {
     describe('set to false', () => {
       it('Dropdown should have the invalid className', () => {
-        render(<Dropdown inputProps={{ value: '' }} valid={false} />);
+        render(<Dropdown id="testDropdown" inputProps={{ value: '' }} valid={false} />);
         expect(dropdown.props.className).to.contain('invalid');
       });
     });

--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
@@ -28,6 +28,7 @@ export default class CustomMonthPicker extends Component {
   static displayName = 'CustomMonthPicker';
 
   static propTypes = {
+    id: PropTypes.string.isRequired,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
     value: PropTypes.shape({
@@ -35,7 +36,6 @@ export default class CustomMonthPicker extends Component {
       year: PropTypes.number
     }),
     valid: PropTypes.bool,
-    id: PropTypes.string,
     minYear: PropTypes.number.isRequired,
     maxYear: PropTypes.number.isRequired,
     ascendingYears: PropTypes.bool.isRequired
@@ -131,7 +131,7 @@ export default class CustomMonthPicker extends Component {
   }
 
   render() {
-    const { value, valid, id } = this.props;
+    const { id, value, valid } = this.props;
     // eslint-disable-next-line react/prop-types
     const { label, labelProps, secondaryLabel, tertiaryLabel } = this.props;
 
@@ -143,7 +143,7 @@ export default class CustomMonthPicker extends Component {
       <div>
         <FieldLabel
           {...{
-            ...(id ? { id: `${id}-month` } : {}),
+            id: `${id}-month`,
             label: <span>{label}<ScreenReaderOnly> Month</ScreenReaderOnly></span>,
             labelProps,
             secondaryLabel,
@@ -152,7 +152,7 @@ export default class CustomMonthPicker extends Component {
         />
         <FieldLabel
           {...{
-            ...(id ? { id: `${id}-year` } : {}),
+            id: `${id}-year`,
             label: <ScreenReaderOnly>{label} Year</ScreenReaderOnly>,
             raw: true
           }}
@@ -160,7 +160,7 @@ export default class CustomMonthPicker extends Component {
 
         <div className={styles.dropdownWrapper}>
           <Dropdown
-            {...(id ? { id: `${id}-month` } : {})}
+            id={`${id}-month`}
             options={months}
             className={styles.dropdown}
             valid={valid}
@@ -175,7 +175,7 @@ export default class CustomMonthPicker extends Component {
           />
 
           <Dropdown
-            {...(id ? { id: `${id}-year` } : {})}
+            id={`${id}-year`}
             options={this.yearOptions}
             className={styles.dropdown}
             valid={valid}

--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.test.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.test.js
@@ -50,17 +50,17 @@ describe('CustomMonthPicker', () => {
   }
 
   it('should have a displayName', () => {
-    render(<CustomMonthPicker />);
+    render(<CustomMonthPicker id="testCustomMonthPicker" />);
     expect(element.type.displayName).to.equal('CustomMonthPicker');
   });
 
   it('should render without exploding', () => {
-    render(<CustomMonthPicker />);
+    render(<CustomMonthPicker id="testCustomMonthPicker" />);
     expect(errors.length).to.equal(0);
   });
 
   it('should send valid prop to false to both dropdowns when valid is false', () => {
-    render(<CustomMonthPicker valid={false} />);
+    render(<CustomMonthPicker id="testCustomMonthPicker" valid={false} />);
     expect(monthDropdown.props.valid).to.equal(false);
     expect(yearDropdown.props.valid).to.equal(false);
   });
@@ -71,6 +71,7 @@ describe('CustomMonthPicker', () => {
     };
     renderToDom(
       <CustomMonthPicker
+        id="testCustomMonthPicker"
         minYear={2000}
         maxYear={2010}
         onChange={onChange}
@@ -91,6 +92,7 @@ describe('CustomMonthPicker', () => {
     };
     renderToDom(
       <CustomMonthPicker
+        id="testCustomMonthPicker"
         minYear={1990}
         maxYear={2010}
         onChange={onChange}

--- a/react/MonthPicker/MonthPicker.js
+++ b/react/MonthPicker/MonthPicker.js
@@ -16,18 +16,8 @@ export default class MonthPicker extends Component {
   static displayName = 'MonthPicker';
 
   static propTypes = {
-    /* eslint-disable consistent-return */
-    id: (props, propName, componentName) => {
-      const { id } = props;
-
-      if (typeof id !== 'string') {
-        return new Error(
-          `Invalid prop \`id\` of type \`${typeof id}\` supplied to \`${componentName}\`, expected \`string\`.`
-        );
-      }
-    },
+    id: PropTypes.string.isRequired,
     className: PropTypes.string,
-    /* eslint-enable consistent-return */
     valid: PropTypes.bool,
     value: PropTypes.shape({
       month: PropTypes.number,
@@ -42,7 +32,6 @@ export default class MonthPicker extends Component {
   };
 
   static defaultProps = {
-    id: '',
     className: '',
     native: false,
     maxYear: currYear,
@@ -72,7 +61,7 @@ export default class MonthPicker extends Component {
     const { label, labelProps, secondaryLabel, tertiaryLabel } = this.props;
 
     const monthPickerProps = {
-      ...(id ? { id } : {}),
+      id,
       value,
       onChange,
       onBlur,

--- a/react/MonthPicker/MonthPicker.test.js
+++ b/react/MonthPicker/MonthPicker.test.js
@@ -30,7 +30,7 @@ describe('MonthPicker', () => {
   }
 
   it('should have a displayName', () => {
-    render(<MonthPicker />);
+    render(<MonthPicker id="testMonthPicker" />);
     expect(element.type.displayName).to.equal('MonthPicker');
   });
 
@@ -43,12 +43,12 @@ describe('MonthPicker', () => {
 
   describe('input', () => {
     it('should render the `CustomMonthPicker` when native is not set', () => {
-      render(<MonthPicker />);
+      render(<MonthPicker id="testMonthPicker" />);
       expect(monthPicker.type.displayName).to.equal('CustomMonthPicker');
     });
 
     it('should render the `NativeMonthPicker` when native is true', () => {
-      render(<MonthPicker native={true} />);
+      render(<MonthPicker id="testMonthPicker" native={true} />);
       expect(monthPicker.type.displayName).to.equal('NativeMonthPicker');
     });
   });
@@ -56,7 +56,7 @@ describe('MonthPicker', () => {
   describe('onChange', () => {
     it('should pass onChange prop through to input', () => {
       const onChange = () => {};
-      render(<MonthPicker onChange={onChange} />);
+      render(<MonthPicker id="testMonthPicker" onChange={onChange} />);
       expect(monthPicker.props.onChange).to.equal(onChange);
     });
   });
@@ -64,7 +64,7 @@ describe('MonthPicker', () => {
   describe('onBlur', () => {
     it('should pass onBlur prop through to input', () => {
       const onBlur = () => {};
-      render(<MonthPicker onBlur={onBlur} />);
+      render(<MonthPicker id="testMonthPicker" onBlur={onBlur} />);
       expect(monthPicker.props.onBlur).to.equal(onBlur);
     });
   });
@@ -72,7 +72,7 @@ describe('MonthPicker', () => {
   describe('value', () => {
     it('should pass value prop through to input', () => {
       const value = { month: 1, year: 2000 };
-      render(<MonthPicker value={value} />);
+      render(<MonthPicker id="testMonthPicker" value={value} />);
       expect(monthPicker.props.value).to.equal(value);
     });
   });

--- a/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.js
+++ b/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.js
@@ -32,14 +32,14 @@ export default class NativeMonthPicker extends Component {
   static displayName = 'NativeMonthPicker';
 
   static propTypes = {
+    id: PropTypes.string.isRequired,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
     value: PropTypes.shape({
       month: PropTypes.number,
       year: PropTypes.number
     }),
-    valid: PropTypes.bool,
-    id: PropTypes.string
+    valid: PropTypes.bool
   };
 
   static defaultProps = {
@@ -70,7 +70,7 @@ export default class NativeMonthPicker extends Component {
   }
 
   render() {
-    const { value, valid, id } = this.props;
+    const { id, value, valid } = this.props;
     // eslint-disable-next-line react/prop-types
     const { label, labelProps, secondaryLabel, tertiaryLabel } = this.props;
 
@@ -85,7 +85,7 @@ export default class NativeMonthPicker extends Component {
       <div className={rootClasses}>
         <FieldLabel
           {...{
-            ...(id ? { id } : {}),
+            id,
             label: <span>{label}<ScreenReaderOnly> Month Year</ScreenReaderOnly></span>,
             labelProps,
             secondaryLabel,
@@ -98,7 +98,7 @@ export default class NativeMonthPicker extends Component {
           direction="down"
         />
         <input
-          {...(id ? { id } : {})}
+          id={id}
           className={styles.input}
           type="month"
           value={inputValue}

--- a/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.test.js
+++ b/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.test.js
@@ -44,22 +44,22 @@ describe('NativeMonthPicker', () => {
   }
 
   it('should have a displayName', () => {
-    render(<NativeMonthPicker />);
+    render(<NativeMonthPicker id="testNativeMonthPicker" />);
     expect(element.type.displayName).to.equal('NativeMonthPicker');
   });
 
   it('should render without exploding', () => {
-    render(<NativeMonthPicker />);
+    render(<NativeMonthPicker id="testNativeMonthPicker" />);
     expect(errors.length).to.equal(0);
   });
 
   it('should assign invalid className when valid is false', () => {
-    render(<NativeMonthPicker valid={false} />);
+    render(<NativeMonthPicker id="testNativeMonthPicker" valid={false} />);
     expect(rootElement.props.className).to.contain('invalid');
   });
 
   it('should convert monthValue & yearValue to generic month string', () => {
-    render(<NativeMonthPicker value={{ month: 1, year: 2016 }} />);
+    render(<NativeMonthPicker id="testNativeMonthPicker" value={{ month: 1, year: 2016 }} />);
     expect(input.props.value).to.equal('2016-01');
   });
 
@@ -67,7 +67,7 @@ describe('NativeMonthPicker', () => {
     const onChange = newValue => {
       value = newValue;
     };
-    renderToDom(<NativeMonthPicker onChange={onChange} value={{ month: 6, year: 2010 }} />);
+    renderToDom(<NativeMonthPicker id="testNativeMonthPicker" onChange={onChange} value={{ month: 6, year: 2010 }} />);
     input.value = '2012-11';
     Simulate.change(input);
     expect(value).to.deep.equal({
@@ -80,7 +80,7 @@ describe('NativeMonthPicker', () => {
     const onBlur = newValue => {
       value = newValue;
     };
-    renderToDom(<NativeMonthPicker onBlur={onBlur} value={{ month: 6, year: 2010 }} />);
+    renderToDom(<NativeMonthPicker id="testNativeMonthPicker" onBlur={onBlur} value={{ month: 6, year: 2010 }} />);
     input.value = '2012-11';
     Simulate.blur(input);
     expect(value).to.deep.equal({

--- a/react/Radio/Radio.js
+++ b/react/Radio/Radio.js
@@ -19,10 +19,10 @@ export default class Radio extends Component {
   static displayName = 'Radio';
 
   static propTypes = {
+    id: PropTypes.string.isRequired,
     className: PropTypes.string,
     label: PropTypes.string,
     labelProps: PropTypes.object,
-    id: PropTypes.string.isRequired,
     inputProps: PropTypes.object
   };
 
@@ -33,11 +33,11 @@ export default class Radio extends Component {
   };
 
   renderInput() {
-    const { inputProps, id } = this.props;
+    const { id, inputProps } = this.props;
     const allInputProps = {
+      id,
       ...combineClassNames(inputProps, styles.input),
-      type: 'radio',
-      id
+      type: 'radio'
     };
 
     return <input {...allInputProps} />;
@@ -46,8 +46,8 @@ export default class Radio extends Component {
   renderLabel() {
     const { label, labelProps, id } = this.props;
     const allLabelProps = {
-      ...combineClassNames(labelProps, styles.label),
-      htmlFor: id
+      htmlFor: id,
+      ...combineClassNames(labelProps, styles.label)
     };
 
     return (

--- a/react/Radio/Radio.test.js
+++ b/react/Radio/Radio.test.js
@@ -5,7 +5,7 @@ import Radio from './Radio';
 
 describe('Radio', () => {
   const requiredProps = {
-    id: 'still-in-role',
+    id: 'testRadio',
     label: 'Still in role'
   };
 

--- a/react/Radio/__snapshots__/Radio.test.js.snap
+++ b/react/Radio/__snapshots__/Radio.test.js.snap
@@ -7,12 +7,12 @@ exports[`Radio inputProps should pass through other props to the input 1`] = `
   <input
     className="input"
     data-automation="first-name-field"
-    id="still-in-role"
+    id="testRadio"
     type="radio"
   />
   <label
     className="label"
-    htmlFor="still-in-role"
+    htmlFor="testRadio"
   >
     <svg
       className="svg"
@@ -51,12 +51,12 @@ exports[`Radio inputProps should render as checked 1`] = `
   <input
     checked={true}
     className="input"
-    id="still-in-role"
+    id="testRadio"
     type="radio"
   />
   <label
     className="label"
-    htmlFor="still-in-role"
+    htmlFor="testRadio"
   >
     <svg
       className="svg"
@@ -94,12 +94,12 @@ exports[`Radio should render with className 1`] = `
 >
   <input
     className="input"
-    id="still-in-role"
+    id="testRadio"
     type="radio"
   />
   <label
     className="label"
-    htmlFor="still-in-role"
+    htmlFor="testRadio"
   >
     <svg
       className="svg"
@@ -137,12 +137,12 @@ exports[`Radio should render with simple props 1`] = `
 >
   <input
     className="input"
-    id="still-in-role"
+    id="testRadio"
     type="radio"
   />
   <label
     className="label"
-    htmlFor="still-in-role"
+    htmlFor="testRadio"
   >
     <svg
       className="svg"

--- a/react/SlideToggle/SlideToggle.js
+++ b/react/SlideToggle/SlideToggle.js
@@ -48,9 +48,9 @@ export default class SlideToggle extends Component {
     return (
       <div className={classnames(styles.root, className)}>
         <input
+          id={id}
           ref={this.storeInputRef}
           type="checkbox"
-          id={id}
           aria-label={label}
           className={inputStyles}
           checked={checked}

--- a/react/SlideToggle/SlideToggle.test.js
+++ b/react/SlideToggle/SlideToggle.test.js
@@ -5,7 +5,7 @@ import SlideToggle from './SlideToggle';
 
 const renderSlideToggle = (props, children) => shallow(
   <SlideToggle
-    id="testToggle"
+    id="testSlideToggle"
     label="Test toggle"
     {...props}>
     {children}

--- a/react/SlideToggle/__snapshots__/SlideToggle.test.js.snap
+++ b/react/SlideToggle/__snapshots__/SlideToggle.test.js.snap
@@ -8,12 +8,12 @@ exports[`Slide toggle: should render a checked state 1`] = `
     aria-label="Test toggle"
     checked={true}
     className="input"
-    id="testToggle"
+    id="testSlideToggle"
     type="checkbox"
   />
   <label
     className="switch"
-    htmlFor="testToggle"
+    htmlFor="testSlideToggle"
   >
     <div
       className="slideContainer"
@@ -42,12 +42,12 @@ exports[`Slide toggle: should render with default props 1`] = `
   <input
     aria-label="Test toggle"
     className="input"
-    id="testToggle"
+    id="testSlideToggle"
     type="checkbox"
   />
   <label
     className="switch"
-    htmlFor="testToggle"
+    htmlFor="testSlideToggle"
   >
     <div
       className="slideContainer"
@@ -76,12 +76,12 @@ exports[`Slide toggle: should render with the label hidden 1`] = `
   <input
     aria-label="Test toggle"
     className="input"
-    id="testToggle"
+    id="testSlideToggle"
     type="checkbox"
   />
   <label
     className="switch"
-    htmlFor="testToggle"
+    htmlFor="testSlideToggle"
   >
     <div
       className="slideContainer"
@@ -105,12 +105,12 @@ exports[`Slide toggle: should render with the label on the left 1`] = `
   <input
     aria-label="Test toggle"
     className="input inputLeft"
-    id="testToggle"
+    id="testSlideToggle"
     type="checkbox"
   />
   <label
     className="switch"
-    htmlFor="testToggle"
+    htmlFor="testSlideToggle"
   >
     <span
       className="labelText labelLeft"

--- a/react/TextField/TextField.js
+++ b/react/TextField/TextField.js
@@ -32,15 +32,7 @@ export default class TextField extends Component {
   static displayName = 'TextField';
 
   static propTypes = {
-    /* eslint-disable consistent-return */
-    id: (props, propName, componentName) => {
-      const { id } = props;
-
-      if (typeof id !== 'string') {
-        return new Error(`Invalid prop \`id\` of type \`${typeof id}\` supplied to \`${componentName}\`, expected \`string\`.`);
-      }
-    },
-    /* eslint-enable consistent-return */
+    id: PropTypes.string.isRequired,
     className: PropTypes.string,
     valid: PropTypes.bool,
     /* eslint-disable consistent-return */
@@ -61,7 +53,6 @@ export default class TextField extends Component {
   };
 
   static defaultProps = {
-    id: '',
     className: ''
   };
 
@@ -92,11 +83,11 @@ export default class TextField extends Component {
   }
 
   renderInput() {
-    const { inputProps = {}, id } = this.props;
+    const { id, inputProps = {} } = this.props;
     const { ref } = inputProps;
     const allInputProps = {
+      id,
       ...combineClassNames(inputProps, styles.input),
-      ...(id ? { id } : {}),
       ref: attachRefs(this.storeInputReference, ref)
     };
 
@@ -116,7 +107,7 @@ export default class TextField extends Component {
   }
 
   render() {
-    const { className, valid, onClear, inputProps = {} } = this.props;
+    const { id, className, valid, onClear, inputProps = {} } = this.props;
     const hasValue = (inputProps.value && inputProps.value.length > 0);
     const canClear = hasValue && (typeof onClear === 'function');
     const classNames = classnames({
@@ -127,7 +118,7 @@ export default class TextField extends Component {
     });
 
     // eslint-disable-next-line react/prop-types
-    const { id, label, labelProps, secondaryLabel, tertiaryLabel, invalid, help, helpProps, message, messageProps } = this.props;
+    const { label, labelProps, secondaryLabel, tertiaryLabel, invalid, help, helpProps, message, messageProps } = this.props;
 
     return (
       <div ref={this.storeContainerReference} className={classNames}>

--- a/react/TextField/TextField.test.js
+++ b/react/TextField/TextField.test.js
@@ -14,7 +14,7 @@ describe('TextField', () => {
   });
 
   it('should render with defaults', () => {
-    expect(shallow(<TextField />)).toMatchSnapshot();
+    expect(shallow(<TextField id="testTextField" />)).toMatchSnapshot();
   });
 
   describe('errors', () => {
@@ -32,7 +32,7 @@ describe('TextField', () => {
         /Invalid prop `inputProps`/
       );
 
-      shallow(<TextField inputProps="hey" />);
+      shallow(<TextField id="testTextField" inputProps="hey" />);
       expect(spy).toBeCalledWith(expectedError);
     });
 
@@ -49,41 +49,41 @@ describe('TextField', () => {
   it('should render with input props', () => {
     expect(shallow(
       <TextField
+        id="testTextField"
         inputProps={{
           className: 'first-name-field',
-          id: 'firstName',
           'data-automation': 'first-name-field'
         }}
       />)).toMatchSnapshot();
   });
 
   it('should render with valid false', () => {
-    expect(shallow(<TextField valid={false} />)).toMatchSnapshot();
+    expect(shallow(<TextField id="testTextField" valid={false} />)).toMatchSnapshot();
   });
 
   describe('clear button', () => {
     const handleClear = () => {};
 
     it('should not be visible when value is empty', () => {
-      expect(shallow(<TextField inputProps={{ value: '' }} onClear={handleClear} />)).toMatchSnapshot();
+      expect(shallow(<TextField id="testTextField" inputProps={{ value: '' }} onClear={handleClear} />)).toMatchSnapshot();
     });
 
     it('should not be visible when value is provided but no clear handler', () => {
-      expect(shallow(<TextField inputProps={{ value: 'abc' }} />)).toMatchSnapshot();
+      expect(shallow(<TextField id="testTextField" inputProps={{ value: 'abc' }} />)).toMatchSnapshot();
     });
 
     it('should be visible when value is provided', () => {
-      expect(shallow(<TextField inputProps={{ value: 'abc' }} onClear={handleClear} />)).toMatchSnapshot();
+      expect(shallow(<TextField id="testTextField" inputProps={{ value: 'abc' }} onClear={handleClear} />)).toMatchSnapshot();
     });
 
     it('should be visible when value has white spaces only', () => {
-      expect(shallow(<TextField inputProps={{ value: '  ' }} onClear={handleClear} />)).toMatchSnapshot();
+      expect(shallow(<TextField id="testTextField" inputProps={{ value: '  ' }} onClear={handleClear} />)).toMatchSnapshot();
     });
 
     it('should invoke the clear handler when clicked and focus on input', () => {
       const clickHandlerSpy = jest.fn();
 
-      const wrapper = mount(<TextField onClear={clickHandlerSpy} />);
+      const wrapper = mount(<TextField id="testTextField" onClear={clickHandlerSpy} />);
       const input = wrapper.find('input').html();
       const clearButton = wrapper.find('.clearField');
 

--- a/react/TextField/__snapshots__/TextField.test.js.snap
+++ b/react/TextField/__snapshots__/TextField.test.js.snap
@@ -5,7 +5,7 @@ exports[`TextField clear button should be visible when value has white spaces on
   className="root canClear"
 >
   <FieldLabel
-    id=""
+    id="testTextField"
     label=""
     raw={false}
     secondaryLabel=""
@@ -13,6 +13,7 @@ exports[`TextField clear button should be visible when value has white spaces on
   />
   <input
     className="input"
+    id="testTextField"
     value="  "
   />
   <span
@@ -39,7 +40,7 @@ exports[`TextField clear button should be visible when value is provided 1`] = `
   className="root canClear"
 >
   <FieldLabel
-    id=""
+    id="testTextField"
     label=""
     raw={false}
     secondaryLabel=""
@@ -47,6 +48,7 @@ exports[`TextField clear button should be visible when value is provided 1`] = `
   />
   <input
     className="input"
+    id="testTextField"
     value="abc"
   />
   <span
@@ -73,7 +75,7 @@ exports[`TextField clear button should not be visible when value is empty 1`] = 
   className="root"
 >
   <FieldLabel
-    id=""
+    id="testTextField"
     label=""
     raw={false}
     secondaryLabel=""
@@ -81,6 +83,7 @@ exports[`TextField clear button should not be visible when value is empty 1`] = 
   />
   <input
     className="input"
+    id="testTextField"
     value=""
   />
   <span
@@ -107,7 +110,7 @@ exports[`TextField clear button should not be visible when value is provided but
   className="root"
 >
   <FieldLabel
-    id=""
+    id="testTextField"
     label=""
     raw={false}
     secondaryLabel=""
@@ -115,6 +118,7 @@ exports[`TextField clear button should not be visible when value is provided but
   />
   <input
     className="input"
+    id="testTextField"
     value="abc"
   />
   <span
@@ -141,7 +145,7 @@ exports[`TextField should render with defaults 1`] = `
   className="root"
 >
   <FieldLabel
-    id=""
+    id="testTextField"
     label=""
     raw={false}
     secondaryLabel=""
@@ -149,6 +153,7 @@ exports[`TextField should render with defaults 1`] = `
   />
   <input
     className="input"
+    id="testTextField"
   />
   <span
     className="clearField"
@@ -174,7 +179,7 @@ exports[`TextField should render with input props 1`] = `
   className="root"
 >
   <FieldLabel
-    id=""
+    id="testTextField"
     label=""
     raw={false}
     secondaryLabel=""
@@ -183,7 +188,7 @@ exports[`TextField should render with input props 1`] = `
   <input
     className="input first-name-field"
     data-automation="first-name-field"
-    id="firstName"
+    id="testTextField"
   />
   <span
     className="clearField"
@@ -209,7 +214,7 @@ exports[`TextField should render with valid false 1`] = `
   className="root invalid"
 >
   <FieldLabel
-    id=""
+    id="testTextField"
     label=""
     raw={false}
     secondaryLabel=""
@@ -217,6 +222,7 @@ exports[`TextField should render with valid false 1`] = `
   />
   <input
     className="input"
+    id="testTextField"
   />
   <span
     className="clearField"

--- a/react/Textarea/Textarea.js
+++ b/react/Textarea/Textarea.js
@@ -21,15 +21,7 @@ export default class Textarea extends Component {
   static displayName = 'Textarea';
 
   static propTypes = {
-    /* eslint-disable consistent-return */
-    id: (props, propName, componentName) => {
-      const { id } = props;
-
-      if (typeof id !== 'string') {
-        return new Error(`Invalid prop \`id\` of type \`${typeof id}\` supplied to \`${componentName}\`, expected \`string\`.`);
-      }
-    },
-    /* eslint-enable consistent-return */
+    id: PropTypes.string.isRequired,
     className: PropTypes.string,
     valid: PropTypes.bool,
     description: PropTypes.string,
@@ -63,7 +55,6 @@ export default class Textarea extends Component {
   };
 
   static defaultProps = {
-    id: '',
     className: '',
     description: ''
   };
@@ -104,10 +95,10 @@ export default class Textarea extends Component {
   /* eslint-enable consistent-return */
 
   renderInput() {
-    const { inputProps, id } = this.props;
+    const { id, inputProps } = this.props;
     const allInputProps = {
-      ...combineClassNames(inputProps, styles.textarea),
-      ...(id ? { id } : {})
+      id,
+      ...combineClassNames(inputProps, styles.textarea)
     };
 
     return (
@@ -116,7 +107,7 @@ export default class Textarea extends Component {
   }
 
   render() {
-    const { className, valid } = this.props;
+    const { id, className, valid } = this.props;
     const classNames = classnames({
       [styles.root]: true,
       [styles.invalid]: valid === false,
@@ -124,7 +115,7 @@ export default class Textarea extends Component {
     });
 
     // eslint-disable-next-line react/prop-types
-    const { id, label, labelProps, invalid, help, helpProps, message, messageProps, secondaryLabel, tertiaryLabel, description } = this.props;
+    const { label, labelProps, invalid, help, helpProps, message, messageProps, secondaryLabel, tertiaryLabel, description } = this.props;
     const hasDescription = description.length > 0;
 
     return (

--- a/react/Textarea/Textarea.test.js
+++ b/react/Textarea/Textarea.test.js
@@ -33,12 +33,12 @@ describe('Textarea', () => {
   }
 
   it('should have a displayName', () => {
-    render(<Textarea />);
+    render(<Textarea id="testTextarea" />);
     expect(element.type.displayName).to.equal('Textarea');
   });
 
   it('should render without errors', () => {
-    render(<Textarea />);
+    render(<Textarea id="testTextarea" />);
     expect(errors.length).to.equal(0);
   });
 
@@ -49,16 +49,9 @@ describe('Textarea', () => {
     });
   });
 
-  describe('input', () => {
-    it('should not have an `id` if it is not specified', () => {
-      render(<Textarea />);
-      expect(input.props).not.to.include.keys('id');
-    });
-  });
-
   describe('inputProps', () => {
     it('should error if `inputProps` is not an object', () => {
-      render(<Textarea inputProps="hey" />);
+      render(<Textarea id="testTextarea" inputProps="hey" />);
       expect(errors[0]).to.match(/Invalid prop `inputProps`/);
     });
 
@@ -68,12 +61,12 @@ describe('Textarea', () => {
     });
 
     it('should pass through className to the input', () => {
-      render(<Textarea inputProps={{ className: 'first-name-field' }} />);
+      render(<Textarea id="testTextarea" inputProps={{ className: 'first-name-field' }} />);
       expect(input.props.className).to.match(/first-name-field$/);
     });
 
     it('should pass through other props to the input', () => {
-      render(<Textarea inputProps={{ id: 'firstName', 'data-automation': 'first-name-field' }} />);
+      render(<Textarea id="testTextarea" inputProps={{ id: 'firstName', 'data-automation': 'first-name-field' }} />);
       expect(input.props.id).to.equal('firstName');
       expect(input.props['data-automation']).to.equal('first-name-field');
     });
@@ -82,7 +75,7 @@ describe('Textarea', () => {
   describe('valid', () => {
     describe('set to false', () => {
       it('Textarea should have the invalid className', () => {
-        render(<Textarea valid={false} />);
+        render(<Textarea id="testTextarea" valid={false} />);
         expect(textarea.props.className).to.contain('invalid');
       });
     });
@@ -90,54 +83,54 @@ describe('Textarea', () => {
 
   describe('secondaryLabel', () => {
     it('should not be rendered by default', () => {
-      render(<Textarea />);
+      render(<Textarea id="testTextarea" />);
       expect(textarea.props.children[0].props.secondaryLabel).to.equal('');
     });
 
     it('should pass secondaryLabel message if \`secondaryLabel\` is supplied', () => {
-      render(<Textarea secondaryLabel="secondary" />);
+      render(<Textarea id="testTextarea" secondaryLabel="secondary" />);
       expect(textarea.props.children[0].props.secondaryLabel).to.equal('secondary');
     });
   });
 
   describe('description', () => {
     it('should not be rendered by default', () => {
-      render(<Textarea />);
+      render(<Textarea id="testTextarea" />);
       expect(textarea.props.children[1]).to.equal(null);
     });
 
     it('should render description when specified', () => {
-      render(<Textarea description="test" />);
+      render(<Textarea id="testTextarea" description="test" />);
       expect(textarea.props.children[1].props.children).to.equal('test');
     });
   });
 
   describe('characterCount', () => {
     it('should not be rendered by default', () => {
-      render(<Textarea />);
+      render(<Textarea id="testTextarea" />);
       expect(characterCount).to.equal(null);
     });
 
     it('should error if \`countFeedback\` is not a function', () => {
-      render(<Textarea countFeedback={true} />);
+      render(<Textarea id="testTextarea" countFeedback={true} />);
       expect(errors[0]).to.match(/Invalid prop `countFeedback`/);
     });
 
     it('should error if \`countFeedback\` is supplied without \`inputProps.value\`', () => {
       const countFeedback = v => ({ count: v.length });
-      render(<Textarea countFeedback={countFeedback} />);
+      render(<Textarea id="testTextarea" countFeedback={countFeedback} />);
       expect(errors[0]).to.match(/`inputProps.value` must be supplied if `countFeedback` is set/);
     });
 
     it('should show count value if \`countFeedback\` function is supplied correctly', () => {
       const countFeedback = v => ({ count: v.length });
-      render(<Textarea countFeedback={countFeedback} inputProps={{ value: 'Test value' }} />);
+      render(<Textarea id="testTextarea" countFeedback={countFeedback} inputProps={{ value: 'Test value' }} />);
       expect(characterCount.props.children).to.equal(10);
     });
 
     it('should hide count value if \`countFeedback\` function returns \`{ show: false }\`', () => {
       const countFeedback = () => ({ show: false });
-      render(<Textarea countFeedback={countFeedback} inputProps={{ value: 'Test value' }} />);
+      render(<Textarea id="testTextarea" countFeedback={countFeedback} inputProps={{ value: 'Test value' }} />);
       expect(characterCount).to.equal(null);
     });
   });

--- a/react/private/FieldLabel/FieldLabel.js
+++ b/react/private/FieldLabel/FieldLabel.js
@@ -21,15 +21,7 @@ export default class FieldLabel extends Component {
   static displayName = 'FieldLabel';
 
   static propTypes = {
-    /* eslint-disable consistent-return */
-    id: (props, propName, componentName) => {
-      const { id, label } = props;
-
-      if (label && !id) {
-        return new Error(`When ${componentName} has a \`label\`, it should also have an \`id\`.`);
-      }
-    },
-    /* eslint-enable consistent-return */
+    id: PropTypes.string.isRequired,
     label: PropTypes.node,
     /* eslint-disable consistent-return */
     labelProps: (props, propName, componentName) => {
@@ -102,10 +94,10 @@ export default class FieldLabel extends Component {
       return null;
     }
 
-    const { labelProps, id } = this.props;
+    const { id, labelProps } = this.props;
     const allLabelProps = {
-      ...combineClassNames(labelProps),
-      ...(id ? { htmlFor: id } : {})
+      htmlFor: id,
+      ...combineClassNames(labelProps)
     };
     return (
       <label {...allLabelProps}>

--- a/react/private/FieldLabel/FieldLabel.test.js
+++ b/react/private/FieldLabel/FieldLabel.test.js
@@ -38,64 +38,64 @@ describe('FieldLabel', () => {
   }
 
   it('should have a displayName', () => {
-    render(<FieldLabel />);
+    render(<FieldLabel id="testFieldLabel" />);
     expect(element.type.displayName).to.equal('FieldLabel');
   });
 
   describe('label', () => {
     it('should not be rendered by default', () => {
-      render(<FieldLabel />);
+      render(<FieldLabel id="testFieldLabel" />);
       expect(label).to.equal(null);
     });
 
     it('should have `htmlFor` equal to `id` when `label` is specified', () => {
-      render(<FieldLabel id="firstName" label="First Name" />);
-      expect(label.props).to.contain.keys({ htmlFor: 'firstName' });
+      render(<FieldLabel id="testFieldLabel" label="First Name" />);
+      expect(label.props).to.contain.keys({ htmlFor: 'testFieldLabel' });
     });
 
     it('should have the right text when `label` is specified', () => {
-      render(<FieldLabel id="firstName" label="First Name" labelTextProps={{ className: 'text' }} />);
+      render(<FieldLabel id="testFieldLabel" label="First Name" labelTextProps={{ className: 'text' }} />);
       expect(labelText.props.children).to.equal('First Name');
     });
 
     it('should be able to pass a node to `label`', () => {
-      render(<FieldLabel id="firstName" label={<span>First Name</span>} />);
+      render(<FieldLabel id="testFieldLabel" label={<span>First Name</span>} />);
       expect(labelText.props.children.type).to.equal('span');
       expect(labelText.props.children.props.children).to.equal('First Name');
     });
 
-    it('should error if `id` is not specified but `label` is', () => {
-      render(<FieldLabel label="First Name" />);
-      expect(errors[0]).to.match(/have an `id`/);
+    it('should error if `id` is not a string', () => {
+      render(<FieldLabel id={true} />);
+      expect(errors[0]).to.match(/Invalid prop `id`/);
     });
   });
 
   describe('secondaryLabel', () => {
     it('should not be rendered by default', () => {
-      render(<FieldLabel />);
+      render(<FieldLabel id="testFieldLabel" />);
       expect(secondaryLabel).to.equal(null);
     });
 
     it('should have the right text when `secondaryLabel` is specified', () => {
-      render(<FieldLabel id="firstName" label="First Name" secondaryLabel="Hint Message" />);
+      render(<FieldLabel id="testFieldLabel" label="First Name" secondaryLabel="Hint Message" />);
       expect(secondaryLabel.props.children).to.equal('Hint Message');
     });
   });
 
   describe('tertiaryLabel', () => {
     it('should not be rendered by default', () => {
-      render(<FieldLabel />);
+      render(<FieldLabel id="testFieldLabel" />);
 
       expect(tertiaryLabel).to.equal(null);
     });
 
     it('should have the right text when `tertiaryLabel` is specified', () => {
-      render(<FieldLabel id="firstName" label="First Name" tertiaryLabel="Test Tertiary Label" />);
+      render(<FieldLabel id="testFieldLabel" label="First Name" tertiaryLabel="Test Tertiary Label" />);
       expect(tertiaryLabel.props.children).to.equal('Test Tertiary Label');
     });
 
     it('should be able to pass a node to `tertiaryLabel`', () => {
-      render(<FieldLabel id="firstName" label="First Name" tertiaryLabel={<TextLink>Tertiary TextLink</TextLink>} />);
+      render(<FieldLabel id="testFieldLabel" label="First Name" tertiaryLabel={<TextLink>Tertiary TextLink</TextLink>} />);
       expect(tertiaryLabel.props.children.type.displayName).to.equal('TextLink');
       expect(tertiaryLabel.props.children.props.children).to.equal('Tertiary TextLink');
     });
@@ -103,27 +103,27 @@ describe('FieldLabel', () => {
 
   describe('labelProps', () => {
     it('should error if `labelProps` is not an object', () => {
-      render(<FieldLabel id="firstName" label="First Name" labelProps="data-automation=first-name" />);
+      render(<FieldLabel id="testFieldLabel" label="First Name" labelProps="data-automation=first-name" />);
       expect(errors[0]).to.match(/Invalid prop `labelProps`/);
     });
 
     it('should error if `labelProps` is specified but `label` is not', () => {
-      render(<FieldLabel labelProps={{ 'data-automation': 'first-name' }} />);
+      render(<FieldLabel id="testFieldLabel" labelProps={{ 'data-automation': 'first-name' }} />);
       expect(errors[0]).to.match(/Specifying `labelProps` is redundant/);
     });
 
     it('should error if `labelProps`\'s `htmlFor` is specified', () => {
-      render(<FieldLabel id="firstName" label="First Name" labelProps={{ htmlFor: 'ignored' }} />);
+      render(<FieldLabel id="testFieldLabel" label="First Name" labelProps={{ htmlFor: 'ignored' }} />);
       expect(errors[0]).to.match(/`labelProps.htmlFor` will be overridden by `id`/);
     });
 
     it('should pass through className to the label', () => {
-      render(<FieldLabel id="firstName" label="First Name" labelProps={{ className: 'first-name-label' }} />);
+      render(<FieldLabel id="testFieldLabel" label="First Name" labelProps={{ className: 'first-name-label' }} />);
       expect(label.props.className).to.match(/first-name-label$/);
     });
 
     it('should pass through other props to the label', () => {
-      render(<FieldLabel id="firstName" label="First Name" labelProps={{ 'data-automation': 'first-name-label' }} />);
+      render(<FieldLabel id="testFieldLabel" label="First Name" labelProps={{ 'data-automation': 'first-name-label' }} />);
       expect(label.props['data-automation']).to.equal('first-name-label');
     });
   });


### PR DESCRIPTION
BREAKING CHANGE:
`id` is now required as string for `Autosuggest`, `Checkbox`, `Dropdown`, `MonthPicker`, `TextField` and `Textarea` ( was already required for `Radio` & `SlideToggle`). 
This standardises our form elements, removes a custom prop type check, allow future accessibility fixes as well as making it not possible to accidentally opt out of these fixes by omitting a id.

Reverts seek-oss/seek-style-guide#462 to restore #460