### PR TITLE
feat(Pill): Accept content as children, support all valid node types

### DIFF
--- a/react/Pill/Pill.demo.js
+++ b/react/Pill/Pill.demo.js
@@ -29,7 +29,7 @@ export default {
   container: Container,
   sketch,
   initialProps: {
-    text: 'I\'m a pill',
+    children: 'I\'m a pill',
     onClose: null
   },
   options: [

--- a/react/Pill/Pill.js
+++ b/react/Pill/Pill.js
@@ -1,6 +1,5 @@
 // @flow
 import styles from './Pill.less';
-import PropTypes from 'prop-types';
 
 import React, { Component } from 'react';
 import classnames from 'classnames';
@@ -10,7 +9,7 @@ import CrossIcon from '../CrossIcon/CrossIcon';
 import ScreenReaderOnly from '../ScreenReaderOnly/ScreenReaderOnly';
 
 type Props = {
-  text: PropTypes.node,
+  text: React$Node,
   onClose?: Function,
   className?: string
 };

--- a/react/Pill/Pill.js
+++ b/react/Pill/Pill.js
@@ -1,15 +1,15 @@
 // @flow
 import styles from './Pill.less';
-
 import React, { Component } from 'react';
+import type { Node } from 'react';
 import classnames from 'classnames';
-
 import Text from '../Text/Text';
 import CrossIcon from '../CrossIcon/CrossIcon';
 import ScreenReaderOnly from '../ScreenReaderOnly/ScreenReaderOnly';
 
 type Props = {
-  text: React$Node,
+  children?: Node,
+  text?: Node,
   onClose?: Function,
   className?: string
 };
@@ -27,25 +27,29 @@ export default class Pill extends Component<Props> {
   }
 
   renderStaticPill() {
-    const { text, className, ...restProps } = this.props;
+    const { children, text, className, ...restProps } = this.props;
+    const content = children || text;
+
     return (
       <span className={classnames(className, styles.staticPill)} {...restProps}>
-        <Text baseline={false} raw>{text}</Text>
+        <Text baseline={false} raw>{content}</Text>
       </span>
     );
   }
 
   renderInteractivePill() {
-    const { text, onClose, className, ...restProps } = this.props;
+    const { children, text, onClose, className, ...restProps } = this.props;
+    const content = children || text;
+
     return (
       <span
         className={classnames(className, styles.interactivePill)}
         {...restProps}>
-        <Text baseline={false} raw>{text}</Text>
+        <Text baseline={false} raw>{content}</Text>
         <button
           className={styles.removeButton}
           onClick={onClose}>
-          <ScreenReaderOnly>Remove item {text}</ScreenReaderOnly>
+          <ScreenReaderOnly>Remove item {content}</ScreenReaderOnly>
           <div className={styles.removeCircle}>
             <CrossIcon
               className={styles.removeIcon}
@@ -59,6 +63,7 @@ export default class Pill extends Component<Props> {
 
   render() {
     const { onClose } = this.props;
+
     return onClose ?
       this.renderInteractivePill() :
       this.renderStaticPill();

--- a/react/Pill/Pill.js
+++ b/react/Pill/Pill.js
@@ -1,5 +1,6 @@
 // @flow
 import styles from './Pill.less';
+import PropTypes from 'prop-types';
 
 import React, { Component } from 'react';
 import classnames from 'classnames';
@@ -9,7 +10,7 @@ import CrossIcon from '../CrossIcon/CrossIcon';
 import ScreenReaderOnly from '../ScreenReaderOnly/ScreenReaderOnly';
 
 type Props = {
-  text: string,
+  text: PropTypes.node,
   onClose?: Function,
   className?: string
 };

--- a/react/Pill/Pill.sketch.js
+++ b/react/Pill/Pill.sketch.js
@@ -7,12 +7,12 @@ const noop = () => {};
 export const symbols = {
   'Pill/Static': (
     <SketchFieldContainer>
-      <Pill text="Pill text" />
+      <Pill>Pill text</Pill>
     </SketchFieldContainer>
   ),
   'Pill/Interactive': (
     <SketchFieldContainer>
-      <Pill text="Pill text" onClose={noop} />
+      <Pill onClose={noop}>Pill text</Pill>
     </SketchFieldContainer>
   )
 };

--- a/react/Pill/Pill.test.js
+++ b/react/Pill/Pill.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, render } from 'enzyme';
 import Pill from './Pill';
-import { render } from 'enzyme/build/index';
 
 const renderPill = props => shallow(
   <Pill

--- a/react/Pill/Pill.test.js
+++ b/react/Pill/Pill.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, render } from 'enzyme';
+import { shallow } from 'enzyme';
 import Pill from './Pill';
 
 const renderPill = props => shallow(
@@ -17,7 +17,8 @@ describe('Pill:', () => {
 
   it('should render a child component', () => {
     const ChildComponent = () => (<div>Hello</div>);
-    expect(render(<Pill text={<ChildComponent />} />)).toMatchSnapshot();
+    const pill = renderPill({ text: <ChildComponent /> });
+    expect(pill).toMatchSnapshot();
   });
 
   it('should render an interactive pill', () => {

--- a/react/Pill/Pill.test.js
+++ b/react/Pill/Pill.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Pill from './Pill';
+import { render } from 'enzyme/build/index';
 
 const renderPill = props => shallow(
   <Pill
@@ -13,6 +14,11 @@ describe('Pill:', () => {
   it('should render a static pill', () => {
     const pill = renderPill();
     expect(pill).toMatchSnapshot();
+  });
+
+  it('should render a child component', () => {
+    const ChildComponent = () => (<div>Hello</div>);
+    expect(render(<Pill text={<ChildComponent />} />)).toMatchSnapshot();
   });
 
   it('should render an interactive pill', () => {

--- a/react/Pill/Pill.test.js
+++ b/react/Pill/Pill.test.js
@@ -4,7 +4,7 @@ import Pill from './Pill';
 
 const renderPill = props => shallow(
   <Pill
-    text="I am a pill"
+    children="I am a pill"
     {...props}
   />
 );
@@ -17,12 +17,23 @@ describe('Pill:', () => {
 
   it('should render a child component', () => {
     const ChildComponent = () => (<div>Hello</div>);
-    const pill = renderPill({ text: <ChildComponent /> });
+    const pill = renderPill({ children: <ChildComponent /> });
+    expect(pill).toMatchSnapshot();
+  });
+
+  it('should support the legacy "text" prop', () => {
+    const ChildComponent = () => (<div>Hello</div>);
+    const pill = renderPill({ children: null, text: <ChildComponent /> });
     expect(pill).toMatchSnapshot();
   });
 
   it('should render an interactive pill', () => {
     const pill = renderPill({ onClose: () => {} });
+    expect(pill).toMatchSnapshot();
+  });
+
+  it('should render an interactive pill with the legacy "text" prop', () => {
+    const pill = renderPill({ onClose: () => {}, children: null, text: 'I am a pill' });
     expect(pill).toMatchSnapshot();
   });
 

--- a/react/Pill/__snapshots__/Pill.test.js.snap
+++ b/react/Pill/__snapshots__/Pill.test.js.snap
@@ -116,3 +116,48 @@ exports[`Pill: should render an interactive pill 1`] = `
   </button>
 </span>
 `;
+
+exports[`Pill: should render an interactive pill with the legacy "text" prop 1`] = `
+<span
+  className="interactivePill"
+>
+  <Text
+    baseline={false}
+    raw={true}
+  >
+    I am a pill
+  </Text>
+  <button
+    className="removeButton"
+    onClick={[Function]}
+  >
+    <ScreenReaderOnly
+      component="span"
+    >
+      Remove item 
+      I am a pill
+    </ScreenReaderOnly>
+    <div
+      className="removeCircle"
+    >
+      <CrossIcon
+        className="removeIcon"
+        svgClassName="removeSvg"
+      />
+    </div>
+  </button>
+</span>
+`;
+
+exports[`Pill: should support the legacy "text" prop 1`] = `
+<span
+  className="staticPill"
+>
+  <Text
+    baseline={false}
+    raw={true}
+  >
+    <ChildComponent />
+  </Text>
+</span>
+`;

--- a/react/Pill/__snapshots__/Pill.test.js.snap
+++ b/react/Pill/__snapshots__/Pill.test.js.snap
@@ -16,19 +16,14 @@ exports[`Pill: should pass through additional props 1`] = `
 
 exports[`Pill: should render a child component 1`] = `
 <span
-  class="staticPill"
+  className="staticPill"
 >
-  <span
-    class="root standard raw"
+  <Text
+    baseline={false}
+    raw={true}
   >
-    <span
-      class=""
-    >
-      <div>
-        Hello
-      </div>
-    </span>
-  </span>
+    <ChildComponent />
+  </Text>
 </span>
 `;
 

--- a/react/Pill/__snapshots__/Pill.test.js.snap
+++ b/react/Pill/__snapshots__/Pill.test.js.snap
@@ -14,6 +14,24 @@ exports[`Pill: should pass through additional props 1`] = `
 </span>
 `;
 
+exports[`Pill: should render a child component 1`] = `
+<span
+  class="staticPill"
+>
+  <span
+    class="root standard raw"
+  >
+    <span
+      class=""
+    >
+      <div>
+        Hello
+      </div>
+    </span>
+  </span>
+</span>
+`;
+
 exports[`Pill: should render a static pill 1`] = `
 <span
   className="staticPill"


### PR DESCRIPTION
Pills currently only support rendering strings as content. In order to support the full range of typographical components, you can now render arbitrary nodes inside of pills.

To make this clearer, we now support rendering pill content as children. Note that, while this is a backwards compatible change, you're strongly encouraged to migrate to the new API.

EXAMPLE USAGE:

```js
<Pill>The last word is <Strong>strong.</Strong></Pill>
```

MIGRATION GUIDE:

```diff
-<Pill text="Hello world" />
+<Pill>Hello world</Pill>
```