### PR TITLE
feat(PasswordField): Add basic password field component

### DIFF
--- a/react/PasswordField/PasswordField.js
+++ b/react/PasswordField/PasswordField.js
@@ -1,0 +1,43 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import TextField from '../TextField/TextField';
+
+export default class PasswordField extends Component {
+  static displayName = 'PasswordField';
+
+  static propTypes = {
+    inputProps: PropTypes.object
+  };
+
+  static defaultProps = {
+    inputProps: {}
+  };
+
+  constructor() {
+    super();
+
+    this.storeInputReference = this.storeInputReference.bind(this);
+  }
+
+  storeInputReference(textField) {
+    if (textField !== null) {
+      this.input = textField.input;
+    }
+  }
+
+  render() {
+    const { inputProps, ...props } = this.props;
+    const combinedInputProps = {
+      ...inputProps
+    };
+
+    return (
+      <TextField
+        {...props}
+        ref={this.storeInputReference}
+        type='password'
+        inputProps={combinedInputProps}
+      />
+    );
+  }
+}

--- a/react/index.js
+++ b/react/index.js
@@ -69,6 +69,7 @@ export { default as ClearField } from './ClearField/ClearField';
 export { default as Dropdown } from './Dropdown/Dropdown';
 export { default as EmailField } from './EmailField/EmailField';
 export { default as MonthPicker } from './MonthPicker/MonthPicker';
+export { default as PasswordField } from './PasswordField/PasswordField';
 export { default as SlideToggle } from './SlideToggle/SlideToggle';
 export { default as Textarea } from './Textarea/Textarea';
 export { default as TextField } from './TextField/TextField';


### PR DESCRIPTION
Similar to the existing `EmailField` component, this new component simply exports a `TextField` component with an input type of `password`.

The need for this component arose when working with the `@seek/forms-ui` lib where I had to create a wrapping component in my project to connect the `forms-ui` Field with the style guide's `TextField` which had a type of `password`.

NOTE: The more complex password component with Show/Hide functionality could be added to this basic component in the future.

EXAMPLE USAGE:

```js
import { PasswordField } from 'seek-style-guide/react';

<PasswordField />
```
