### PR TITLE
fix(Button): Fix how Button renders when pink and ghost

### DIFF
--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -112,6 +112,10 @@
   line-height: @touchableTextHeight - (@border-width * 2);
 }
 
+.root_isPink.root_isGhost {
+  .ghostColor(@sk-pink)
+}
+
 .root_isBlue.root_isGhost {
   .ghostColor(@sk-blue-lighter)
 }


### PR DESCRIPTION
Usage of 
```js
<Button
 color="pink"
 ghost
>
 Hello world
</Button>
```
is now consistent with how blue and gray ghost buttons display.