### PR TITLE
feat(Text): Support text highlighting, add Highlight component

### DIFF
--- a/docs/src/components/Typography/Typography.js
+++ b/docs/src/components/Typography/Typography.js
@@ -11,10 +11,12 @@ import {
   Positive,
   Critical,
   Secondary,
+  Highlight,
   Info
 } from 'seek-style-guide/react';
 import Demo from '../Demo/Demo';
 import textDemoSpec from 'seek-style-guide/react/Text/Text.demo';
+import omit from 'lodash/omit';
 
 const BackgroundContainer = ({ component: DemoComponent, componentProps }) => (
   <PageBlock>
@@ -59,7 +61,7 @@ export default () => (
     </PageBlock>
     <Demo
       spec={{
-        ...textDemoSpec,
+        ...omit(textDemoSpec, 'sketch'),
         title: null
       }}
     />
@@ -410,6 +412,40 @@ export default () => (
         initialProps: {
           // eslint-disable-next-line react/jsx-key
           children: ['The last word of this sentence is ', <Secondary>secondary.</Secondary>]
+        },
+        options: []
+      }}
+    />
+    <PageBlock>
+      <Card transparent style={{ maxWidth: 720 }}>
+        <Section>
+          <Text heading>Highlighted Text</Text>
+          <Paragraph>
+            <Text>Any text element can be explicity marked as highlighted with the &ldquo;highlight&rdquo; property or the inline &ldquo;Highlight&rdquo; component.</Text>
+          </Paragraph>
+        </Section>
+      </Card>
+    </PageBlock>
+    <Demo
+      spec={{
+        component: Text,
+        container: BackgroundContainer,
+        block: true,
+        initialProps: {
+          highlight: true,
+          children: loremIpsumShort
+        },
+        options: []
+      }}
+    />
+    <Demo
+      spec={{
+        component: Text,
+        container: BackgroundContainer,
+        block: true,
+        initialProps: {
+          // eslint-disable-next-line react/jsx-key
+          children: ['The last word of this sentence is ', <Highlight>highlighted.</Highlight>]
         },
         options: []
       }}

--- a/react/Highlight/Highlight.demo.js
+++ b/react/Highlight/Highlight.demo.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Highlight from './Highlight';
+import Text from '../Text/Text';
+
+export default {
+  route: '/highlight',
+  title: 'Highlight',
+  category: 'Typography',
+  component: Text,
+  initialProps: {
+    headline: true,
+    children: [
+      'This text is ',
+      <Highlight key="highlight">highlighted</Highlight>
+    ]
+  },
+  options: [
+    {
+      label: 'States',
+      type: 'checklist',
+      states: [
+        {
+          label: 'Secondary',
+          transformProps: props => ({
+            ...props,
+            secondary: true,
+            children: [
+              'This text is ',
+              <Highlight key="highlight" secondary>highlighted</Highlight>
+            ]
+          })
+        }
+      ]
+    }
+  ]
+};

--- a/react/Highlight/Highlight.js
+++ b/react/Highlight/Highlight.js
@@ -1,0 +1,24 @@
+import styles from './Highlight.less';
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+export default function Highlight({ children, secondary, className, ...restProps }) {
+  return (
+    <span
+      {...restProps}
+      className={classnames({
+        [styles.root]: true,
+        [styles.secondary]: secondary,
+        className
+      })}>
+      {children}
+    </span>
+  );
+}
+
+Highlight.propTypes = {
+  children: PropTypes.node.isRequired,
+  secondary: PropTypes.bool,
+  className: PropTypes.string
+};

--- a/react/Highlight/Highlight.less
+++ b/react/Highlight/Highlight.less
@@ -1,0 +1,13 @@
+@import (reference) "~seek-style-guide/theme";
+
+.root {
+  background-color: fade(@sk-blue-lighter, 12%);
+  border-radius: 2px;
+  display: inline-block;
+  margin: -2px;
+  padding: 2px;
+}
+
+.secondary {
+  color: @sk-charcoal;
+}

--- a/react/Text/Text.demo.js
+++ b/react/Text/Text.demo.js
@@ -38,6 +38,13 @@ export default {
           })
         },
         {
+          label: 'Highlight',
+          transformProps: props => ({
+            ...props,
+            highlight: true
+          })
+        },
+        {
           label: 'Disable baseline',
           transformProps: props => ({
             ...props,

--- a/react/Text/Text.js
+++ b/react/Text/Text.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import stylesPositive from '../Positive/Positive.less';
 import stylesCritical from '../Critical/Critical.less';
 import stylesSecondary from '../Secondary/Secondary.less';
+import stylesHighlight from '../Highlight/Highlight.less';
 import stylesInfo from '../Info/Info.less';
 import stylesStrong from '../Strong/Strong.less';
 import stylesRegular from '../Regular/Regular.less';
@@ -23,6 +24,7 @@ const Text = ({
   positive,
   critical,
   secondary,
+  highlight,
   info,
   strong,
   regular,
@@ -47,6 +49,8 @@ const Text = ({
           [stylesPositive.root]: positive,
           [stylesCritical.root]: critical,
           [stylesSecondary.root]: secondary,
+          [stylesHighlight.root]: highlight,
+          [stylesHighlight.secondary]: highlight && secondary,
           [stylesInfo.root]: info,
           [stylesStrong.root]: strong,
           [stylesRegular.root]: regular,
@@ -74,6 +78,7 @@ Text.propTypes = {
   positive: PropTypes.bool,
   critical: PropTypes.bool,
   secondary: PropTypes.bool,
+  highlight: PropTypes.bool,
   info: PropTypes.bool,
   strong: PropTypes.bool,
   regular: PropTypes.bool,

--- a/react/index.js
+++ b/react/index.js
@@ -20,6 +20,7 @@ export { default as Critical } from './Critical/Critical';
 export { default as Paragraph } from './Paragraph/Paragraph';
 export { default as Positive } from './Positive/Positive';
 export { default as Secondary } from './Secondary/Secondary';
+export { default as Highlight } from './Highlight/Highlight';
 export { default as Info } from './Info/Info';
 export { default as Strong } from './Strong/Strong';
 export { default as Text } from './Text/Text';


### PR DESCRIPTION
<img width="341" alt="screen shot 2018-06-26 at 10 32 43 am" src="https://user-images.githubusercontent.com/696693/41882463-61fc533c-792c-11e8-99c5-8ee9d312bc1b.png">

EXAMPLE USAGE:

Block highlighting:

```js
<Text highlight>This text block is highlighted.</Text>
```

Inline highlighting:

```js
<Text>The last word of this sentence is <Highlight>highlighted.</Highlight></Text>
```

Secondary text highlighting:
```js
<Text secondary>The last word of this secondary text is <Highlight secondary>highlighted.</Highlight></Text>
```
