### PR TITLE
fix(Rating): Fix description component use case, add test

### DIFF
--- a/react/Rating/Rating.demo.js
+++ b/react/Rating/Rating.demo.js
@@ -1,4 +1,7 @@
 import Rating from './Rating';
+import React from 'react';
+
+const Component = () => (<span>overall rating</span>);
 
 export default {
   route: '/rating',
@@ -26,7 +29,7 @@ export default {
           transformProps: ({ ...props }) => ({
             ...props,
             showTextRating: true,
-            description: 'overall'
+            description: <Component />
           })
         }
       ]

--- a/react/Rating/Rating.demo.js
+++ b/react/Rating/Rating.demo.js
@@ -1,7 +1,7 @@
 import Rating from './Rating';
 import React from 'react';
 
-const Component = () => (<span>overall rating</span>);
+const Description = () => (<span>overall rating</span>);
 
 export default {
   route: '/rating',
@@ -29,7 +29,7 @@ export default {
           transformProps: ({ ...props }) => ({
             ...props,
             showTextRating: true,
-            description: <Component />
+            description: <Description />
           })
         }
       ]

--- a/react/Rating/Rating.js
+++ b/react/Rating/Rating.js
@@ -63,7 +63,7 @@ const Rating = ({
         })}
         {(showTextRating || Boolean(description)) &&
           <span className={styles.textRating}>
-            {rating.toFixed(1)}{description ? ` ${description}` : ''}
+            {rating.toFixed(1)}{description ? ' ' : ''}{description}
           </span>
         }
       </span>

--- a/react/Rating/Rating.test.js
+++ b/react/Rating/Rating.test.js
@@ -18,6 +18,12 @@ describe('Rating', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should render with description as a component', () => {
+    const SomeComponent = () => <span>overall rating</span>;
+    const wrapper = render(<Rating rating={5.0} description={<SomeComponent />} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
   describe('should render correct star rating', () => {
     const ratings = [2.74, 2.75, 3.74, 3.75, 0.0, 5.0];
 

--- a/react/Rating/__snapshots__/Rating.test.js.snap
+++ b/react/Rating/__snapshots__/Rating.test.js.snap
@@ -650,6 +650,59 @@ exports[`Rating should render with description 1`] = `
 </span>
 `;
 
+exports[`Rating should render with description as a component 1`] = `
+<span
+  class="root standard raw baseline"
+>
+  <span
+    class="root"
+  >
+    <span
+      class="root"
+    >
+      5 out of 5
+    </span>
+    <span
+      class="rating"
+    >
+      <span
+        class="root _large filled standard star"
+      >
+        mock svg
+      </span>
+      <span
+        class="root _large filled standard star"
+      >
+        mock svg
+      </span>
+      <span
+        class="root _large filled standard star"
+      >
+        mock svg
+      </span>
+      <span
+        class="root _large filled standard star"
+      >
+        mock svg
+      </span>
+      <span
+        class="root _large filled standard star"
+      >
+        mock svg
+      </span>
+      <span
+        class="textRating"
+      >
+        5.0 
+        <span>
+          overall rating
+        </span>
+      </span>
+    </span>
+  </span>
+</span>
+`;
+
 exports[`Rating should render with starClassName 1`] = `
 <span
   class="root standard raw baseline"


### PR DESCRIPTION
Currently if `description` prop is passed as a component it is coerced to string, which makes rendering incorrect.
