### PR TITLE
fix(Pill): Fix IE11 styling of close button

### DIFF
--- a/react/Pill/Pill.less
+++ b/react/Pill/Pill.less
@@ -40,6 +40,9 @@
   box-shadow: none;
   border: none;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   &:focus {
     outline: none;
@@ -70,10 +73,11 @@
   height: @removeCircleDiameter;
   width: @removeCircleDiameter;
   border-radius: @removeCircleDiameter / 2;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
   transition: @spring-transition;
+  line-height: normal;
 }
 
 .removeIcon {


### PR DESCRIPTION
Styling of the close button is broken in IE11 due to there being no support for `display:
inline-flex`. Using `display: flex` instead to work around the problem

![screen shot 2018-05-28 at 10 27 34 am](https://user-images.githubusercontent.com/1896277/40592595-a7c40e5c-6264-11e8-8e81-5fe3efeb8c2b.png)

