### PR TITLE
feat(forms): Add top-level value, checked, type, onChange/Focus/Blur

### DIFF
--- a/react/Autosuggest/Autosuggest.demo.js
+++ b/react/Autosuggest/Autosuggest.demo.js
@@ -44,12 +44,10 @@ class AutosuggestContainer extends Component {
       <div style={{ width: '300px' }}>
         <DemoComponent
           {...componentProps}
-          inputProps={{
-            type: 'search',
-            onChange: this.handleChange,
-            onFocus: this.handleFocus,
-            value: inputValue
-          }}
+          type="search"
+          value={inputValue}
+          onChange={this.handleChange}
+          onFocus={this.handleFocus}
           onClear={this.handleClear}
         />
       </div>
@@ -66,6 +64,9 @@ export default {
   initialProps: {
     id: 'jobTitles',
     label: 'Job Titles',
+    type: 'search',
+    value: '...',
+    onChange: () => {},
     autosuggestProps: {
       suggestions: ['Developer', 'Product manager', 'Iteration manager', 'Designer'],
       onSuggestionsFetchRequested: () => {},
@@ -74,12 +75,6 @@ export default {
       getSuggestionValue: suggestion => suggestion
     },
     message: false,
-    // Documentation only:
-    inputProps: {
-      type: 'search',
-      value: '...',
-      onChange: () => {}
-    },
     onClear: () => {}
   },
   options: [

--- a/react/Autosuggest/Autosuggest.js
+++ b/react/Autosuggest/Autosuggest.js
@@ -1,24 +1,26 @@
 import styles from './Autosuggest.less';
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import ReactAutosuggest from 'react-autosuggest';
 import IsolatedScroll from 'react-isolated-scroll';
-
 import omit from 'lodash/omit';
-
 import TextField from '../TextField/TextField';
-
 import smoothScroll from '../private/smoothScroll';
 import smallDeviceOnly from '../private/smallDeviceOnly';
 
+/* eslint-disable react/no-deprecated */
 export default class Autosuggest extends Component {
   static displayName = 'Autosuggest';
 
   static propTypes = {
     id: PropTypes.string.isRequired,
-    inputProps: PropTypes.object.isRequired,
+    value: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
+    type: PropTypes.string,
+    inputProps: PropTypes.object,
     label: PropTypes.string,
     labelProps: PropTypes.object,
     className: PropTypes.string,
@@ -43,9 +45,11 @@ export default class Autosuggest extends Component {
   };
 
   static defaultProps = {
+    type: 'text',
     className: '',
     label: '',
     labelProps: {},
+    inputProps: {},
     showMobileBackdrop: false
   };
 
@@ -113,7 +117,18 @@ export default class Autosuggest extends Component {
   }
 
   render() {
-    const { inputProps, label, autosuggestProps, suggestionsContainerClassName, showMobileBackdrop } = this.props;
+    const {
+      value,
+      onChange,
+      onFocus,
+      onBlur,
+      type,
+      inputProps,
+      label,
+      autosuggestProps,
+      suggestionsContainerClassName,
+      showMobileBackdrop
+    } = this.props;
     const { theme = {} } = autosuggestProps;
 
     const allAutosuggestProps = {
@@ -134,7 +149,7 @@ export default class Autosuggest extends Component {
     return (
       <div>
         <ReactAutosuggest
-          inputProps={inputProps}
+          inputProps={{ value, onChange, onFocus, onBlur, type, ...inputProps }}
           ref={this.storeInputReference}
           {...allAutosuggestProps}
         />

--- a/react/Autosuggest/Autosuggest.test.js
+++ b/react/Autosuggest/Autosuggest.test.js
@@ -1,6 +1,5 @@
 import { mount, render } from 'enzyme';
 import React from 'react';
-
 import Autosuggest from './Autosuggest';
 
 const getAutosuggestProps = (suggestions = []) => ({
@@ -13,17 +12,17 @@ const getAutosuggestProps = (suggestions = []) => ({
     onSuggestionSelected: () => {},
     alwaysRenderSuggestions: true
   },
-  inputProps: {
-    value: '',
-    onChange: () => {}
-  }
+  value: '',
+  onChange: () => {}
 });
 
 describe('Autosuggest', () => {
   let spy;
 
   beforeEach(() => {
-    spy = jest.spyOn(global.console, 'error');
+    spy = jest
+      .spyOn(global.console, 'error')
+      .mockImplementation(() => {}); // Swallow console errors
   });
 
   afterEach(() => {
@@ -33,6 +32,18 @@ describe('Autosuggest', () => {
   it('should render with simple props', () => {
     const wrapper = render(<Autosuggest {...getAutosuggestProps()} id="testAutosuggest" />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should pass through the type', () => {
+    const wrapper = mount(<Autosuggest {...getAutosuggestProps()} type="search" id="testAutosuggest" />);
+    const inputType = wrapper.find('input').prop('type');
+    expect(inputType).toEqual('search');
+  });
+
+  it('should pass through the value', () => {
+    const wrapper = mount(<Autosuggest {...getAutosuggestProps()} value="foo" id="testAutosuggest" />);
+    const inputValue = wrapper.find('input').prop('value');
+    expect(inputValue).toEqual('foo');
   });
 
   it('should render with suggestions', () => {
@@ -81,5 +92,57 @@ describe('Autosuggest', () => {
     const input = wrapper.find('input').html();
     firstSuggestion.simulate('click');
     expect(global.document.activeElement.outerHTML).toEqual(input);
+  });
+
+  it('should invoke the focus handler', () => {
+    const callback = jest.fn();
+    const wrapper = mount(<Autosuggest {...getAutosuggestProps()} onFocus={callback} id="testAutosuggest" />);
+    wrapper.find('input').simulate('focus');
+    expect(callback.mock.calls.length).toEqual(1);
+  });
+
+  it('should invoke the blur handler', () => {
+    const callback = jest.fn();
+    const wrapper = mount(<Autosuggest {...getAutosuggestProps()} onBlur={callback} id="testAutosuggest" />);
+    wrapper.find('input').simulate('blur');
+    expect(callback.mock.calls.length).toEqual(1);
+  });
+
+  it('should invoke the change handler', () => {
+    const callback = jest.fn();
+    const wrapper = mount(<Autosuggest {...getAutosuggestProps()} onChange={callback} id="testAutosuggest" />);
+    wrapper.find('input').simulate('change', { target: { value: 'foo' } });
+    expect(callback.mock.calls.length).toEqual(1);
+    expect(callback.mock.calls[0][0].target.value).toEqual('foo');
+  });
+
+  describe('inputProps', () => {
+    it('should pass through value', () => {
+      const wrapper = mount(<Autosuggest {...getAutosuggestProps()} inputProps={{ value: 'input props value' }} id="testAutosuggest" />);
+      const inputValue = wrapper.find('input').prop('value');
+      expect(inputValue).toEqual('input props value');
+    });
+
+    it('should invoke the focus event', () => {
+      const onFocus = jest.fn();
+      const wrapper = mount(<Autosuggest {...getAutosuggestProps()} inputProps={{ onFocus }} id="testAutosuggest" />);
+      wrapper.find('input').simulate('focus');
+      expect(onFocus.mock.calls.length).toEqual(1);
+    });
+
+    it('should invoke the blur event', () => {
+      const onBlur = jest.fn();
+      const wrapper = mount(<Autosuggest {...getAutosuggestProps()} inputProps={{ onBlur }} id="testAutosuggest" />);
+      wrapper.find('input').simulate('blur');
+      expect(onBlur.mock.calls.length).toEqual(1);
+    });
+
+    it('should invoke the change event', () => {
+      const onChange = jest.fn();
+      const wrapper = mount(<Autosuggest {...getAutosuggestProps()} inputProps={{ onChange }} id="testAutosuggest" />);
+      wrapper.find('input').simulate('change', { target: { value: 'foo' } });
+      expect(onChange.mock.calls.length).toEqual(1);
+      expect(onChange.mock.calls[0][0].target.value).toEqual('foo');
+    });
   });
 });

--- a/react/Checkbox/Checkbox.demo.js
+++ b/react/Checkbox/Checkbox.demo.js
@@ -33,10 +33,8 @@ class CheckboxContainer extends Component {
       <div className={demoStyles.root}>
         <DemoComponent
           {...componentProps}
-          inputProps={{
-            checked,
-            onChange: this.handleChange
-          }}
+          checked={checked}
+          onChange={this.handleChange}
         />
       </div>
     );
@@ -55,10 +53,8 @@ export default {
     label: 'Still in role',
     type: 'standard',
     // Documentation only:
-    inputProps: {
-      checked: false,
-      onChange: () => {}
-    }
+    checked: false,
+    onChange: () => {}
   },
   options: [
     {

--- a/react/Checkbox/Checkbox.js
+++ b/react/Checkbox/Checkbox.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
 import styles from './Checkbox.less';
 import CheckMarkIcon from '../CheckMarkIcon/CheckMarkIcon';
 import classnames from 'classnames';
@@ -24,11 +23,13 @@ export default class Checkbox extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     label: PropTypes.node.isRequired,
+    value: PropTypes.string,
     className: PropTypes.string,
-    inputProps: PropTypes.shape({
-      onChange: PropTypes.func,
-      checked: PropTypes.bool.isRequired
-    }),
+    checked: PropTypes.bool.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
+    inputProps: PropTypes.object,
     type: PropTypes.oneOf([STANDARD, BUTTON]),
     valid: PropTypes.bool,
     message: PropTypes.oneOfType([
@@ -40,9 +41,8 @@ export default class Checkbox extends Component {
 
   static defaultProps = {
     className: '',
-    inputProps: {
-      checked: false
-    },
+    checked: false,
+    inputProps: {},
     type: STANDARD
   };
 
@@ -91,10 +91,15 @@ export default class Checkbox extends Component {
   }
 
   renderInput() {
-    const { id, inputProps } = this.props;
+    const { id, value, checked, onChange, onFocus, onBlur, inputProps } = this.props;
 
     const allInputProps = {
       id,
+      value,
+      checked,
+      onChange,
+      onFocus,
+      onBlur,
       ...combineClassNames(inputProps, styles.input),
       type: 'checkbox'
     };

--- a/react/Checkbox/Checkbox.sketch.js
+++ b/react/Checkbox/Checkbox.sketch.js
@@ -13,22 +13,22 @@ const noop = () => {};
 export const symbols = {
   'Checkbox/Standard/Checked': (
     <Container>
-      <Checkbox id="checkbox2" label="Checkbox" inputProps={{ checked: true, onChange: noop }} />
+      <Checkbox id="checkbox2" label="Checkbox" checked={true} onChange={noop} />
     </Container>
   ),
   'Checkbox/Standard/Unchecked': (
     <Container>
-      <Checkbox id="checkbox1" label="Checkbox" inputProps={{ checked: false, onChange: noop }} />
+      <Checkbox id="checkbox1" label="Checkbox" checked={false} onChange={noop} />
     </Container>
   ),
   'Checkbox/Button/Checked': (
     <Container>
-      <Checkbox id="checkbox2" label="Checkbox" type="button" inputProps={{ checked: true, onChange: noop }} />
+      <Checkbox id="checkbox2" label="Checkbox" type="button" checked={true} onChange={noop} />
     </Container>
   ),
   'Checkbox/Button/Unchecked': (
     <Container>
-      <Checkbox id="checkbox2" label="Checkbox" type="button" inputProps={{ checked: false, onChange: noop }} />
+      <Checkbox id="checkbox2" label="Checkbox" type="button" checked={false} onChange={noop} />
     </Container>
   )
 };

--- a/react/Checkbox/Checkbox.test.js
+++ b/react/Checkbox/Checkbox.test.js
@@ -1,17 +1,30 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-
 import Checkbox from './Checkbox';
 
 describe('Checkbox', () => {
   const requiredProps = {
     id: 'testCheckbox',
-    label: 'Still in role'
+    label: 'Still in role',
+    checked: false,
+    onChange: () => {}
   };
 
   it('should render with simple props', () => {
     const wrapper = shallow(<Checkbox {...requiredProps} />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render as checked', () => {
+    const wrapper = shallow(<Checkbox {...requiredProps} checked={true} />);
+    const inputChecked = wrapper.find('input').prop('checked');
+    expect(inputChecked).toEqual(true);
+  });
+
+  it('should pass through the value', () => {
+    const wrapper = shallow(<Checkbox {...requiredProps} value="foo" checked={true} />);
+    const inputValue = wrapper.find('input').prop('value');
+    expect(inputValue).toEqual('foo');
   });
 
   it('should render with className', () => {
@@ -30,27 +43,45 @@ describe('Checkbox', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should invoke the change handler', () => {
+    const onChange = jest.fn();
+    const props = { ...requiredProps, onChange, checked: false };
+    const checkedEvent = { target: { checked: true } };
+    const wrapper = shallow(<Checkbox {...props} />);
+    wrapper.find('input').simulate('change', checkedEvent);
+    expect(onChange).toBeCalledWith(checkedEvent);
+  });
+
+  it('should invoke the focus handler', () => {
+    const onFocus = jest.fn();
+    const props = { ...requiredProps, onFocus, checked: false };
+    const wrapper = shallow(<Checkbox {...props} />);
+    wrapper.find('input').simulate('focus');
+    expect(onFocus.mock.calls.length).toEqual(1);
+  });
+
+  it('should invoke the blur handler', () => {
+    const onBlur = jest.fn();
+    const props = { ...requiredProps, onBlur, checked: false };
+    const wrapper = shallow(<Checkbox {...props} />);
+    wrapper.find('input').simulate('blur');
+    expect(onBlur.mock.calls.length).toEqual(1);
+  });
+
   describe('inputProps', () => {
-    it('should invoke the onChange handler when touched', () => {
+    it('should invoke the change handler', () => {
       const handleChange = jest.fn();
-      const props = {
-        ...requiredProps,
-        inputProps: {
-          onChange: handleChange,
-          checked: false
-        }
-      };
+      const props = { ...requiredProps, inputProps: { onChange: handleChange, checked: false } };
       const checkedEvent = { target: { checked: true } };
-
       const wrapper = shallow(<Checkbox {...props} />);
-
       wrapper.find('input').simulate('change', checkedEvent);
       expect(handleChange).toBeCalledWith(checkedEvent);
     });
 
     it('should render as checked', () => {
       const wrapper = shallow(<Checkbox {...requiredProps} inputProps={{ checked: true }} />);
-      expect(wrapper).toMatchSnapshot();
+      const inputChecked = wrapper.find('input').prop('checked');
+      expect(inputChecked).toEqual(true);
     });
 
     it('should pass through other props to the input', () => {

--- a/react/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/react/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -8,6 +8,7 @@ exports[`Checkbox FieldMessage should render field message when passed 1`] = `
     checked={false}
     className="input"
     id="testCheckbox"
+    onChange={[Function]}
     type="checkbox"
   />
   <label
@@ -54,57 +55,11 @@ exports[`Checkbox inputProps should pass through other props to the input 1`] = 
   className="root"
 >
   <input
+    checked={false}
     className="input"
     data-automation="first-name-field"
     id="testCheckbox"
-    type="checkbox"
-  />
-  <label
-    className="label"
-    htmlFor="testCheckbox"
-  >
-    <div
-      className="standard"
-    >
-      <div
-        className="checkbox"
-      >
-        <CheckMarkIcon
-          className="checkMark"
-          svgClassName="checkMarkSvg checkMarkSvg_isHover"
-        />
-        <CheckMarkIcon
-          className="checkMark"
-          svgClassName="checkMarkSvg checkMarkSvg_isSelected"
-        />
-      </div>
-      <span>
-        Still in role
-      </span>
-    </div>
-  </label>
-  <FieldMessage
-    id="testCheckbox-message"
-    message=""
-    messageProps={
-      Object {
-        "critical": false,
-        "positive": false,
-        "secondary": false,
-      }
-    }
-  />
-</div>
-`;
-
-exports[`Checkbox inputProps should render as checked 1`] = `
-<div
-  className="root"
->
-  <input
-    checked={true}
-    className="input"
-    id="testCheckbox"
+    onChange={[Function]}
     type="checkbox"
   />
   <label
@@ -153,6 +108,7 @@ exports[`Checkbox should render with button style 1`] = `
     checked={false}
     className="input"
     id="testCheckbox"
+    onChange={[Function]}
     type="checkbox"
   />
   <label
@@ -187,6 +143,7 @@ exports[`Checkbox should render with className 1`] = `
     checked={false}
     className="input"
     id="testCheckbox"
+    onChange={[Function]}
     type="checkbox"
   />
   <label
@@ -235,6 +192,7 @@ exports[`Checkbox should render with simple props 1`] = `
     checked={false}
     className="input"
     id="testCheckbox"
+    onChange={[Function]}
     type="checkbox"
   />
   <label
@@ -283,6 +241,7 @@ exports[`Checkbox should render with standard checkbox style 1`] = `
     checked={false}
     className="input"
     id="testCheckbox"
+    onChange={[Function]}
     type="checkbox"
   />
   <label

--- a/react/Dropdown/Dropdown.demo.js
+++ b/react/Dropdown/Dropdown.demo.js
@@ -34,10 +34,8 @@ class DropdownContainer extends Component {
     return (
       <DemoComponent
         {...componentProps}
-        inputProps={{
-          value,
-          onChange: this.handleChange
-        }}
+        value={value}
+        onChange={this.handleChange}
       />
     );
   }
@@ -73,10 +71,8 @@ export default {
       }
     ],
     // Documentation only:
-    inputProps: {
-      onChange: () => {},
-      value: '...'
-    }
+    onChange: () => {},
+    value: '...'
   },
   options: [
     {

--- a/react/Dropdown/Dropdown.js
+++ b/react/Dropdown/Dropdown.js
@@ -1,12 +1,8 @@
 import styles from './Dropdown.less';
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
 import classnames from 'classnames';
-
 import ChevronIcon from '../ChevronIcon/ChevronIcon';
-
 import FieldMessage from '../private/FieldMessage/FieldMessage';
 import FieldLabel from '../private/FieldLabel/FieldLabel';
 
@@ -26,24 +22,11 @@ export default class Dropdown extends Component {
     id: PropTypes.string.isRequired,
     className: PropTypes.string,
     valid: PropTypes.bool,
-    /* eslint-disable consistent-return */
-    inputProps: (props, propName, componentName) => {
-      const { id, inputProps } = props;
-      const { id: inputId, value } = inputProps || {};
-
-      if (typeof inputProps !== 'object') {
-        return new Error(`Invalid prop \`inputProps\` of type \`${typeof inputProps}\` supplied to \`${componentName}\`, expected \`object\`.`);
-      }
-
-      if (typeof value !== 'string') {
-        return new Error(`Invalid prop \`inputProps.value\` of type \`${typeof value}\` supplied to \`${componentName}\`, expected \`string\`.`);
-      }
-
-      if (inputId && id) {
-        return new Error(`\`inputProps.id\` will be overridden by \`id\` in ${componentName}. Please remove it.`);
-      }
-    },
-    /* eslint-enable consistent-return */
+    value: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
+    inputProps: PropTypes.object,
     options: PropTypes.arrayOf(
       PropTypes.shape({
         value: PropTypes.oneOfType([
@@ -62,7 +45,8 @@ export default class Dropdown extends Component {
   static defaultProps = {
     className: '',
     placeholder: '',
-    options: []
+    options: [],
+    inputProps: {}
   };
 
   constructor() {
@@ -79,14 +63,19 @@ export default class Dropdown extends Component {
       { label }
     </option>);
   }
+
   renderSelect() {
-    const { id, inputProps, options, placeholder } = this.props;
+    const { id, value, onChange, onFocus, onBlur, inputProps, options, placeholder } = this.props;
     const inputStyles = classnames({
       [styles.dropdown]: true,
-      [styles.placeholderSelected]: !inputProps.value
+      [styles.placeholderSelected]: !value && !inputProps.value
     });
     const allInputProps = {
       id,
+      value,
+      onChange,
+      onFocus,
+      onBlur,
       'aria-describedby': `${id}-message`, // Order is important here so passed in inputProps can overide this if requried
       ...combineClassNames(inputProps, inputStyles)
     };
@@ -99,11 +88,11 @@ export default class Dropdown extends Component {
           { placeholder }
         </option>
         {
-          options.map(({ value, label }) => {
-            if (Array.isArray(value)) {
-              return (<optgroup value="" label={label} key={label}>{value.map(this.renderOption)}</optgroup>);
+          options.map(option => {
+            if (Array.isArray(option.value)) {
+              return (<optgroup value="" label={option.label} key={option.label}>{option.value.map(this.renderOption)}</optgroup>);
             }
-            return this.renderOption({ value, label });
+            return this.renderOption(option);
           })
         }
       </select>

--- a/react/Dropdown/Dropdown.sketch.js
+++ b/react/Dropdown/Dropdown.sketch.js
@@ -8,10 +8,8 @@ const commonProps = {
   label: 'Label',
   placeholder: 'Placeholder text',
   options: [],
-  inputProps: {
-    value: '',
-    onChange: () => {}
-  }
+  value: '',
+  onChange: () => {}
 };
 
 export const symbols = {

--- a/react/Dropdown/Dropdown.test.js
+++ b/react/Dropdown/Dropdown.test.js
@@ -3,10 +3,8 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import React from 'react';
 import { createRenderer } from 'react-test-renderer/shallow';
-import {
-  findAllWithClass,
-  findAllWithType
-} from 'react-shallow-testutils';
+import { shallow } from 'enzyme';
+import { findAllWithClass, findAllWithType } from 'react-shallow-testutils';
 import Dropdown from './Dropdown';
 
 chai.use(sinonChai);
@@ -54,21 +52,49 @@ describe('Dropdown', () => {
   }
 
   it('should have a displayName', () => {
-    render(<Dropdown id="testDropdown" inputProps={{ value: '' }} />);
+    render(<Dropdown id="testDropdown" value="" />);
     expect(element.type.displayName).to.equal('Dropdown');
   });
 
   describe('id', () => {
     it('should error if `id` is not a string', () => {
-      render(<Dropdown id={true} inputProps={{ value: '' }} />);
+      render(<Dropdown id={true} value="" />);
       expect(errors[0]).to.match(/Invalid prop `id`/);
     });
+  });
+
+  it('should pass through the value', () => {
+    const wrapper = shallow(<Dropdown id="testDropdown" value="foo" />);
+    const selectValue = wrapper.find('select').prop('value');
+    expect(selectValue).to.equal('foo');
+  });
+
+  it('should invoke the focus handler', () => {
+    const onFocus = jest.fn();
+    const wrapper = shallow(<Dropdown id="testDropdown" value="" onFocus={onFocus} />);
+    wrapper.find('select').simulate('focus');
+    expect(onFocus.mock.calls.length).to.equal(1);
+  });
+
+  it('should invoke the blur handler', () => {
+    const onBlur = jest.fn();
+    const wrapper = shallow(<Dropdown id="testDropdown" value="" onBlur={onBlur} />);
+    wrapper.find('select').simulate('blur');
+    expect(onBlur.mock.calls.length).to.equal(1);
+  });
+
+  it('should invoke the change handler', () => {
+    const onChange = jest.fn();
+    const wrapper = shallow(<Dropdown id="testDropdown" value="" onChange={onChange} />);
+    wrapper.find('select').simulate('change', { target: { value: 'foo' } });
+    expect(onChange.mock.calls.length).to.equal(1);
+    expect(onChange.mock.calls[0][0].target.value).to.equal('foo');
   });
 
   describe('options', () => {
     const opt = [{ label: 'suburbs', value: '3130' }];
     it('should render options correctly', () => {
-      render(<Dropdown id="testDropdown" inputProps={{ value: '' }} options={opt} />);
+      render(<Dropdown id="testDropdown" value="" options={opt} />);
       expect(option.props.value).to.equal('3130');
     });
   });
@@ -76,7 +102,7 @@ describe('Dropdown', () => {
   describe('Option Group', () => {
     beforeAll(() => {
       const opts = [{ label: 'suburbs', value: [{ label: 'truganina', value: '3029' }, { label: 'wl', value: '3029' }] }];
-      render(<Dropdown id="testDropdown" inputProps={{ value: '' }} options={opts} />);
+      render(<Dropdown id="testDropdown" value="" options={opts} />);
     });
     it('should render optgroup correctly', () => {
       expect(optionGroup.props.label).to.equal('suburbs');
@@ -94,40 +120,43 @@ describe('Dropdown', () => {
 
   describe('placeholder', () => {
     it('should render placeholder as first option in list ', () => {
-      render(<Dropdown id="testDropdown" inputProps={{ value: '' }} options={options} placeholder="test" />);
+      render(<Dropdown id="testDropdown" value="" options={options} placeholder="test" />);
       expect(placeholderText()).to.equal('test');
     });
   });
 
   describe('inputProps', () => {
-    it('should error if `inputProps` is not an object', () => {
-      render(<Dropdown id="testDropdown" inputProps="hey" />);
-      expect(errors[0]).to.match(/Invalid prop `inputProps`/);
-    });
-
-    it('should error if `inputProps.value` is not supplied', () => {
-      render(<Dropdown id="testDropdown" inputProps={{}} />);
-      expect(errors[0]).to.match(/Invalid prop `inputProps.value` of type `undefined` supplied to `Dropdown`, expected `string`/);
-    });
-
-    it('should error if `inputProps.value` is not a string', () => {
-      render(<Dropdown id="testDropdown" inputProps={{ value: 2 }} />);
-      expect(errors[0]).to.match(/Invalid prop `inputProps.value` of type `number` supplied to `Dropdown`, expected `string`/);
-    });
-
-    it('should error if `inputProps`\'s `id` is specified', () => {
-      render(<Dropdown id="testDropdown" inputProps={{ id: 'ignored', value: '' }} />);
-      expect(errors[0]).to.match(/`inputProps.id` will be overridden by `id`/);
-    });
-
     it('should pass through className to the input', () => {
       render(<Dropdown id="testDropdown" inputProps={{ className: 'first-name-field' }} />);
       expect(input.props.className).to.match(/first-name-field$/);
     });
 
+    it('should invoke the focus handler', () => {
+      const onFocus = jest.fn();
+      const wrapper = shallow(<Dropdown id="testDropdown" value="" inputProps={{ onFocus }} />);
+      wrapper.find('select').simulate('focus');
+      expect(onFocus.mock.calls.length).to.equal(1);
+    });
+
+    it('should invoke the blur handler', () => {
+      const onBlur = jest.fn();
+      const wrapper = shallow(<Dropdown id="testDropdown" value="" inputProps={{ onBlur }} />);
+      wrapper.find('select').simulate('blur');
+      expect(onBlur.mock.calls.length).to.equal(1);
+    });
+
+    it('should invoke the change handler', () => {
+      const onChange = jest.fn();
+      const wrapper = shallow(<Dropdown id="testDropdown" value="" inputProps={{ onChange }} />);
+      wrapper.find('select').simulate('change', { target: { value: 'foo' } });
+      expect(onChange.mock.calls.length).to.equal(1);
+      expect(onChange.mock.calls[0][0].target.value).to.equal('foo');
+    });
+
     it('should pass through other props to the input', () => {
-      render(<Dropdown id="testDropdown" inputProps={{ id: 'firstName', 'data-automation': 'first-name-field' }} />);
+      render(<Dropdown id="testDropdown" inputProps={{ id: 'firstName', value: 'value', 'data-automation': 'first-name-field' }} />);
       expect(input.props.id).to.equal('firstName');
+      expect(input.props.value).to.equal('value');
       expect(input.props['data-automation']).to.equal('first-name-field');
     });
   });
@@ -135,7 +164,7 @@ describe('Dropdown', () => {
   describe('valid', () => {
     describe('set to false', () => {
       it('Dropdown should have the invalid className', () => {
-        render(<Dropdown id="testDropdown" inputProps={{ value: '' }} valid={false} />);
+        render(<Dropdown id="testDropdown" value="" valid={false} />);
         expect(dropdown.props.className).to.contain('invalid');
       });
     });

--- a/react/EmailField/EmailField.js
+++ b/react/EmailField/EmailField.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
 import TextField from '../TextField/TextField';
 
 const seekEmailRegex = '^[a-zA-Z0-9_][a-zA-Z0-9!#$%&\'*+/=?_`{|}~\-]*(?:\.[a-zA-Z0-9!#$%&\';*+/=?_`{|}~\-]+)*@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+(?:[a-zA-Z]{2,})$';
@@ -32,10 +31,9 @@ export default class EmailField extends Component {
     const { inputProps, ...props } = this.props;
     const combinedInputProps = {
       ...inputProps,
-      type: 'email',
       pattern: seekEmailRegex
     };
 
-    return <TextField {...props} ref={this.storeInputReference} inputProps={combinedInputProps} />;
+    return <TextField {...props} ref={this.storeInputReference} type="email" inputProps={combinedInputProps} />;
   }
 }

--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
@@ -24,6 +24,7 @@ const months = [
   { value: '12', label: 'Dec' }
 ];
 
+/* eslint-disable react/no-deprecated */
 export default class CustomMonthPicker extends Component {
   static displayName = 'CustomMonthPicker';
 

--- a/react/Radio/Radio.demo.js
+++ b/react/Radio/Radio.demo.js
@@ -42,19 +42,15 @@ class RadioContainer extends Component {
           {...componentProps}
           id="Yes"
           label="Yes"
-          inputProps={{
-            checked: value === 'Yes',
-            onChange: this.handleYes
-          }}
+          checked={value === 'Yes'}
+          onChange={this.handleYes}
         />
         <DemoComponent
           {...componentProps}
           id="No"
           label="No"
-          inputProps={{
-            checked: value === 'No',
-            onChange: this.handleNo
-          }}
+          checked={value === 'No'}
+          onChange={this.handleNo}
         />
       </div>
     );
@@ -72,10 +68,8 @@ export default {
     name: 'stillInRole',
     // Documentation only:
     id: 'myRadio',
-    inputProps: {
-      checked: false,
-      onChange: () => {}
-    }
+    checked: false,
+    onChange: () => {}
   },
   options: []
 };

--- a/react/Radio/Radio.js
+++ b/react/Radio/Radio.js
@@ -1,7 +1,5 @@
 import styles from './Radio.less';
-
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import Text from '../Text/Text';
@@ -20,6 +18,11 @@ export default class Radio extends Component {
 
   static propTypes = {
     id: PropTypes.string.isRequired,
+    value: PropTypes.string,
+    checked: PropTypes.bool.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
     className: PropTypes.string,
     label: PropTypes.string,
     labelProps: PropTypes.object,
@@ -33,9 +36,14 @@ export default class Radio extends Component {
   };
 
   renderInput() {
-    const { id, inputProps } = this.props;
+    const { id, value, checked, onChange, onFocus, onBlur, inputProps } = this.props;
     const allInputProps = {
       id,
+      value,
+      checked,
+      onChange,
+      onFocus,
+      onBlur,
       ...combineClassNames(inputProps, styles.input),
       type: 'radio'
     };

--- a/react/Radio/Radio.sketch.js
+++ b/react/Radio/Radio.sketch.js
@@ -13,12 +13,12 @@ const noop = () => {};
 export const symbols = {
   'Radio/Checked': (
     <Container>
-      <Radio id="radio2" label="Radio" inputProps={{ checked: true, onChange: noop }} />
+      <Radio id="radio2" label="Radio" checked={true} onChange={noop} />
     </Container>
   ),
   'Radio/Unchecked': (
     <Container>
-      <Radio id="radio1" label="Radio" inputProps={{ checked: false, onChange: noop }} />
+      <Radio id="radio1" label="Radio" checked={false} onChange={noop} />
     </Container>
   )
 };

--- a/react/Radio/Radio.test.js
+++ b/react/Radio/Radio.test.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-
 import Radio from './Radio';
 
 describe('Radio', () => {
   const requiredProps = {
     id: 'testRadio',
-    label: 'Still in role'
+    label: 'Still in role',
+    checked: false,
+    onChange: () => {}
   };
 
   it('should render with simple props', () => {
@@ -20,31 +21,71 @@ describe('Radio', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should render as checked', () => {
+    const wrapper = shallow(<Radio {...requiredProps} checked={true} />);
+    const inputChecked = wrapper.find('input').prop('checked');
+    expect(inputChecked).toEqual(true);
+  });
+
+  it('should pass through the value', () => {
+    const wrapper = shallow(<Radio {...requiredProps} value="foo" checked={true} />);
+    const inputValue = wrapper.find('input').prop('value');
+    expect(inputValue).toEqual('foo');
+  });
+
+  it('should invoke the change handler', () => {
+    const onChange = jest.fn();
+    const props = { ...requiredProps, onChange, checked: false };
+    const checkedEvent = { target: { checked: true } };
+    const wrapper = shallow(<Radio {...props} />);
+    wrapper.find('input').simulate('change', checkedEvent);
+    expect(onChange).toBeCalledWith(checkedEvent);
+  });
+
+  it('should invoke the focus handler', () => {
+    const onFocus = jest.fn();
+    const props = { ...requiredProps, onFocus };
+    const wrapper = shallow(<Radio {...props} />);
+    wrapper.find('input').simulate('focus');
+    expect(onFocus.mock.calls.length).toBe(1);
+  });
+
+  it('should invoke the blur handler', () => {
+    const onBlur = jest.fn();
+    const props = { ...requiredProps, onBlur };
+    const wrapper = shallow(<Radio {...props} />);
+    wrapper.find('input').simulate('blur');
+    expect(onBlur.mock.calls.length).toBe(1);
+  });
+
   describe('inputProps', () => {
-    it('should invoke the onChange handler when touched', () => {
-      const handleChange = jest.fn();
-      const props = {
-        ...requiredProps,
-        inputProps: {
-          onChange: handleChange,
-          checked: false
-        }
-      };
+    it('should invoke the change handler', () => {
+      const onChange = jest.fn();
+      const props = { ...requiredProps, inputProps: { onChange, checked: false } };
       const checkedEvent = { target: { checked: true } };
-
       const wrapper = shallow(<Radio {...props} />);
-
       wrapper.find('input').simulate('change', checkedEvent);
-      expect(handleChange).toBeCalledWith(checkedEvent);
+      expect(onChange).toBeCalledWith(checkedEvent);
     });
 
-    it('should render as checked', () => {
-      const wrapper = shallow(<Radio {...requiredProps} inputProps={{ checked: true }} />);
-      expect(wrapper).toMatchSnapshot();
+    it('should invoke the focus handler', () => {
+      const onFocus = jest.fn();
+      const props = { ...requiredProps, inputProps: { onFocus } };
+      const wrapper = shallow(<Radio {...props} />);
+      wrapper.find('input').simulate('focus');
+      expect(onFocus.mock.calls.length).toBe(1);
+    });
+
+    it('should invoke the blur handler', () => {
+      const onBlur = jest.fn();
+      const props = { ...requiredProps, inputProps: { onBlur } };
+      const wrapper = shallow(<Radio {...props} />);
+      wrapper.find('input').simulate('blur');
+      expect(onBlur.mock.calls.length).toBe(1);
     });
 
     it('should pass through other props to the input', () => {
-      const wrapper = shallow(<Radio {...requiredProps} inputProps={{ 'data-automation': 'first-name-field' }} />);
+      const wrapper = shallow(<Radio {...requiredProps} inputProps={{ checked: true, 'data-automation': 'first-name-field' }} />);
       expect(wrapper).toMatchSnapshot();
     });
   });

--- a/react/Radio/__snapshots__/Radio.test.js.snap
+++ b/react/Radio/__snapshots__/Radio.test.js.snap
@@ -5,53 +5,11 @@ exports[`Radio inputProps should pass through other props to the input 1`] = `
   className="root"
 >
   <input
+    checked={true}
     className="input"
     data-automation="first-name-field"
     id="testRadio"
-    type="radio"
-  />
-  <label
-    className="label"
-    htmlFor="testRadio"
-  >
-    <svg
-      className="svg"
-      focusable="false"
-      viewBox="0 0 200 200"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <circle
-        className="circle circle_isHover"
-        cx="100"
-        cy="100"
-        r="100"
-      />
-      <circle
-        className="circle circle_isSelected"
-        cx="100"
-        cy="100"
-        r="100"
-      />
-    </svg>
-    <Text
-      baseline={false}
-      className="labelText"
-      raw={true}
-    >
-      Still in role
-    </Text>
-  </label>
-</div>
-`;
-
-exports[`Radio inputProps should render as checked 1`] = `
-<div
-  className="root"
->
-  <input
-    checked={true}
-    className="input"
-    id="testRadio"
+    onChange={[Function]}
     type="radio"
   />
   <label
@@ -93,8 +51,10 @@ exports[`Radio should render with className 1`] = `
   className="root testClassname"
 >
   <input
+    checked={false}
     className="input"
     id="testRadio"
+    onChange={[Function]}
     type="radio"
   />
   <label
@@ -136,8 +96,10 @@ exports[`Radio should render with simple props 1`] = `
   className="root"
 >
   <input
+    checked={false}
     className="input"
     id="testRadio"
+    onChange={[Function]}
     type="radio"
   />
   <label

--- a/react/TextField/TextField.demo.js
+++ b/react/TextField/TextField.demo.js
@@ -41,10 +41,8 @@ class TextFieldContainer extends Component {
       <div style={{ width: '300px' }}>
         <DemoComponent
           {...componentProps}
-          inputProps={{
-            onChange: this.handleChange,
-            value: inputValue
-          }}
+          onChange={this.handleChange}
+          value={inputValue}
           onClear={this.handleClear}
         />
       </div>
@@ -64,10 +62,8 @@ export default {
     label: 'First Name',
     message: 'e.g. Olivia',
     // Documentation only:
-    inputProps: {
-      onChange: () => {},
-      value: '...'
-    },
+    onChange: () => {},
+    value: '...',
     onClear: () => {}
   },
   options: [

--- a/react/TextField/TextField.js
+++ b/react/TextField/TextField.js
@@ -1,14 +1,10 @@
 import styles from './TextField.less';
-
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
 import ClearField from '../ClearField/ClearField';
-
 import FieldMessage from '../private/FieldMessage/FieldMessage';
 import FieldLabel from '../private/FieldLabel/FieldLabel';
-
 import invoke from 'lodash/invoke';
 
 function combineClassNames(props = {}, ...classNames) {
@@ -33,27 +29,20 @@ export default class TextField extends Component {
 
   static propTypes = {
     id: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
+    type: PropTypes.string,
     className: PropTypes.string,
     valid: PropTypes.bool,
-    /* eslint-disable consistent-return */
-    inputProps: (props, propName, componentName) => {
-      const { id, inputProps } = props;
-      const { id: inputId } = inputProps || {};
-
-      if (typeof inputProps !== 'undefined' && typeof inputProps !== 'object') {
-        return new Error(`Invalid prop \`inputProps\` of type \`${typeof inputProps}\` supplied to \`${componentName}\`, expected \`object\`.`);
-      }
-
-      if (inputId && id) {
-        return new Error(`\`inputProps.id\` will be overridden by \`id\` in ${componentName}. Please remove it.`);
-      }
-    },
-    /* eslint-enable consistent-return */
+    inputProps: PropTypes.object,
     onClear: PropTypes.func
   };
 
   static defaultProps = {
-    className: ''
+    className: '',
+    inputProps: {}
   };
 
   constructor() {
@@ -83,10 +72,15 @@ export default class TextField extends Component {
   }
 
   renderInput() {
-    const { id, inputProps = {} } = this.props;
+    const { id, value, onChange, onFocus, onBlur, type, inputProps = {} } = this.props;
     const { ref } = inputProps;
     const allInputProps = {
       id,
+      value,
+      onChange,
+      onFocus,
+      onBlur,
+      type,
       ...combineClassNames(inputProps, styles.input),
       ref: attachRefs(this.storeInputReference, ref),
       'aria-describedby': `${id}-message`
@@ -108,8 +102,9 @@ export default class TextField extends Component {
   }
 
   render() {
-    const { id, className, valid, onClear, inputProps = {} } = this.props;
-    const hasValue = (inputProps.value && inputProps.value.length > 0);
+    const { id, value, className, valid, onClear, inputProps = {} } = this.props;
+    const resolvedValue = value || inputProps.value || '';
+    const hasValue = resolvedValue.length > 0;
     const canClear = hasValue && (typeof onClear === 'function');
     const classNames = classnames({
       [styles.root]: true,

--- a/react/TextField/TextField.test.js
+++ b/react/TextField/TextField.test.js
@@ -3,54 +3,64 @@ import React from 'react';
 import TextField from './TextField';
 
 describe('TextField', () => {
-  let spy;
+  const requiredProps = {
+    id: 'testTextField',
+    onChange: () => {},
+    value: ''
+  };
 
+  let spy;
   beforeEach(() => {
     spy = jest.spyOn(global.console, 'error');
   });
-
   afterEach(() => {
     spy.mockRestore();
   });
 
   it('should render with defaults', () => {
-    expect(shallow(<TextField id="testTextField" />)).toMatchSnapshot();
+    expect(shallow(<TextField {...requiredProps} />)).toMatchSnapshot();
   });
 
-  describe('errors', () => {
-    it('should error if `id` is not a string', () => {
-      const expectedError = expect.stringMatching(
-        /Invalid prop `id` of type `boolean` supplied to `TextField`, expected `string/
-      );
+  it('should pass through the type', () => {
+    const wrapper = shallow(<TextField {...requiredProps} type="search" />);
+    const inputType = wrapper.find('input').prop('type');
+    expect(inputType).toEqual('search');
+  });
 
-      shallow(<TextField id={true} />);
-      expect(spy).toBeCalledWith(expectedError);
-    });
+  it('should pass through the value', () => {
+    const wrapper = shallow(<TextField {...requiredProps} value="foo" />);
+    const inputValue = wrapper.find('input').prop('value');
+    expect(inputValue).toEqual('foo');
+  });
 
-    it('should error if `inputProps` is not an object', () => {
-      const expectedError = expect.stringMatching(
-        /Invalid prop `inputProps`/
-      );
+  it('should invoke the focus handler', () => {
+    const onFocus = jest.fn();
+    const wrapper = shallow(<TextField {...requiredProps} onFocus={onFocus} />);
+    wrapper.find('input').simulate('focus');
+    expect(onFocus.mock.calls.length).toEqual(1);
+  });
 
-      shallow(<TextField id="testTextField" inputProps="hey" />);
-      expect(spy).toBeCalledWith(expectedError);
-    });
+  it('should invoke the blur handler', () => {
+    const onBlur = jest.fn();
+    const wrapper = shallow(<TextField {...requiredProps} onBlur={onBlur} />);
+    wrapper.find('input').simulate('blur');
+    expect(onBlur.mock.calls.length).toEqual(1);
+  });
 
-    it('should error if `id` is specified in `inputProps`', () => {
-      const expectedError = expect.stringMatching(
-        /`inputProps.id` will be overridden by `id`/
-      );
-
-      shallow(<TextField id="firstName" inputProps={{ id: 'ignored' }} />);
-      expect(spy).toBeCalledWith(expectedError);
-    });
+  it('should invoke the change handler', () => {
+    const onChange = jest.fn();
+    const wrapper = shallow(<TextField {...requiredProps} onChange={onChange} />);
+    wrapper.find('input').simulate('change', { target: { value: 'foo' } });
+    expect(onChange.mock.calls.length).toEqual(1);
+    expect(onChange.mock.calls[0][0].target.value).toEqual('foo');
   });
 
   it('should render with input props', () => {
     expect(shallow(
       <TextField
-        id="testTextField"
+        {...requiredProps}
         inputProps={{
+          value: 'value',
           className: 'first-name-field',
           'data-automation': 'first-name-field'
         }}
@@ -58,32 +68,32 @@ describe('TextField', () => {
   });
 
   it('should render with valid false', () => {
-    expect(shallow(<TextField id="testTextField" valid={false} />)).toMatchSnapshot();
+    expect(shallow(<TextField {...requiredProps} valid={false} />)).toMatchSnapshot();
   });
 
   describe('clear button', () => {
     const handleClear = () => {};
 
     it('should not be visible when value is empty', () => {
-      expect(shallow(<TextField id="testTextField" inputProps={{ value: '' }} onClear={handleClear} />)).toMatchSnapshot();
+      expect(shallow(<TextField {...requiredProps} value="" onClear={handleClear} />)).toMatchSnapshot();
     });
 
     it('should not be visible when value is provided but no clear handler', () => {
-      expect(shallow(<TextField id="testTextField" inputProps={{ value: 'abc' }} />)).toMatchSnapshot();
+      expect(shallow(<TextField {...requiredProps} value="abc" />)).toMatchSnapshot();
     });
 
     it('should be visible when value is provided', () => {
-      expect(shallow(<TextField id="testTextField" inputProps={{ value: 'abc' }} onClear={handleClear} />)).toMatchSnapshot();
+      expect(shallow(<TextField {...requiredProps} value="abc" onClear={handleClear} />)).toMatchSnapshot();
     });
 
     it('should be visible when value has white spaces only', () => {
-      expect(shallow(<TextField id="testTextField" inputProps={{ value: '  ' }} onClear={handleClear} />)).toMatchSnapshot();
+      expect(shallow(<TextField {...requiredProps} value="  " onClear={handleClear} />)).toMatchSnapshot();
     });
 
     it('should invoke the clear handler when clicked and focus on input', () => {
       const clickHandlerSpy = jest.fn();
 
-      const wrapper = mount(<TextField id="testTextField" onClear={clickHandlerSpy} />);
+      const wrapper = mount(<TextField {...requiredProps} onClear={clickHandlerSpy} />);
       const input = wrapper.find('input').html();
       const clearButton = wrapper.find('.clearField');
 
@@ -91,6 +101,24 @@ describe('TextField', () => {
       expect(clickHandlerSpy).toBeCalled();
       expect(global.document.activeElement.outerHTML).toEqual(input);
       clickHandlerSpy.mockRestore();
+    });
+
+    describe('inputProps', () => {
+      it('should not be visible when value is empty', () => {
+        expect(shallow(<TextField {...requiredProps} inputProps={{ value: '' }} onClear={handleClear} />)).toMatchSnapshot();
+      });
+
+      it('should not be visible when value is provided but no clear handler', () => {
+        expect(shallow(<TextField {...requiredProps} inputProps={{ value: 'abc' }} />)).toMatchSnapshot();
+      });
+
+      it('should be visible when value is provided', () => {
+        expect(shallow(<TextField {...requiredProps} inputProps={{ value: 'abc' }} onClear={handleClear} />)).toMatchSnapshot();
+      });
+
+      it('should be visible when value has white spaces only', () => {
+        expect(shallow(<TextField {...requiredProps} inputProps={{ value: '  ' }} onClear={handleClear} />)).toMatchSnapshot();
+      });
     });
   });
 });

--- a/react/TextField/__snapshots__/TextField.test.js.snap
+++ b/react/TextField/__snapshots__/TextField.test.js.snap
@@ -1,5 +1,157 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TextField clear button inputProps should be visible when value has white spaces only 1`] = `
+<div
+  className="root canClear"
+>
+  <FieldLabel
+    id="testTextField"
+    label=""
+    raw={false}
+    secondaryLabel=""
+    tertiaryLabel=""
+  />
+  <input
+    aria-describedby="testTextField-message"
+    className="input"
+    id="testTextField"
+    onChange={[Function]}
+    value="  "
+  />
+  <span
+    className="clearField"
+    onMouseDown={[Function]}
+  >
+    <ClearField />
+  </span>
+  <FieldMessage
+    id="testTextField-message"
+    message=""
+    messageProps={
+      Object {
+        "critical": false,
+        "positive": false,
+        "secondary": false,
+      }
+    }
+  />
+</div>
+`;
+
+exports[`TextField clear button inputProps should be visible when value is provided 1`] = `
+<div
+  className="root canClear"
+>
+  <FieldLabel
+    id="testTextField"
+    label=""
+    raw={false}
+    secondaryLabel=""
+    tertiaryLabel=""
+  />
+  <input
+    aria-describedby="testTextField-message"
+    className="input"
+    id="testTextField"
+    onChange={[Function]}
+    value="abc"
+  />
+  <span
+    className="clearField"
+    onMouseDown={[Function]}
+  >
+    <ClearField />
+  </span>
+  <FieldMessage
+    id="testTextField-message"
+    message=""
+    messageProps={
+      Object {
+        "critical": false,
+        "positive": false,
+        "secondary": false,
+      }
+    }
+  />
+</div>
+`;
+
+exports[`TextField clear button inputProps should not be visible when value is empty 1`] = `
+<div
+  className="root"
+>
+  <FieldLabel
+    id="testTextField"
+    label=""
+    raw={false}
+    secondaryLabel=""
+    tertiaryLabel=""
+  />
+  <input
+    aria-describedby="testTextField-message"
+    className="input"
+    id="testTextField"
+    onChange={[Function]}
+    value=""
+  />
+  <span
+    className="clearField"
+    onMouseDown={[Function]}
+  >
+    <ClearField />
+  </span>
+  <FieldMessage
+    id="testTextField-message"
+    message=""
+    messageProps={
+      Object {
+        "critical": false,
+        "positive": false,
+        "secondary": false,
+      }
+    }
+  />
+</div>
+`;
+
+exports[`TextField clear button inputProps should not be visible when value is provided but no clear handler 1`] = `
+<div
+  className="root"
+>
+  <FieldLabel
+    id="testTextField"
+    label=""
+    raw={false}
+    secondaryLabel=""
+    tertiaryLabel=""
+  />
+  <input
+    aria-describedby="testTextField-message"
+    className="input"
+    id="testTextField"
+    onChange={[Function]}
+    value="abc"
+  />
+  <span
+    className="clearField"
+    onMouseDown={[Function]}
+  >
+    <ClearField />
+  </span>
+  <FieldMessage
+    id="testTextField-message"
+    message=""
+    messageProps={
+      Object {
+        "critical": false,
+        "positive": false,
+        "secondary": false,
+      }
+    }
+  />
+</div>
+`;
+
 exports[`TextField clear button should be visible when value has white spaces only 1`] = `
 <div
   className="root canClear"
@@ -15,6 +167,7 @@ exports[`TextField clear button should be visible when value has white spaces on
     aria-describedby="testTextField-message"
     className="input"
     id="testTextField"
+    onChange={[Function]}
     value="  "
   />
   <span
@@ -52,6 +205,7 @@ exports[`TextField clear button should be visible when value is provided 1`] = `
     aria-describedby="testTextField-message"
     className="input"
     id="testTextField"
+    onChange={[Function]}
     value="abc"
   />
   <span
@@ -89,6 +243,7 @@ exports[`TextField clear button should not be visible when value is empty 1`] = 
     aria-describedby="testTextField-message"
     className="input"
     id="testTextField"
+    onChange={[Function]}
     value=""
   />
   <span
@@ -126,6 +281,7 @@ exports[`TextField clear button should not be visible when value is provided but
     aria-describedby="testTextField-message"
     className="input"
     id="testTextField"
+    onChange={[Function]}
     value="abc"
   />
   <span
@@ -163,6 +319,8 @@ exports[`TextField should render with defaults 1`] = `
     aria-describedby="testTextField-message"
     className="input"
     id="testTextField"
+    onChange={[Function]}
+    value=""
   />
   <span
     className="clearField"
@@ -200,6 +358,8 @@ exports[`TextField should render with input props 1`] = `
     className="input first-name-field"
     data-automation="first-name-field"
     id="testTextField"
+    onChange={[Function]}
+    value="value"
   />
   <span
     className="clearField"
@@ -236,6 +396,8 @@ exports[`TextField should render with valid false 1`] = `
     aria-describedby="testTextField-message"
     className="input"
     id="testTextField"
+    onChange={[Function]}
+    value=""
   />
   <span
     className="clearField"

--- a/react/Textarea/Textarea.demo.js
+++ b/react/Textarea/Textarea.demo.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
 import Textarea from './Textarea';
 import styles from './Textarea.less';
 import classnames from 'classnames';
@@ -35,10 +34,8 @@ class TextareaContainer extends Component {
     return (
       <DemoComponent
         {...componentProps}
-        inputProps={{
-          onChange: this.handleChange,
-          value: inputValue
-        }}
+        onChange={this.handleChange}
+        value={inputValue}
       />
     );
   }
@@ -56,10 +53,8 @@ export default {
     label: 'Description',
     message: '',
     // Documentation only:
-    inputProps: {
-      onChange: () => {},
-      value: '...'
-    }
+    onChange: () => {},
+    value: '...'
   },
   options: [
     {

--- a/react/Textarea/Textarea.js
+++ b/react/Textarea/Textarea.js
@@ -1,9 +1,7 @@
 import styles from './Textarea.less';
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-
 import FieldMessage from '../private/FieldMessage/FieldMessage';
 import FieldLabel from '../private/FieldLabel/FieldLabel';
 import Text from '../Text/Text';
@@ -22,32 +20,24 @@ export default class Textarea extends Component {
 
   static propTypes = {
     id: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
     className: PropTypes.string,
     valid: PropTypes.bool,
     description: PropTypes.string,
+    inputProps: PropTypes.object,
     /* eslint-disable consistent-return */
-    inputProps: (props, propName, componentName) => {
-      const { id, inputProps } = props;
-      const { id: inputId } = inputProps || {};
-
-      if (typeof inputProps !== 'undefined' && typeof inputProps !== 'object') {
-        return new Error(`Invalid prop \`inputProps\` of type \`${typeof inputProps}\` supplied to \`${componentName}\`, expected \`object\`.`);
-      }
-
-      if (inputId && id) {
-        return new Error(`\`inputProps.id\` will be overridden by \`id\` in ${componentName}. Please remove it.`);
-      }
-    },
     countFeedback: (props, propName, componentName) => {
-      const { inputProps = {} } = props;
-      const { value } = inputProps;
+      const { value, inputProps = {} } = props;
 
       if (typeof props[propName] !== 'function' && typeof props[propName] !== 'undefined') {
         return new Error(`Invalid prop \`${propName}\` of type \`${typeof props[propName]}\` supplied to \`${componentName}\`, expected \`function\`.`);
       }
 
-      if (props[propName] && typeof value !== 'string') {
-        return new Error(`\`inputProps.value\` must be supplied if \`${propName}\` is set`);
+      if (props[propName] && typeof value !== 'string' && typeof inputProps.value !== 'string') {
+        return new Error(`\`value\` must be supplied if \`${propName}\` is set`);
       }
     },
     secondaryLabel: PropTypes.string
@@ -56,7 +46,8 @@ export default class Textarea extends Component {
 
   static defaultProps = {
     className: '',
-    description: ''
+    description: '',
+    inputProps: {}
   };
 
   constructor() {
@@ -68,14 +59,14 @@ export default class Textarea extends Component {
 
   /* eslint-disable consistent-return */
   renderCharacterCount() {
-    const { countFeedback, inputProps = {} } = this.props;
-    const { value } = inputProps;
+    const { value, countFeedback, inputProps = {} } = this.props;
+    const resolvedValue = value || inputProps.value || '';
 
-    if (typeof countFeedback !== 'function' || typeof value !== 'string') {
+    if (typeof countFeedback !== 'function') {
       return;
     }
 
-    const { show = true, count } = countFeedback(value);
+    const { show = true, count } = countFeedback(resolvedValue);
 
     if (!show) {
       return;
@@ -95,9 +86,13 @@ export default class Textarea extends Component {
   /* eslint-enable consistent-return */
 
   renderInput() {
-    const { id, inputProps } = this.props;
+    const { id, value, onChange, onFocus, onBlur, inputProps } = this.props;
     const allInputProps = {
       id,
+      value,
+      onChange,
+      onFocus,
+      onBlur,
       ...combineClassNames(inputProps, styles.textarea),
       'aria-describedby': `${id}-message`
     };

--- a/react/Textarea/Textarea.sketch.js
+++ b/react/Textarea/Textarea.sketch.js
@@ -6,9 +6,8 @@ import SketchFieldContainer from '../private/SketchFieldContainer/SketchFieldCon
 const commonProps = {
   className: styles.root,
   label: 'Label',
-  inputProps: {
-    value: ''
-  },
+  value: '',
+  onChange: () => {},
   countFeedback: () => ({ count: 500 })
 };
 

--- a/react/Textarea/Textarea.test.js
+++ b/react/Textarea/Textarea.test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import React from 'react';
 import { createRenderer } from 'react-test-renderer/shallow';
+import { shallow } from 'enzyme';
 import { findAllWithClass } from 'react-shallow-testutils';
 import Textarea from './Textarea';
 
@@ -37,9 +38,37 @@ describe('Textarea', () => {
     expect(element.type.displayName).to.equal('Textarea');
   });
 
+  it('should pass through the value', () => {
+    const wrapper = shallow(<Textarea id="testTextarea" value="foo" />);
+    const textareaValue = wrapper.find('textarea').prop('value');
+    expect(textareaValue).to.equal('foo');
+  });
+
   it('should render without errors', () => {
     render(<Textarea id="testTextarea" />);
     expect(errors.length).to.equal(0);
+  });
+
+  it('should invoke the focus handler', () => {
+    const onFocus = jest.fn();
+    const wrapper = shallow(<Textarea id="testTextarea" onFocus={onFocus} />);
+    wrapper.find('textarea').simulate('focus');
+    expect(onFocus.mock.calls.length).to.equal(1);
+  });
+
+  it('should invoke the blur handler', () => {
+    const onBlur = jest.fn();
+    const wrapper = shallow(<Textarea id="testTextarea" onBlur={onBlur} />);
+    wrapper.find('textarea').simulate('blur');
+    expect(onBlur.mock.calls.length).to.equal(1);
+  });
+
+  it('should invoke the change handler', () => {
+    const onChange = jest.fn();
+    const wrapper = shallow(<Textarea id="testTextarea" onChange={onChange} />);
+    wrapper.find('textarea').simulate('change', { target: { value: 'foo' } });
+    expect(onChange.mock.calls.length).to.equal(1);
+    expect(onChange.mock.calls[0][0].target.value).to.equal('foo');
   });
 
   describe('id', () => {
@@ -50,24 +79,15 @@ describe('Textarea', () => {
   });
 
   describe('inputProps', () => {
-    it('should error if `inputProps` is not an object', () => {
-      render(<Textarea id="testTextarea" inputProps="hey" />);
-      expect(errors[0]).to.match(/Invalid prop `inputProps`/);
-    });
-
-    it('should error if `inputProps`\'s `id` is specified', () => {
-      render(<Textarea id="firstName" inputProps={{ id: 'ignored' }} />);
-      expect(errors[0]).to.match(/`inputProps.id` will be overridden by `id`/);
-    });
-
     it('should pass through className to the input', () => {
       render(<Textarea id="testTextarea" inputProps={{ className: 'first-name-field' }} />);
       expect(input.props.className).to.match(/first-name-field$/);
     });
 
     it('should pass through other props to the input', () => {
-      render(<Textarea id="testTextarea" inputProps={{ id: 'firstName', 'data-automation': 'first-name-field' }} />);
+      render(<Textarea id="testTextarea" inputProps={{ id: 'firstName', value: 'value', 'data-automation': 'first-name-field' }} />);
       expect(input.props.id).to.equal('firstName');
+      expect(input.props.value).to.equal('value');
       expect(input.props['data-automation']).to.equal('first-name-field');
     });
   });
@@ -116,22 +136,48 @@ describe('Textarea', () => {
       expect(errors[0]).to.match(/Invalid prop `countFeedback`/);
     });
 
-    it('should error if \`countFeedback\` is supplied without \`inputProps.value\`', () => {
+    it('should error if \`countFeedback\` is supplied without a value', () => {
       const countFeedback = v => ({ count: v.length });
       render(<Textarea id="testTextarea" countFeedback={countFeedback} />);
-      expect(errors[0]).to.match(/`inputProps.value` must be supplied if `countFeedback` is set/);
+      expect(errors[0]).to.match(/`value` must be supplied if `countFeedback` is set/);
     });
 
     it('should show count value if \`countFeedback\` function is supplied correctly', () => {
       const countFeedback = v => ({ count: v.length });
-      render(<Textarea id="testTextarea" countFeedback={countFeedback} inputProps={{ value: 'Test value' }} />);
+      render(<Textarea id="testTextarea" countFeedback={countFeedback} value="Test value" />);
       expect(characterCount.props.children).to.equal(10);
+    });
+
+    it('should show count value if value is blank', () => {
+      const countFeedback = v => ({ count: 500 - v.length });
+      render(<Textarea id="testTextarea" countFeedback={countFeedback} value="" />);
+      expect(characterCount.props.children).to.equal(500);
     });
 
     it('should hide count value if \`countFeedback\` function returns \`{ show: false }\`', () => {
       const countFeedback = () => ({ show: false });
-      render(<Textarea id="testTextarea" countFeedback={countFeedback} inputProps={{ value: 'Test value' }} />);
+      render(<Textarea id="testTextarea" countFeedback={countFeedback} value="Test value" />);
       expect(characterCount).to.equal(null);
+    });
+
+    describe('inputProps', () => {
+      it('should show count value if \`countFeedback\` function is supplied correctly', () => {
+        const countFeedback = v => ({ count: v.length });
+        render(<Textarea id="testTextarea" countFeedback={countFeedback} inputProps={{ value: 'Test value' }} />);
+        expect(characterCount.props.children).to.equal(10);
+      });
+
+      it('should show count value if value is blank', () => {
+        const countFeedback = v => ({ count: 500 - v.length });
+        render(<Textarea id="testTextarea" countFeedback={countFeedback} inputProps={{ value: '' }} />);
+        expect(characterCount.props.children).to.equal(500);
+      });
+
+      it('should hide count value if \`countFeedback\` function returns \`{ show: false }\`', () => {
+        const countFeedback = () => ({ show: false });
+        render(<Textarea id="testTextarea" countFeedback={countFeedback} inputProps={{ value: 'Test value' }} />);
+        expect(characterCount).to.equal(null);
+      });
     });
   });
 });


### PR DESCRIPTION
This non-breaking API change affects the following form components:
- **Autosuggest**
- **Checkbox**
- **Dropdown**
- **EmailField**
- **Radio**
- **TextField**
- **Textarea**

The following props can now be provided via the top-level component API, rather than via an `inputProps` object:
- **value**
- **checked** (for Checkbox and Radio)
- **type** (for Autosuggest and TextField)
- **onChange**
- **onFocus**
- **onBlur**

Currently, `value`, `checked`, `type`, `onChange`, `onFocus` and `onBlur` need to be provided via the `inputProps` object. Since these props are heavily used across all form fields, it adds a lot of friction to our component APIs. It also hinders our ability to create and use form libraries, since this is a custom, non-standard API.

**NOTE: Since `inputProps` is still supported, this API change is backwards compatible.**

## Migration Guide

For example, when migrating `TextField`:

```diff
-<TextField {...} inputProps={{ type: 'search', value, onChange: handleChange, onFocus: handleFocus, onBlur: handleBlur />
+<TextField {...} type="search" value={value} onChange={handleChange} onFocus={handleFocus} onBlur={handleBlur} />
```

As another example, when migrating `Checkbox`:

```diff
-<Checkbox {...} inputProps={{ value, checked: true, onChange: handleChange, onFocus: handleFocus, onBlur: handleBlur />
+<Checkbox {...} value={value} checked={true} onChange={handleChange} onFocus={handleFocus} onBlur={handleBlur} />
```
