### PR TITLE
feat(Info): Add new component and prop for Text

### DIFF
--- a/docs/src/components/Typography/Typography.js
+++ b/docs/src/components/Typography/Typography.js
@@ -10,7 +10,8 @@ import {
   Strong,
   Positive,
   Critical,
-  Secondary
+  Secondary,
+  Info
 } from 'seek-style-guide/react';
 import Demo from '../Demo/Demo';
 import textDemoSpec from 'seek-style-guide/react/Text/Text.demo';
@@ -409,6 +410,40 @@ export default () => (
         initialProps: {
           // eslint-disable-next-line react/jsx-key
           children: ['The last word of this sentence is ', <Secondary>secondary.</Secondary>]
+        },
+        options: []
+      }}
+    />
+    <PageBlock>
+      <Card transparent style={{ maxWidth: 720 }}>
+        <Section>
+          <Text heading>Info Text</Text>
+          <Paragraph>
+            <Text>Any text element can be explicity marked as info with the &ldquo;info&rdquo; property or the inline &ldquo;Info&rdquo; component.</Text>
+          </Paragraph>
+        </Section>
+      </Card>
+    </PageBlock>
+    <Demo
+      spec={{
+        component: Text,
+        container: BackgroundContainer,
+        block: true,
+        initialProps: {
+          info: true,
+          children: loremIpsumShort
+        },
+        options: []
+      }}
+    />
+    <Demo
+      spec={{
+        component: Text,
+        container: BackgroundContainer,
+        block: true,
+        initialProps: {
+          // eslint-disable-next-line react/jsx-key
+          children: ['The last word of this sentence is ', <Info>info.</Info>]
         },
         options: []
       }}

--- a/react/Info/Info.demo.js
+++ b/react/Info/Info.demo.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import Info from './Info';
+import Text from '../Text/Text';
+
+export default {
+  route: '/info',
+  title: 'Info',
+  category: 'Typography',
+  component: Text,
+  initialProps: {
+    headline: true,
+    children: [
+      'This text is ',
+      <Info key="info">info</Info>
+    ]
+  },
+  options: []
+};

--- a/react/Info/Info.js
+++ b/react/Info/Info.js
@@ -1,0 +1,18 @@
+import styles from './Info.less';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import classnames from 'classnames';
+
+export default function Info({ children, className, ...restProps }) {
+  return (
+    <span {...restProps} className={classnames(styles.root, className)}>
+      {children}
+    </span>
+  );
+}
+
+Info.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string
+};

--- a/react/Info/Info.less
+++ b/react/Info/Info.less
@@ -1,0 +1,5 @@
+@import (reference) "~seek-style-guide/theme";
+
+.root {
+  color: @sk-info;
+}

--- a/react/Text/Text.demo.js
+++ b/react/Text/Text.demo.js
@@ -74,6 +74,13 @@ export default {
             ...props,
             secondary: true
           })
+        },
+        {
+          label: 'Info',
+          transformProps: props => ({
+            ...props,
+            info: true
+          })
         }
       ]
     },

--- a/react/Text/Text.js
+++ b/react/Text/Text.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import stylesPositive from '../Positive/Positive.less';
 import stylesCritical from '../Critical/Critical.less';
 import stylesSecondary from '../Secondary/Secondary.less';
-import stylesInfo from '../info/info.less';
+import stylesInfo from '../Info/Info.less';
 import stylesStrong from '../Strong/Strong.less';
 import stylesRegular from '../Regular/Regular.less';
 

--- a/react/Text/Text.js
+++ b/react/Text/Text.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import stylesPositive from '../Positive/Positive.less';
 import stylesCritical from '../Critical/Critical.less';
 import stylesSecondary from '../Secondary/Secondary.less';
+import stylesInfo from '../info/info.less';
 import stylesStrong from '../Strong/Strong.less';
 import stylesRegular from '../Regular/Regular.less';
 
@@ -22,6 +23,7 @@ const Text = ({
   positive,
   critical,
   secondary,
+  info,
   strong,
   regular,
   light,
@@ -45,6 +47,7 @@ const Text = ({
           [stylesPositive.root]: positive,
           [stylesCritical.root]: critical,
           [stylesSecondary.root]: secondary,
+          [stylesInfo.root]: info,
           [stylesStrong.root]: strong,
           [stylesRegular.root]: regular,
           [styles.light]: light
@@ -71,6 +74,7 @@ Text.propTypes = {
   positive: PropTypes.bool,
   critical: PropTypes.bool,
   secondary: PropTypes.bool,
+  info: PropTypes.bool,
   strong: PropTypes.bool,
   regular: PropTypes.bool,
   light: PropTypes.bool,

--- a/react/index.js
+++ b/react/index.js
@@ -19,6 +19,7 @@ export { default as Critical } from './Critical/Critical';
 export { default as Paragraph } from './Paragraph/Paragraph';
 export { default as Positive } from './Positive/Positive';
 export { default as Secondary } from './Secondary/Secondary';
+export { default as Info } from './Info/Info';
 export { default as Strong } from './Strong/Strong';
 export { default as Text } from './Text/Text';
 export { default as TextLink } from './TextLink/TextLink';


### PR DESCRIPTION
Inline with the other text short cut components such as `<Positive />` and `<Critical />` this adds `<Info />` also have added this as a prop to `<Text />`

EXAMPLE USAGE:

```js
This text is <Info>info</Info>
```

```js
This text is <Text info>info</Text>
```
