### PR TITLE
build(sketch): Temporarily disable sketch export generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "BASE_HREF=/ node docs/server",
     "start-header-footer": "webpack-dev-server --config standalone/header-footer/webpack.config.js --content-base dist",
-    "test": "npm run test-unit && npm run lint && npm run build && npm run html-sketchapp",
+    "test": "npm run test-unit && npm run lint && npm run build",
     "test-unit": "BABEL_ENV=test jest --config ./jest.config.json",
     "update-snapshot": "npm run test-unit -- --updateSnapshot",
     "lint": "npm run lint-js && npm run lint-less && npm run flow",


### PR DESCRIPTION
Temporarily disabling the generation of our sketch exports as it's blocking the pipeline and the root cause seems to be a couple of levels deep. Will keep digging, but for now i feel its best to unblock.