### PR TITLE
fix(TextField): Remove 'value' prop to be required

### DIFF
--- a/react/TextField/TextField.js
+++ b/react/TextField/TextField.js
@@ -29,7 +29,7 @@ export default class TextField extends Component {
 
   static propTypes = {
     id: PropTypes.string.isRequired,
-    value: PropTypes.string.isRequired,
+    value: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     onFocus: PropTypes.func,
     onBlur: PropTypes.func,


### PR DESCRIPTION
The props is not required, we are even evaluating it in render
```
const resolvedValue = value || inputProps.value || '';
```