### PR TITLE
test(css): Parse CSS class names in unit tests

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -2,11 +2,9 @@
   "testPathIgnorePatterns": [
     "<rootDir>[/\\\\](dist|node_modules)[/\\\\]"
   ],
-  "moduleNameMapper": {
-    "\\.(css|less)$": "identity-obj-proxy"
-  },
   "transform": {
     "^.+\\.js$": "<rootDir>/test/babel.transform.js",
+    "^.+\\.(css|less)$": "<rootDir>/test/cssModules.transform.js",
     "^.+\\.svg$": "<rootDir>/test/svg.transform.js"
   },
   "transformIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "html-sketchapp-cli": "0.5.2",
     "html-webpack-plugin": "^2.30.1",
     "husky": "^0.14.3",
-    "identity-obj-proxy": "^3.0.0",
     "ignore-loader": "^0.1.2",
     "import-glob": "^1.5.0",
     "jest": "^22.0.0",

--- a/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
+++ b/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
@@ -6,6 +6,7 @@ exports[`Autosuggest should render with label 1`] = `
     aria-expanded="false"
     aria-haspopup="listbox"
     aria-owns="react-autowhatever-1"
+    class="container"
     role="combobox"
   >
     <div
@@ -75,6 +76,7 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
     aria-expanded="false"
     aria-haspopup="listbox"
     aria-owns="react-autowhatever-1"
+    class="container"
     role="combobox"
   >
     <div
@@ -144,6 +146,7 @@ exports[`Autosuggest should render with simple props 1`] = `
     aria-expanded="false"
     aria-haspopup="listbox"
     aria-owns="react-autowhatever-1"
+    class="container"
     role="combobox"
   >
     <div
@@ -194,6 +197,7 @@ exports[`Autosuggest should render with suggestions 1`] = `
     aria-expanded="true"
     aria-haspopup="listbox"
     aria-owns="react-autowhatever-1"
+    class="container containerOpen"
     role="combobox"
   >
     <div
@@ -227,7 +231,7 @@ exports[`Autosuggest should render with suggestions 1`] = `
       />
     </div>
     <div
-      class="suggestionsContainer"
+      class="suggestionsContainer suggestionsContainerOpen"
       id="react-autowhatever-1"
       role="listbox"
     >
@@ -236,6 +240,7 @@ exports[`Autosuggest should render with suggestions 1`] = `
       >
         <li
           aria-selected="false"
+          class="suggestion"
           data-suggestion-index="0"
           id="react-autowhatever-1--item-0"
           role="option"
@@ -248,6 +253,7 @@ exports[`Autosuggest should render with suggestions 1`] = `
         </li>
         <li
           aria-selected="false"
+          class="suggestion"
           data-suggestion-index="1"
           id="react-autowhatever-1--item-1"
           role="option"

--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -129,7 +129,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 >
                   SEEK sites
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -253,7 +253,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 >
                   International partners
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -454,7 +454,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 >
                   Partner services
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -590,7 +590,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 >
                   Social
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -897,7 +897,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 >
                   SEEK sites
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -1021,7 +1021,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 >
                   International partners
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -1222,7 +1222,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 >
                   Partner services
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -1358,7 +1358,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 >
                   Social
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -1665,7 +1665,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 >
                   SEEK sites
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -1789,7 +1789,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 >
                   International partners
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -1990,7 +1990,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 >
                   Partner services
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -2126,7 +2126,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 >
                   Social
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -2433,7 +2433,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 >
                   SEEK sites
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -2557,7 +2557,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 >
                   International partners
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -2758,7 +2758,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 >
                   Partner services
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -2894,7 +2894,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 >
                   Social
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -3190,7 +3190,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 >
                   SEEK sites
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -3314,7 +3314,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 >
                   International partners
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>
@@ -3559,7 +3559,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 >
                   Social
                   <span
-                    class="root root down chevron"
+                    class="root root chevron"
                   >
                     mock svg
                   </span>

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -135,7 +135,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                   />
                 </span>
                 <span
-                  class="root root down chevron"
+                  class="root root chevron"
                 >
                   mock svg
                 </span>
