### PR TITLE
fix(reset): Remove browser default styling of mark elements

### DIFF
--- a/react/StyleGuideProvider/reset.less
+++ b/react/StyleGuideProvider/reset.less
@@ -47,8 +47,11 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
+
+/* Custom reset rules */
 mark {
   background-color: transparent;
   color: inherit;
 }
+
 /* stylelint-enable */

--- a/react/StyleGuideProvider/reset.less
+++ b/react/StyleGuideProvider/reset.less
@@ -47,4 +47,8 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
+mark {
+  background-color: transparent;
+  color: inherit;
+}
 /* stylelint-enable */


### PR DESCRIPTION
The introduction of the `<Highlight>` component using the `<mark>` element has exposed that we previously had no reset for the default browser styles of this element — namely the `background-color` and `color`.

Anyone using the `<mark>` element elsewhere in their apps and expecting the default browser styling (extremely unlikely) will have to manually reinstate these rules.