### PR TITLE
feat(AsidedLayout): Support left aligned aside

### DIFF
--- a/react/AsidedLayout/AsidedLayout.demo.js
+++ b/react/AsidedLayout/AsidedLayout.demo.js
@@ -46,6 +46,33 @@ export default {
   },
   options: [
     {
+      label: 'Position',
+      type: 'radio',
+      states: [
+        {
+          label: 'Default',
+          transformProps: props => ({
+            ...props,
+            position: undefined
+          })
+        },
+        {
+          label: 'Left',
+          transformProps: props => ({
+            ...props,
+            position: 'left'
+          })
+        },
+        {
+          label: 'Right',
+          transformProps: props => ({
+            ...props,
+            position: 'right'
+          })
+        }
+      ]
+    },
+    {
       label: 'Order',
       type: 'checkbox',
       states: [

--- a/react/AsidedLayout/AsidedLayout.js
+++ b/react/AsidedLayout/AsidedLayout.js
@@ -3,13 +3,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
+const LEFT = 'left';
+const RIGHT = 'right';
+
 const defaultRenderAside = () => null;
 
-const conditionallyRenderAside = (condition, renderAside, classNameAside, size) => (
+const conditionallyRenderAside = (condition, renderAside, classNameAside, size, position) => (
   condition ?
     <div
       className={classnames({
         [classNameAside]: classNameAside,
+        [styles.leftAside]: position === LEFT,
+        [styles.rightAside]: position !== LEFT,
         [styles.aside]: true
       })}
       style={{ flexBasis: size }}>
@@ -18,7 +23,8 @@ const conditionallyRenderAside = (condition, renderAside, classNameAside, size) 
     null
 );
 
-export default function AsidedLayout({ className, children, renderAside = defaultRenderAside, classNameAside, size, reverse, ...restProps }) {
+export default function AsidedLayout({ className, children, position, renderAside = defaultRenderAside, classNameAside, size, reverse, ...restProps }) {
+  const renderAsideBeforeContent = position === LEFT ? !reverse : reverse;
   return (
     <div
       {...restProps}
@@ -27,11 +33,11 @@ export default function AsidedLayout({ className, children, renderAside = defaul
         [styles.root]: true,
         [styles.reverse]: reverse
       })}>
-      { conditionallyRenderAside(reverse, renderAside, classNameAside, size) }
+      { conditionallyRenderAside(renderAsideBeforeContent, renderAside, classNameAside, size, position) }
       <div className={styles.content}>
         {children}
       </div>
-      { conditionallyRenderAside(!reverse, renderAside, classNameAside, size) }
+      { conditionallyRenderAside(!renderAsideBeforeContent, renderAside, classNameAside, size, position) }
     </div>
   );
 }
@@ -42,5 +48,10 @@ AsidedLayout.propTypes = {
   renderAside: PropTypes.func,
   classNameAside: PropTypes.string,
   size: PropTypes.string,
+  position: PropTypes.oneOf([LEFT, RIGHT]),
   reverse: PropTypes.bool
+};
+
+AsidedLayout.defaultProps = {
+  position: RIGHT
 };

--- a/react/AsidedLayout/AsidedLayout.less
+++ b/react/AsidedLayout/AsidedLayout.less
@@ -20,8 +20,19 @@
 
 .aside {
   @media @desktop {
-    padding-left: @gutter-width;
     flex-grow: 0;
     flex-shrink: 0;
+  }
+}
+
+.leftAside {
+  @media @desktop {
+    padding-right: @gutter-width;
+  }
+}
+
+.rightAside {
+  @media @desktop {
+    padding-left: @gutter-width;
   }
 }


### PR DESCRIPTION
# Reason for Change
We are looking to support layouts where an aside is provided to the left of the main content.

Support a left aside with the `position` prop.
Default behaviour remains right aligned.
Right aligned behaviour is unchanged.
'Reverse on mobile' behaviour is maintained for right and left aligned positions.

# How it works
Currently the position of the aside node moves depending on the `reverse` prop.
CSS is then used to reverse the display order using `flex-direction: row-reversed` on desktop.
This change reuses this same functionality but applies XOR behaviour to `position` and `reverse` as follows.

Props | Desktop Position | Mobile Position | DOM Position
------ | ---------------- | --------------- | --------------
| `position=right` | Right | After | After |
| `position=right` `reverse` | Right | Before | Before |
| `position=left` | Left | Before | Before |
| `position=left` `reverse` | Left | After | After |

# Example usage

```js
<AsidedLayout position="left" renderAside={...} >
...
</AsidedLayout>
```

```js
<AsidedLayout position="right" renderAside={...} >
...
</AsidedLayout>
```
