### PR TITLE
feat(Text): Add large body Text

### DIFF
--- a/docs/src/components/Typography/Typography.js
+++ b/docs/src/components/Typography/Typography.js
@@ -97,6 +97,28 @@ export default () => (
     <PageBlock>
       <Card transparent style={{ maxWidth: 720 }}>
         <Section>
+          <Text heading>Large Text</Text>
+          <Paragraph>
+            <Text>In rare cases where larger text is required, you can use the &ldquo;large&rdquo; text variant, which is 18px over 5 grid rows on both desktop and mobile.</Text>
+          </Paragraph>
+        </Section>
+      </Card>
+    </PageBlock>
+    <Demo
+      spec={{
+        component: Text,
+        container: BackgroundContainer,
+        block: true,
+        initialProps: {
+          large: true,
+          children: loremIpsum
+        },
+        options: []
+      }}
+    />
+    <PageBlock>
+      <Card transparent style={{ maxWidth: 720 }}>
+        <Section>
           <Text heading>Small Text</Text>
           <Paragraph>
             <Text>In rare cases where smaller text is required, you can use the &ldquo;small&rdquo; text variant, which is 14px over 3 grid rows on both desktop and mobile.</Text>

--- a/react/BulletList/BulletList.demo.js
+++ b/react/BulletList/BulletList.demo.js
@@ -1,52 +1,40 @@
 import React from 'react';
 import { BulletList, Bullet } from 'seek-style-guide/react';
 
+const renderChildren = (size = 'Default') =>
+  size === 'Default' ? (
+    <BulletList>
+      <Bullet>Bullet</Bullet>
+      <Bullet>Bullet</Bullet>
+      <Bullet>Bullet</Bullet>
+    </BulletList>
+  ) : (
+    <BulletList>
+      <Bullet {...{ [size.toLowerCase()]: true }}>Bullet</Bullet>
+      <Bullet {...{ [size.toLowerCase()]: true }}>Bullet</Bullet>
+      <Bullet {...{ [size.toLowerCase()]: true }}>Bullet</Bullet>
+    </BulletList>
+  );
+
 export default {
   route: '/bullet-list',
   title: 'Bullet List',
   category: 'Typography',
   component: 'div',
   initialProps: {
-    children: (
-      <BulletList>
-        <Bullet>Bullet point 1</Bullet>
-        <Bullet>Bullet point 2</Bullet>
-        <Bullet>Bullet point 3</Bullet>
-      </BulletList>
-    )
+    children: renderChildren()
   },
   options: [
     {
-      label: 'Type',
+      label: 'Size',
       type: 'radio',
-      states: [
-        {
-          label: 'Standard',
-          transformProps: props => ({
-            ...props,
-            children: (
-              <BulletList>
-                <Bullet>Bullet point 1</Bullet>
-                <Bullet>Bullet point 2</Bullet>
-                <Bullet>Bullet point 3</Bullet>
-              </BulletList>
-            )
-          })
-        },
-        {
-          label: 'Subheading',
-          transformProps: props => ({
-            ...props,
-            children: (
-              <BulletList>
-                <Bullet subheading>Bullet point 1</Bullet>
-                <Bullet subheading>Bullet point 2</Bullet>
-                <Bullet subheading>Bullet point 3</Bullet>
-              </BulletList>
-            )
-          })
-        }
-      ]
+      states: ['Default', 'Large', 'Standard', 'Small'].map(size => ({
+        label: `${String(size)}`,
+        transformProps: props => ({
+          ...props,
+          children: renderChildren(size)
+        })
+      }))
     }
   ]
 };

--- a/react/Rating/Rating.demo.js
+++ b/react/Rating/Rating.demo.js
@@ -49,7 +49,7 @@ export default {
     {
       label: 'Size',
       type: 'radio',
-      states: ['Hero', 'Headline', 'Heading', 'Standard', 'Small']
+      states: ['Hero', 'Headline', 'Heading', 'Large', 'Standard', 'Small']
         .map(size => ({
           label: `${String(size)}`,
           transformProps: ({ hero, ...props }) => ({

--- a/react/StarIcon/StarIcon.less
+++ b/react/StarIcon/StarIcon.less
@@ -54,6 +54,13 @@
     .iconSize(@typography-scale: @heading-type-scale, @typography-scale-mobile: @heading-type-scale-mobile,@icon-scale: @icon-scale);
   }
 
+  &.large {
+    .iconHeight(@large-type-row-span, @large-type-row-span-mobile);
+  }
+  .largeSvg {
+    .iconSize(@large-type-scale, @icon-scale: @icon-scale);
+  }
+
   &.standard {
     .iconHeight(@standard-type-row-span, @standard-type-row-span-mobile);
   }

--- a/react/Text/Text.demo.js
+++ b/react/Text/Text.demo.js
@@ -121,6 +121,13 @@ export default {
           })
         },
         {
+          label: 'Large',
+          transformProps: ({ hero, ...props }) => ({
+            ...props,
+            large: true
+          })
+        },
+        {
           label: 'Standard',
           transformProps: ({ hero, ...props }) => props
         },

--- a/react/Text/Text.less
+++ b/react/Text/Text.less
@@ -32,6 +32,12 @@
   padding-bottom: @row-height;
 }
 
+.large {
+  &:not(.baseline) { .largeTextResponsive(@baseline: false); }
+  &.baseline { .largeTextResponsive(@baseline: true); }
+  padding-bottom: @row-height;
+}
+
 .subheading {
   &:not(.baseline) { .subheadingTextResponsive(@baseline: false); }
   &.baseline { .subheadingTextResponsive(@baseline: true); }

--- a/react/Text/Text.sketch.js
+++ b/react/Text/Text.sketch.js
@@ -10,6 +10,7 @@ const sizes = [
   'headline',
   'heading',
   'subheading',
+  'large',
   'standard',
   'small'
 ];
@@ -32,6 +33,7 @@ export const text = {
   [`${symbolNames.headline}`]: <Text headline>Headline text</Text>,
   [`${symbolNames.heading}`]: <Text heading>Heading text</Text>,
   [`${symbolNames.subheading}`]: <Text subheading>Subheading text</Text>,
+  [`${symbolNames.large}`]: <Text large>Large text</Text>,
   [`${symbolNames.standard}/1. Default`]: <Text>Standard text</Text>,
   [`${symbolNames.standard}/2. Secondary`]: <Text secondary>Standard critical text</Text>,
   [`${symbolNames.standard}/3. Strong`]: <Text strong>Standard strong text</Text>,

--- a/react/Text/__snapshots__/Text.test.js.snap
+++ b/react/Text/__snapshots__/Text.test.js.snap
@@ -108,6 +108,30 @@ exports[`Text sizes should render as hero 2`] = `
 </span>
 `;
 
+exports[`Text sizes should render as large 1`] = `
+<span
+  class="root large baseline"
+>
+  <span
+    class=""
+  >
+    Hello
+  </span>
+</span>
+`;
+
+exports[`Text sizes should render as large 2`] = `
+<span
+  class="root large baseline"
+>
+  <span
+    class=""
+  >
+    Hello
+  </span>
+</span>
+`;
+
 exports[`Text sizes should render as small 1`] = `
 <span
   class="root small baseline"

--- a/react/private/Icon/Icon.less
+++ b/react/private/Icon/Icon.less
@@ -38,6 +38,10 @@
   );
 }
 
+.largeSvg {
+  .iconSize(@large-type-scale);
+}
+
 .standardSvg {
   .iconSize(
     @typography-scale: @standard-type-scale,

--- a/react/private/__snapshots__/withTextProps.test.js.snap
+++ b/react/private/__snapshots__/withTextProps.test.js.snap
@@ -36,6 +36,18 @@ exports[`withTextProps: *hero*: should pass down string size 1`] = `
 />
 `;
 
+exports[`withTextProps: *large*: should convert boolean size into string size 1`] = `
+<OriginalComponent
+  size="large"
+/>
+`;
+
+exports[`withTextProps: *large*: should pass down string size 1`] = `
+<OriginalComponent
+  size="large"
+/>
+`;
+
 exports[`withTextProps: *small*: should convert boolean size into string size 1`] = `
 <OriginalComponent
   size="small"

--- a/react/private/withTextProps.js
+++ b/react/private/withTextProps.js
@@ -10,6 +10,7 @@ import forEach from 'lodash/forEach';
 export const sizes = [
   'small',
   'standard',
+  'large',
   'subheading',
   'heading',
   'headline',

--- a/theme/mixins/type.less
+++ b/theme/mixins/type.less
@@ -17,6 +17,9 @@
 .standardText(@baseline: true) {
   .__type(@standard-type-scale, @standard-type-row-span, @baseline);
 }
+.largeText(@baseline: true) {
+  .__type(@large-type-scale, @large-type-row-span, @baseline);
+}
 .smallText(@baseline: true) {
   .__type(@small-type-scale, @small-type-row-span, @baseline);
 }
@@ -35,6 +38,9 @@
 }
 .standardTextResponsive(@baseline: true) {
   .__responsiveType("standard"; @baseline);
+}
+.largeTextResponsive(@baseline: true) {
+  .__responsiveType("large"; @baseline);
 }
 .smallTextResponsive(@baseline: true) {
   .__responsiveType("small"; @baseline);

--- a/theme/type/type.less
+++ b/theme/type/type.less
@@ -36,6 +36,13 @@
 @subheading-type-row-span-mobile: 4;
 @subheading-type-weight-mobile: @sk-bold;
 
+@large-type-scale: 1.8;
+@large-type-row-span: 5;
+@large-type-weight: @sk-regular;
+@large-type-scale-mobile: 1.8;
+@large-type-row-span-mobile: 5;
+@large-type-weight-mobile: @sk-regular;
+
 @standard-type-scale: 1.6;
 @standard-type-row-span: 4;
 @standard-type-weight: @sk-regular;


### PR DESCRIPTION
Details listed in issue https://github.com/seek-oss/seek-style-guide/issues/485

This change adds `large` Text size, exposing it to `<Text>` and all other components that uses `withTextProps`.

Large has a text size of 18 on both mobile and desktop, but in all other ways works as standard text.

EXAMPLE USAGE:

```js
<Text large>foo </Text>
```
