### PR TITLE
feat(Section): Add fixedGutter prop

### DIFF
--- a/react/Alert/__snapshots__/Alert.test.js.snap
+++ b/react/Alert/__snapshots__/Alert.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Alert: levels: should render primary alerts 1`] = `
 <Section
   className="root"
+  fixedGutter={false}
   header={false}
   level="primary"
   pullout={false}
@@ -33,6 +34,7 @@ exports[`Alert: levels: should render primary alerts 1`] = `
 exports[`Alert: levels: should render secondary alerts 1`] = `
 <Section
   className="root"
+  fixedGutter={false}
   header={false}
   level="secondary"
   pullout={false}
@@ -89,6 +91,7 @@ exports[`Alert: should pass through additional props 1`] = `
 <Section
   className="root"
   custom-prop={true}
+  fixedGutter={false}
   header={false}
   level="primary"
   pullout={false}
@@ -119,6 +122,7 @@ exports[`Alert: should pass through additional props 1`] = `
 exports[`Alert: should render a close button 1`] = `
 <Section
   className="root"
+  fixedGutter={false}
   header={false}
   level="primary"
   pullout={false}
@@ -155,6 +159,7 @@ exports[`Alert: should render a close button 1`] = `
 exports[`Alert: should render the pullout style 1`] = `
 <Section
   className="root"
+  fixedGutter={false}
   header={false}
   level="primary"
   pullout={true}
@@ -185,6 +190,7 @@ exports[`Alert: should render the pullout style 1`] = `
 exports[`Alert: should render with a hidden icon 1`] = `
 <Section
   className="root"
+  fixedGutter={false}
   header={false}
   level="primary"
   pullout={false}
@@ -211,6 +217,7 @@ exports[`Alert: should render with a hidden icon 1`] = `
 exports[`Alert: types: should render critical alerts 1`] = `
 <Section
   className="root"
+  fixedGutter={false}
   header={false}
   level="primary"
   pullout={false}
@@ -240,6 +247,7 @@ exports[`Alert: types: should render critical alerts 1`] = `
 exports[`Alert: types: should render help alerts 1`] = `
 <Section
   className="root"
+  fixedGutter={false}
   header={false}
   level="primary"
   pullout={false}
@@ -269,6 +277,7 @@ exports[`Alert: types: should render help alerts 1`] = `
 exports[`Alert: types: should render info alerts 1`] = `
 <Section
   className="root"
+  fixedGutter={false}
   header={false}
   level="primary"
   pullout={false}
@@ -298,6 +307,7 @@ exports[`Alert: types: should render info alerts 1`] = `
 exports[`Alert: types: should render positive alerts 1`] = `
 <Section
   className="root"
+  fixedGutter={false}
   header={false}
   level="primary"
   pullout={false}
@@ -328,6 +338,7 @@ exports[`Alert: types: should render positive alerts 1`] = `
 exports[`Alert: will accept a node in a the message prop 1`] = `
 <Section
   className="root"
+  fixedGutter={false}
   header={false}
   level="primary"
   pullout={false}

--- a/react/Section/Section.demo.js
+++ b/react/Section/Section.demo.js
@@ -55,6 +55,13 @@ export default {
           })
         },
         {
+          label: 'FixedGutter',
+          transformProps: props => ({
+            ...props,
+            fixedGutter: true
+          })
+        },
+        {
           label: 'Slim',
           transformProps: props => ({
             ...props,

--- a/react/Section/Section.js
+++ b/react/Section/Section.js
@@ -25,6 +25,7 @@ export default function Section({
   slim,
   tone,
   level,
+  fixedGutter,
   ...restProps
 }) {
   return (
@@ -33,6 +34,7 @@ export default function Section({
       className={classnames({
         [className]: className,
         [styles.root]: true,
+        [styles.fixedGutter]: fixedGutter,
         [styles.header]: header,
         [styles.pullout]: pullout,
         [styles.slim]: slim,
@@ -49,6 +51,7 @@ Section.propTypes = {
   className: PropTypes.string,
   header: PropTypes.bool,
   pullout: PropTypes.bool,
+  fixedGutter: PropTypes.bool,
   slim: PropTypes.bool,
   tone: PropTypes.oneOf([TONE.POSITIVE, TONE.INFO, TONE.CRITICAL, TONE.HELP]),
   level: PropTypes.oneOf([LEVEL.PRIMARY, LEVEL.SECONDARY])
@@ -58,5 +61,6 @@ Section.defaultProps = {
   className: '',
   header: false,
   pullout: false,
+  fixedGutter: false,
   slim: false
 };

--- a/react/Section/Section.less
+++ b/react/Section/Section.less
@@ -1,18 +1,26 @@
 @import (reference) "~seek-style-guide/theme";
 
 @gutter-breakpoint: %(~"only screen and (min-width: %s)", (@container-width + (@gutter-width * 2)));
+@desktop-side-padding: (@gutter-width * 1.5);
 
 .root {
   padding: (@row-height * 3) @gutter-width;
-  @media @gutter-breakpoint {
-    padding-left: (@gutter-width * 1.5);
-    padding-right: (@gutter-width * 1.5);
+  
+  &:not(.fixedGutter) {
+    @media @gutter-breakpoint {
+      padding-left: @desktop-side-padding;
+      padding-right: @desktop-side-padding;
+    }
   }
+
 
   &.pullout {
     margin: 0 (-@gutter-width);
-    @media @gutter-breakpoint {
-      margin: 0 (-@gutter-width * 1.5);
+
+    &:not(.fixedGutter) {
+      @media @gutter-breakpoint {
+        margin: 0 -@desktop-side-padding;
+      }
     }
   }
 

--- a/react/Section/Section.less
+++ b/react/Section/Section.less
@@ -5,14 +5,13 @@
 
 .root {
   padding: (@row-height * 3) @gutter-width;
-  
+
   &:not(.fixedGutter) {
     @media @gutter-breakpoint {
       padding-left: @desktop-side-padding;
       padding-right: @desktop-side-padding;
     }
   }
-
 
   &.pullout {
     margin: 0 (-@gutter-width);

--- a/react/Section/Section.test.js
+++ b/react/Section/Section.test.js
@@ -43,6 +43,11 @@ describe('Section:', () => {
     });
   });
 
+  it('should render with fixed gutter', () => {
+    const section = renderSection({ fixedGutter: true });
+    expect(section).toMatchSnapshot();
+  });
+
   it('should render the pullout style', () => {
     const section = renderSection({ pullout: true });
     expect(section).toMatchSnapshot();

--- a/react/Section/__snapshots__/Section.test.js.snap
+++ b/react/Section/__snapshots__/Section.test.js.snap
@@ -65,6 +65,14 @@ exports[`Section: should render the slim style 1`] = `
 </div>
 `;
 
+exports[`Section: should render with fixed gutter 1`] = `
+<div
+  className="root fixedGutter"
+>
+  Test content
+</div>
+`;
+
 exports[`Section: types: should render critical sections 1`] = `
 <div
   className="root critical"


### PR DESCRIPTION
Provide interface to fix the side section gutter if not used for full width purposes.

Currently if Section component is used for non-full width cases (like side column for example), gutters are changing unexpectedly half way to regular mobile breakpoint which looks pretty weird.

This PR is forcing section's side gutters to be fixed (simply @gutter-width) if `fixedGutter` prop is supplied.

```js
<Section fixedGutter>...</Section>
```