@@ -548,7 +548,6 @@ exports[`Header: should append returnUrl to signin and register links if present
             >
               <nav
                 aria-labelledby="Locales"
-                class="root"
                 role="navigation"
               >
                 <span
@@ -563,18 +562,14 @@ exports[`Header: should append returnUrl to signin and register links if present
                 <ul
                   class="list"
                 >
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <span
                       class="locale_isActive"
                     >
                       AU
                     </span>
                   </li>
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <a
                       class="localeLink"
                       data-analytics="header:nz+homepage"
@@ -734,7 +729,7 @@ exports[`Header: should render first part of email address when username isn't p
                   </span>
                 </span>
                 <span
-                  class="root root down chevron"
+                  class="root root chevron"
                 >
                   mock svg
                 </span>
@@ -1151,7 +1146,6 @@ exports[`Header: should render first part of email address when username isn't p
             >
               <nav
                 aria-labelledby="Locales"
-                class="root"
                 role="navigation"
               >
                 <span
@@ -1166,18 +1160,14 @@ exports[`Header: should render first part of email address when username isn't p
                 <ul
                   class="list"
                 >
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <span
                       class="locale_isActive"
                     >
                       AU
                     </span>
                   </li>
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <a
                       class="localeLink"
                       data-analytics="header:nz+homepage"
@@ -1333,7 +1323,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                   />
                 </span>
                 <span
-                  class="root root down chevron"
+                  class="root root chevron"
                 >
                   mock svg
                 </span>
@@ -1746,7 +1736,6 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
             >
               <nav
                 aria-labelledby="Locales"
-                class="root"
                 role="navigation"
               >
                 <span
@@ -1761,18 +1750,14 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                 <ul
                   class="list"
                 >
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <span
                       class="locale_isActive"
                     >
                       AU
                     </span>
                   </li>
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <a
                       class="localeLink"
                       data-analytics="header:nz+homepage"
@@ -1932,7 +1917,7 @@ exports[`Header: should render when authenticated 1`] = `
                   </span>
                 </span>
                 <span
-                  class="root root down chevron"
+                  class="root root chevron"
                 >
                   mock svg
                 </span>
@@ -2349,7 +2334,6 @@ exports[`Header: should render when authenticated 1`] = `
             >
               <nav
                 aria-labelledby="Locales"
-                class="root"
                 role="navigation"
               >
                 <span
@@ -2364,18 +2348,14 @@ exports[`Header: should render when authenticated 1`] = `
                 <ul
                   class="list"
                 >
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <span
                       class="locale_isActive"
                     >
                       AU
                     </span>
                   </li>
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <a
                       class="localeLink"
                       data-analytics="header:nz+homepage"
@@ -2531,7 +2511,7 @@ exports[`Header: should render when authenticated but username and email is not 
                   />
                 </span>
                 <span
-                  class="root root down chevron"
+                  class="root root chevron"
                 >
                   mock svg
                 </span>
@@ -2948,7 +2928,6 @@ exports[`Header: should render when authenticated but username and email is not 
             >
               <nav
                 aria-labelledby="Locales"
-                class="root"
                 role="navigation"
               >
                 <span
@@ -2963,18 +2942,14 @@ exports[`Header: should render when authenticated but username and email is not 
                 <ul
                   class="list"
                 >
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <span
                       class="locale_isActive"
                     >
                       AU
                     </span>
                   </li>
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <a
                       class="localeLink"
                       data-analytics="header:nz+homepage"
@@ -3130,7 +3105,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                   />
                 </span>
                 <span
-                  class="root root down chevron"
+                  class="root root chevron"
                 >
                   mock svg
                 </span>
@@ -3543,7 +3518,6 @@ exports[`Header: should render when authentication is pending 1`] = `
             >
               <nav
                 aria-labelledby="Locales"
-                class="root"
                 role="navigation"
               >
                 <span
@@ -3558,18 +3532,14 @@ exports[`Header: should render when authentication is pending 1`] = `
                 <ul
                   class="list"
                 >
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <span
                       class="locale_isActive"
                     >
                       AU
                     </span>
                   </li>
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <a
                       class="localeLink"
                       data-analytics="header:nz+homepage"
@@ -3727,7 +3697,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                   />
                 </span>
                 <span
-                  class="root root down chevron"
+                  class="root root chevron"
                 >
                   mock svg
                 </span>
@@ -4148,7 +4118,6 @@ exports[`Header: should render when unauthenticated 1`] = `
             >
               <nav
                 aria-labelledby="Locales"
-                class="root"
                 role="navigation"
               >
                 <span
@@ -4163,18 +4132,14 @@ exports[`Header: should render when unauthenticated 1`] = `
                 <ul
                   class="list"
                 >
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <span
                       class="locale_isActive"
                     >
                       AU
                     </span>
                   </li>
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <a
                       class="localeLink"
                       data-analytics="header:nz+homepage"
@@ -4298,7 +4263,7 @@ exports[`Header: should render with a custom logo 1`] = `
                   />
                 </span>
                 <span
-                  class="root root down chevron"
+                  class="root root chevron"
                 >
                   mock svg
                 </span>
@@ -4711,7 +4676,6 @@ exports[`Header: should render with a custom logo 1`] = `
             >
               <nav
                 aria-labelledby="Locales"
-                class="root"
                 role="navigation"
               >
                 <span
@@ -4726,18 +4690,14 @@ exports[`Header: should render with a custom logo 1`] = `
                 <ul
                   class="list"
                 >
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <span
                       class="locale_isActive"
                     >
                       AU
                     </span>
                   </li>
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <a
                       class="localeLink"
                       data-analytics="header:nz+homepage"
@@ -4893,7 +4853,7 @@ exports[`Header: should render with locale of AU 1`] = `
                   />
                 </span>
                 <span
-                  class="root root down chevron"
+                  class="root root chevron"
                 >
                   mock svg
                 </span>
@@ -5306,7 +5266,6 @@ exports[`Header: should render with locale of AU 1`] = `
             >
               <nav
                 aria-labelledby="Locales"
-                class="root"
                 role="navigation"
               >
                 <span
@@ -5321,18 +5280,14 @@ exports[`Header: should render with locale of AU 1`] = `
                 <ul
                   class="list"
                 >
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <span
                       class="locale_isActive"
                     >
                       AU
                     </span>
                   </li>
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <a
                       class="localeLink"
                       data-analytics="header:nz+homepage"
@@ -5488,7 +5443,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                   />
                 </span>
                 <span
-                  class="root root down chevron"
+                  class="root root chevron"
                 >
                   mock svg
                 </span>
@@ -5850,7 +5805,6 @@ exports[`Header: should render with locale of NZ 1`] = `
             >
               <nav
                 aria-labelledby="Locales"
-                class="root"
                 role="navigation"
               >
                 <span
@@ -5865,9 +5819,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                 <ul
                   class="list list_isNZ"
                 >
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <a
                       class="localeLink"
                       data-analytics="header:au+homepage"
@@ -5877,9 +5829,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                       AU
                     </a>
                   </li>
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <span
                       class="locale_isActive"
                     >
@@ -6032,7 +5982,7 @@ exports[`Header: should render with no divider 1`] = `
                   />
                 </span>
                 <span
-                  class="root root down chevron"
+                  class="root root chevron"
                 >
                   mock svg
                 </span>
@@ -6445,7 +6395,6 @@ exports[`Header: should render with no divider 1`] = `
             >
               <nav
                 aria-labelledby="Locales"
-                class="root"
                 role="navigation"
               >
                 <span
@@ -6460,18 +6409,14 @@ exports[`Header: should render with no divider 1`] = `
                 <ul
                   class="list"
                 >
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <span
                       class="locale_isActive"
                     >
                       AU
                     </span>
                   </li>
-                  <li
-                    class="listItem"
-                  >
+                  <li>
                     <a
                       class="localeLink"
                       data-analytics="header:nz+homepage"

--- a/react/PartnerSites/Locales/__snapshots__/Locales.test.js.snap
+++ b/react/PartnerSites/Locales/__snapshots__/Locales.test.js.snap
@@ -3,7 +3,6 @@
 exports[`Locales: should render with locale of AU first and active 1`] = `
 <nav
   aria-labelledby="Locales"
-  class="root"
   role="navigation"
 >
   <span
@@ -18,18 +17,14 @@ exports[`Locales: should render with locale of AU first and active 1`] = `
   <ul
     class="list"
   >
-    <li
-      class="listItem"
-    >
+    <li>
       <span
         class="locale_isActive"
       >
         AU
       </span>
     </li>
-    <li
-      class="listItem"
-    >
+    <li>
       <a
         class="localeLink"
         data-analytics="header:nz+homepage"
@@ -46,7 +41,6 @@ exports[`Locales: should render with locale of AU first and active 1`] = `
 exports[`Locales: should render with locale of NZ first and active 1`] = `
 <nav
   aria-labelledby="Locales"
-  class="root"
   role="navigation"
 >
   <span
@@ -61,9 +55,7 @@ exports[`Locales: should render with locale of NZ first and active 1`] = `
   <ul
     class="list list_isNZ"
   >
-    <li
-      class="listItem"
-    >
+    <li>
       <a
         class="localeLink"
         data-analytics="header:au+homepage"
@@ -73,9 +65,7 @@ exports[`Locales: should render with locale of NZ first and active 1`] = `
         AU
       </a>
     </li>
-    <li
-      class="listItem"
-    >
+    <li>
       <span
         class="locale_isActive"
       >

--- a/test/cssModules.transform.js
+++ b/test/cssModules.transform.js
@@ -1,0 +1,21 @@
+// Really naive, regex-based class name extractor
+
+module.exports = {
+  process: src => {
+    const classNames = [];
+
+    const classNameRegEx = /\.([_a-zA-Z0-9]+)(?=[\.:\[\s{])/gm;
+    let match = classNameRegEx.exec(src);
+    while (match !== null) {
+      classNames.push(match[1]);
+      match = classNameRegEx.exec(src);
+    }
+
+    const cssModule = {};
+    classNames.forEach(className => {
+      cssModule[className] = className;
+    });
+
+    return `module.exports = ${JSON.stringify(cssModule)}`;
+  }
+};

--- a/test/cssModules.transform.js
+++ b/test/cssModules.transform.js
@@ -4,7 +4,7 @@ module.exports = {
   process: src => {
     const classNames = [];
 
-    const classNameRegEx = /\.([_a-zA-Z0-9]+)(?=[\.:\[\s{])/gm;
+    const classNameRegEx = /\.([-_a-zA-Z0-9]+)(?=[\.:\[\s{])/gm;
     let match = classNameRegEx.exec(src);
     while (match !== null) {
       classNames.push(match[1]);


### PR DESCRIPTION
I split this PR out from another piece of work where I've started programatically iterating over the class names exported by a Less file. This clashes with our usage of `identity-obj-proxy` in unit tests, since `Object.keys` returns `[ ]` when called on a proxy object. Instead, we now have a custom Jest transformer that quickly extracts class names via a simple regex.

Not surprisingly, this change has highlighted differences in our snapshots where the proxy object didn't behave like a real CSS module.