### PR TITLE
build(sketch): Re-enable html-sketchapp-cli in test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "BASE_HREF=/ node docs/server",
     "start-header-footer": "webpack-dev-server --config standalone/header-footer/webpack.config.js --content-base dist",
-    "test": "npm run test-unit && npm run lint && npm run build",
+    "test": "npm run test-unit && npm run lint && npm run build && npm run html-sketchapp",
     "test-unit": "BABEL_ENV=test jest --config ./jest.config.json",
     "update-snapshot": "npm run test-unit -- --updateSnapshot",
     "lint": "npm run lint-js && npm run lint-less && npm run flow",
@@ -104,7 +104,7 @@
     "gh-pages": "^1.0.0",
     "hex-rgb": "^1.0.0",
     "html-minifier": "^3.5.6",
-    "html-sketchapp-cli": "0.4.1",
+    "html-sketchapp-cli": "0.5.2",
     "html-webpack-plugin": "^2.30.1",
     "husky": "^0.14.3",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
As of [v0.5.2](https://github.com/seek-oss/html-sketchapp-cli/releases/tag/v0.5.2), html-sketchapp-cli no longer times out in CI waiting for the static server to start, so we can safely reenable this step.