### PR TITLE
fix(Dropdown): Make Dropdown width 100% of parent

### DIFF
--- a/react/Dropdown/Dropdown.demo.js
+++ b/react/Dropdown/Dropdown.demo.js
@@ -32,11 +32,13 @@ class DropdownContainer extends Component {
     const { value } = this.state;
 
     return (
-      <DemoComponent
-        {...componentProps}
-        value={value}
-        onChange={this.handleChange}
-      />
+      <div style={{ width: '300px' }}>
+        <DemoComponent
+          {...componentProps}
+          value={value}
+          onChange={this.handleChange}
+        />
+      </div>
     );
   }
 }

--- a/react/Dropdown/Dropdown.less
+++ b/react/Dropdown/Dropdown.less
@@ -3,7 +3,6 @@
 @chevronWidth: 16px + (@field-gutter-width * 2);
 
 .root {
-  display: inline-block;
   position: relative;
 }
 


### PR DESCRIPTION
BREAKING CHANGE:

`Dropdown` is currently not 100% to the parent at all times and therefore does not function the same as `TextField`. The issue is that the parent (.root) has `display: inline-block;` and the min-width is being dictated by the length of the `option`.

As a consumer if you where relying on inline-block you will have to add it but most use cases are fine.