### PR TITLE
test(css): Prefix mock class names with file name to avoid conflicts

### DIFF
--- a/react/Alert/__snapshots__/Alert.test.js.snap
+++ b/react/Alert/__snapshots__/Alert.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Alert: levels: should render primary alerts 1`] = `
 <Section
-  className="root"
+  className="Alert__root"
   header={false}
   level="primary"
   pullout={false}
@@ -10,14 +10,14 @@ exports[`Alert: levels: should render primary alerts 1`] = `
   tone="positive"
 >
   <div
-    className="alert"
+    className="Alert__alert"
   >
     <TickCircleIcon
-      className="icon"
+      className="Alert__icon"
       filled={false}
     />
     <div
-      className="text"
+      className="Alert__text"
     >
       <Text
         baseline={false}
@@ -32,7 +32,7 @@ exports[`Alert: levels: should render primary alerts 1`] = `
 
 exports[`Alert: levels: should render secondary alerts 1`] = `
 <Section
-  className="root"
+  className="Alert__root"
   header={false}
   level="secondary"
   pullout={false}
@@ -40,14 +40,14 @@ exports[`Alert: levels: should render secondary alerts 1`] = `
   tone="positive"
 >
   <div
-    className="alert"
+    className="Alert__alert"
   >
     <TickCircleIcon
-      className="icon"
+      className="Alert__icon"
       filled={false}
     />
     <div
-      className="text"
+      className="Alert__text"
     >
       <Text
         baseline={false}
@@ -62,17 +62,17 @@ exports[`Alert: levels: should render secondary alerts 1`] = `
 
 exports[`Alert: levels: should render tertiary alerts 1`] = `
 <div
-  className="root positive"
+  className="Alert__root Alert__positive"
 >
   <div
-    className="alert"
+    className="Alert__alert"
   >
     <TickCircleIcon
-      className="icon"
+      className="Alert__icon"
       filled={false}
     />
     <div
-      className="text"
+      className="Alert__text"
     >
       <Text
         baseline={false}
@@ -87,7 +87,7 @@ exports[`Alert: levels: should render tertiary alerts 1`] = `
 
 exports[`Alert: should pass through additional props 1`] = `
 <Section
-  className="root"
+  className="Alert__root"
   custom-prop={true}
   header={false}
   level="primary"
@@ -96,14 +96,14 @@ exports[`Alert: should pass through additional props 1`] = `
   tone="positive"
 >
   <div
-    className="alert"
+    className="Alert__alert"
   >
     <TickCircleIcon
-      className="icon"
+      className="Alert__icon"
       filled={false}
     />
     <div
-      className="text"
+      className="Alert__text"
     >
       <Text
         baseline={false}
@@ -118,7 +118,7 @@ exports[`Alert: should pass through additional props 1`] = `
 
 exports[`Alert: should render a close button 1`] = `
 <Section
-  className="root"
+  className="Alert__root"
   header={false}
   level="primary"
   pullout={false}
@@ -126,14 +126,14 @@ exports[`Alert: should render a close button 1`] = `
   tone="positive"
 >
   <div
-    className="alert"
+    className="Alert__alert"
   >
     <TickCircleIcon
-      className="icon"
+      className="Alert__icon"
       filled={false}
     />
     <div
-      className="text"
+      className="Alert__text"
     >
       <Text
         baseline={false}
@@ -143,7 +143,7 @@ exports[`Alert: should render a close button 1`] = `
       </Text>
     </div>
     <button
-      className="close"
+      className="Alert__close"
       onClick={[Function]}
     >
       <CrossIcon />
@@ -154,7 +154,7 @@ exports[`Alert: should render a close button 1`] = `
 
 exports[`Alert: should render the pullout style 1`] = `
 <Section
-  className="root"
+  className="Alert__root"
   header={false}
   level="primary"
   pullout={true}
@@ -162,14 +162,14 @@ exports[`Alert: should render the pullout style 1`] = `
   tone="positive"
 >
   <div
-    className="alert"
+    className="Alert__alert"
   >
     <TickCircleIcon
-      className="icon"
+      className="Alert__icon"
       filled={false}
     />
     <div
-      className="text"
+      className="Alert__text"
     >
       <Text
         baseline={false}
@@ -184,7 +184,7 @@ exports[`Alert: should render the pullout style 1`] = `
 
 exports[`Alert: should render with a hidden icon 1`] = `
 <Section
-  className="root"
+  className="Alert__root"
   header={false}
   level="primary"
   pullout={false}
@@ -192,10 +192,10 @@ exports[`Alert: should render with a hidden icon 1`] = `
   tone="positive"
 >
   <div
-    className="alert"
+    className="Alert__alert"
   >
     <div
-      className="text"
+      className="Alert__text"
     >
       <Text
         baseline={false}
@@ -210,7 +210,7 @@ exports[`Alert: should render with a hidden icon 1`] = `
 
 exports[`Alert: types: should render critical alerts 1`] = `
 <Section
-  className="root"
+  className="Alert__root"
   header={false}
   level="primary"
   pullout={false}
@@ -218,13 +218,13 @@ exports[`Alert: types: should render critical alerts 1`] = `
   tone="critical"
 >
   <div
-    className="alert"
+    className="Alert__alert"
   >
     <CriticalIcon
-      className="icon"
+      className="Alert__icon"
     />
     <div
-      className="text"
+      className="Alert__text"
     >
       <Text
         baseline={false}
@@ -239,7 +239,7 @@ exports[`Alert: types: should render critical alerts 1`] = `
 
 exports[`Alert: types: should render help alerts 1`] = `
 <Section
-  className="root"
+  className="Alert__root"
   header={false}
   level="primary"
   pullout={false}
@@ -247,13 +247,13 @@ exports[`Alert: types: should render help alerts 1`] = `
   tone="help"
 >
   <div
-    className="alert"
+    className="Alert__alert"
   >
     <HelpIcon
-      className="icon"
+      className="Alert__icon"
     />
     <div
-      className="text"
+      className="Alert__text"
     >
       <Text
         baseline={false}
@@ -268,7 +268,7 @@ exports[`Alert: types: should render help alerts 1`] = `
 
 exports[`Alert: types: should render info alerts 1`] = `
 <Section
-  className="root"
+  className="Alert__root"
   header={false}
   level="primary"
   pullout={false}
@@ -276,13 +276,13 @@ exports[`Alert: types: should render info alerts 1`] = `
   tone="info"
 >
   <div
-    className="alert"
+    className="Alert__alert"
   >
     <InfoIcon
-      className="icon"
+      className="Alert__icon"
     />
     <div
-      className="text"
+      className="Alert__text"
     >
       <Text
         baseline={false}
@@ -297,7 +297,7 @@ exports[`Alert: types: should render info alerts 1`] = `
 
 exports[`Alert: types: should render positive alerts 1`] = `
 <Section
-  className="root"
+  className="Alert__root"
   header={false}
   level="primary"
   pullout={false}
@@ -305,14 +305,14 @@ exports[`Alert: types: should render positive alerts 1`] = `
   tone="positive"
 >
   <div
-    className="alert"
+    className="Alert__alert"
   >
     <TickCircleIcon
-      className="icon"
+      className="Alert__icon"
       filled={false}
     />
     <div
-      className="text"
+      className="Alert__text"
     >
       <Text
         baseline={false}
@@ -327,7 +327,7 @@ exports[`Alert: types: should render positive alerts 1`] = `
 
 exports[`Alert: will accept a node in a the message prop 1`] = `
 <Section
-  className="root"
+  className="Alert__root"
   header={false}
   level="primary"
   pullout={false}
@@ -335,14 +335,14 @@ exports[`Alert: will accept a node in a the message prop 1`] = `
   tone="positive"
 >
   <div
-    className="alert"
+    className="Alert__alert"
   >
     <TickCircleIcon
-      className="icon"
+      className="Alert__icon"
       filled={false}
     />
     <div
-      className="text"
+      className="Alert__text"
     >
       <Text
         baseline={false}

--- a/react/Autosuggest/Autosuggest.test.js
+++ b/react/Autosuggest/Autosuggest.test.js
@@ -48,7 +48,7 @@ describe('Autosuggest', () => {
 
   it('should render with suggestions', () => {
     const wrapper = render(<Autosuggest {...getAutosuggestProps(['test', 'test 2'])} id="testAutosuggest" />);
-    const suggestions = wrapper.find('.suggestionsContainer').find('li');
+    const suggestions = wrapper.find('.Autosuggest__suggestionsContainer').find('li');
     expect(wrapper).toMatchSnapshot();
     expect(suggestions.length).toEqual(2);
   });

--- a/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
+++ b/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
@@ -6,24 +6,24 @@ exports[`Autosuggest should render with label 1`] = `
     aria-expanded="false"
     aria-haspopup="listbox"
     aria-owns="react-autowhatever-1"
-    class="container"
+    class="Autosuggest__container"
     role="combobox"
   >
     <div
-      class="root"
+      class="TextField__root"
     >
       <label
         class=""
         for="testAutosuggest"
       >
         <span
-          class="root standard baseline"
+          class="Text__root Text__standard Text__baseline"
         >
           <span
             class=""
           >
             <strong
-              class="root"
+              class="Strong__root"
             >
               Foo
             </strong>
@@ -36,36 +36,36 @@ exports[`Autosuggest should render with label 1`] = `
         aria-controls="react-autowhatever-1"
         aria-describedby="testAutosuggest-message"
         autocomplete="off"
-        class="input"
+        class="TextField__input"
         id="testAutosuggest"
         type="text"
         value=""
       />
       <span
-        class="clearField"
+        class="TextField__clearField"
       >
         <div
-          class="root"
+          class="ClearField__root"
         >
           <span
-            class="root"
+            class="Icon__root"
           >
             mock svg
           </span>
         </div>
       </span>
       <div
-        class="root"
+        class="FieldMessage__root"
       />
     </div>
     <div
-      class="suggestionsContainer suggestionsContainer_withLabel"
+      class="Autosuggest__suggestionsContainer Autosuggest__suggestionsContainer_withLabel"
       id="react-autowhatever-1"
       role="listbox"
     />
   </div>
   <div
-    class="autosuggestBackdrop"
+    class="Autosuggest__autosuggestBackdrop"
   />
 </div>
 `;
@@ -76,24 +76,24 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
     aria-expanded="false"
     aria-haspopup="listbox"
     aria-owns="react-autowhatever-1"
-    class="container"
+    class="Autosuggest__container"
     role="combobox"
   >
     <div
-      class="root"
+      class="TextField__root"
     >
       <label
-        class="isLabelCoveredWithBackdrop LABEL_TEST_CLASS"
+        class="Autosuggest__isLabelCoveredWithBackdrop LABEL_TEST_CLASS"
         for="testAutosuggest"
       >
         <span
-          class="root standard baseline"
+          class="Text__root Text__standard Text__baseline"
         >
           <span
             class=""
           >
             <strong
-              class="root"
+              class="Strong__root"
             >
               Foo
             </strong>
@@ -106,36 +106,36 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
         aria-controls="react-autowhatever-1"
         aria-describedby="testAutosuggest-message"
         autocomplete="off"
-        class="input"
+        class="TextField__input"
         id="testAutosuggest"
         type="text"
         value=""
       />
       <span
-        class="clearField"
+        class="TextField__clearField"
       >
         <div
-          class="root"
+          class="ClearField__root"
         >
           <span
-            class="root"
+            class="Icon__root"
           >
             mock svg
           </span>
         </div>
       </span>
       <div
-        class="root"
+        class="FieldMessage__root"
       />
     </div>
     <div
-      class="suggestionsContainer suggestionsContainer_withLabel"
+      class="Autosuggest__suggestionsContainer Autosuggest__suggestionsContainer_withLabel"
       id="react-autowhatever-1"
       role="listbox"
     />
   </div>
   <div
-    class="autosuggestBackdrop backdrop_isMobile"
+    class="Autosuggest__autosuggestBackdrop Autosuggest__backdrop_isMobile"
   />
 </div>
 `;
@@ -146,47 +146,47 @@ exports[`Autosuggest should render with simple props 1`] = `
     aria-expanded="false"
     aria-haspopup="listbox"
     aria-owns="react-autowhatever-1"
-    class="container"
+    class="Autosuggest__container"
     role="combobox"
   >
     <div
-      class="root"
+      class="TextField__root"
     >
       <input
         aria-autocomplete="list"
         aria-controls="react-autowhatever-1"
         aria-describedby="testAutosuggest-message"
         autocomplete="off"
-        class="input"
+        class="TextField__input"
         id="testAutosuggest"
         type="text"
         value=""
       />
       <span
-        class="clearField"
+        class="TextField__clearField"
       >
         <div
-          class="root"
+          class="ClearField__root"
         >
           <span
-            class="root"
+            class="Icon__root"
           >
             mock svg
           </span>
         </div>
       </span>
       <div
-        class="root"
+        class="FieldMessage__root"
       />
     </div>
     <div
-      class="suggestionsContainer"
+      class="Autosuggest__suggestionsContainer"
       id="react-autowhatever-1"
       role="listbox"
     />
   </div>
   <div
-    class="autosuggestBackdrop"
+    class="Autosuggest__autosuggestBackdrop"
   />
 </div>
 `;
@@ -197,41 +197,41 @@ exports[`Autosuggest should render with suggestions 1`] = `
     aria-expanded="true"
     aria-haspopup="listbox"
     aria-owns="react-autowhatever-1"
-    class="container containerOpen"
+    class="Autosuggest__container Autosuggest__containerOpen"
     role="combobox"
   >
     <div
-      class="root"
+      class="TextField__root"
     >
       <input
         aria-autocomplete="list"
         aria-controls="react-autowhatever-1"
         aria-describedby="testAutosuggest-message"
         autocomplete="off"
-        class="input"
+        class="TextField__input"
         id="testAutosuggest"
         type="text"
         value=""
       />
       <span
-        class="clearField"
+        class="TextField__clearField"
       >
         <div
-          class="root"
+          class="ClearField__root"
         >
           <span
-            class="root"
+            class="Icon__root"
           >
             mock svg
           </span>
         </div>
       </span>
       <div
-        class="root"
+        class="FieldMessage__root"
       />
     </div>
     <div
-      class="suggestionsContainer suggestionsContainerOpen"
+      class="Autosuggest__suggestionsContainer Autosuggest__suggestionsContainerOpen"
       id="react-autowhatever-1"
       role="listbox"
     >
@@ -240,7 +240,7 @@ exports[`Autosuggest should render with suggestions 1`] = `
       >
         <li
           aria-selected="false"
-          class="suggestion"
+          class="Autosuggest__suggestion"
           data-suggestion-index="0"
           id="react-autowhatever-1--item-0"
           role="option"
@@ -253,7 +253,7 @@ exports[`Autosuggest should render with suggestions 1`] = `
         </li>
         <li
           aria-selected="false"
-          class="suggestion"
+          class="Autosuggest__suggestion"
           data-suggestion-index="1"
           id="react-autowhatever-1--item-1"
           role="option"
@@ -268,7 +268,7 @@ exports[`Autosuggest should render with suggestions 1`] = `
     </div>
   </div>
   <div
-    class="autosuggestBackdrop"
+    class="Autosuggest__autosuggestBackdrop"
   />
 </div>
 `;

--- a/react/BulletList/__snapshots__/BulletList.test.js.snap
+++ b/react/BulletList/__snapshots__/BulletList.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BulletList renders with standard text 1`] = `
 <ul
-  className="root"
+  className="BulletList__root"
 >
   <Bullet>
     Foo

--- a/react/Button/__snapshots__/Button.test.js.snap
+++ b/react/Button/__snapshots__/Button.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Button: color variants: should render blue button 1`] = `
 <button
-  className="root root_isBlue"
+  className="Button__root Button__root_isBlue"
   disabled={false}
 >
   SEEK
@@ -11,7 +11,7 @@ exports[`Button: color variants: should render blue button 1`] = `
 
 exports[`Button: color variants: should render gray button 1`] = `
 <button
-  className="root root_isGray"
+  className="Button__root Button__root_isGray"
   disabled={false}
 >
   SEEK
@@ -20,7 +20,7 @@ exports[`Button: color variants: should render gray button 1`] = `
 
 exports[`Button: color variants: should render pink button 1`] = `
 <button
-  className="root root_isPink"
+  className="Button__root Button__root_isPink"
   disabled={false}
 >
   SEEK
@@ -29,7 +29,7 @@ exports[`Button: color variants: should render pink button 1`] = `
 
 exports[`Button: color variants: should render transparent button 1`] = `
 <button
-  className="root root_isTransparent"
+  className="Button__root Button__root_isTransparent"
   disabled={false}
 >
   SEEK
@@ -38,7 +38,7 @@ exports[`Button: color variants: should render transparent button 1`] = `
 
 exports[`Button: color variants: should render white ghost button 1`] = `
 <button
-  className="root root_isGhost root_isWhite"
+  className="Button__root Button__root_isGhost Button__root_isWhite"
   disabled={false}
 >
   SEEK
@@ -47,7 +47,7 @@ exports[`Button: color variants: should render white ghost button 1`] = `
 
 exports[`Button: should render as an anchor with href="https://www.seek.com.au" 1`] = `
 <a
-  className="root root_isPink"
+  className="Button__root Button__root_isPink"
   disabled={false}
   href="https://www.seek.com.au"
 >
@@ -57,7 +57,7 @@ exports[`Button: should render as an anchor with href="https://www.seek.com.au" 
 
 exports[`Button: should render as loading 1`] = `
 <button
-  className="root loading root_isBlue"
+  className="Button__root Button__loading Button__root_isBlue"
   disabled={true}
 >
   SEEK
@@ -66,7 +66,7 @@ exports[`Button: should render as loading 1`] = `
 
 exports[`Button: should render custom component based on it’s reference 1`] = `
 <CustomComponent
-  className="root root_isPink"
+  className="Button__root Button__root_isPink"
   disabled={false}
 >
   SEEK
@@ -75,7 +75,7 @@ exports[`Button: should render custom component based on it’s reference 1`] = 
 
 exports[`Button: should render fullwidth button 1`] = `
 <button
-  className="root fullWidth root_isTransparent"
+  className="Button__root Button__fullWidth Button__root_isTransparent"
   disabled={false}
 >
   SEEK
@@ -84,7 +84,7 @@ exports[`Button: should render fullwidth button 1`] = `
 
 exports[`Button: should render with array of nodes 1`] = `
 <button
-  className="root root_isBlue"
+  className="Button__root Button__root_isBlue"
   disabled={false}
 >
   <span>
@@ -98,7 +98,7 @@ exports[`Button: should render with array of nodes 1`] = `
 
 exports[`Button: should render with className 1`] = `
 <button
-  className="root foo root_isGray"
+  className="Button__root foo Button__root_isGray"
   disabled={false}
 >
   SEEK
@@ -107,7 +107,7 @@ exports[`Button: should render with className 1`] = `
 
 exports[`Button: should render with node 1`] = `
 <button
-  className="root root_isBlue"
+  className="Button__root Button__root_isBlue"
   disabled={false}
 >
   <h5>

--- a/react/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/react/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ButtonGroup: should combine className when passed in 1`] = `
 <div
-  className="combineMe group"
+  className="combineMe Button__group"
 >
   <Button
     className=""
@@ -21,7 +21,7 @@ exports[`ButtonGroup: should combine className when passed in 1`] = `
 
 exports[`ButtonGroup: should render a button group with node 1`] = `
 <div
-  className="group"
+  className="Button__group"
 >
   <Button
     className=""

--- a/react/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/react/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -2,32 +2,32 @@
 
 exports[`Checkbox FieldMessage should render field message when passed 1`] = `
 <div
-  className="root invalid"
+  className="Checkbox__root Checkbox__invalid"
 >
   <input
     checked={false}
-    className="input"
+    className="Checkbox__input"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
   />
   <label
-    className="label"
+    className="Checkbox__label"
     htmlFor="testCheckbox"
   >
     <div
-      className="standard"
+      className="Checkbox__standard"
     >
       <div
-        className="checkbox"
+        className="Checkbox__checkbox"
       >
         <CheckMarkIcon
-          className="checkMark"
-          svgClassName="checkMarkSvg checkMarkSvg_isHover"
+          className="Checkbox__checkMark"
+          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
         />
         <CheckMarkIcon
-          className="checkMark"
-          svgClassName="checkMarkSvg checkMarkSvg_isSelected"
+          className="Checkbox__checkMark"
+          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
       <span>
@@ -52,33 +52,33 @@ exports[`Checkbox FieldMessage should render field message when passed 1`] = `
 
 exports[`Checkbox inputProps should pass through other props to the input 1`] = `
 <div
-  className="root"
+  className="Checkbox__root"
 >
   <input
     checked={false}
-    className="input"
+    className="Checkbox__input"
     data-automation="first-name-field"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
   />
   <label
-    className="label"
+    className="Checkbox__label"
     htmlFor="testCheckbox"
   >
     <div
-      className="standard"
+      className="Checkbox__standard"
     >
       <div
-        className="checkbox"
+        className="Checkbox__checkbox"
       >
         <CheckMarkIcon
-          className="checkMark"
-          svgClassName="checkMarkSvg checkMarkSvg_isHover"
+          className="Checkbox__checkMark"
+          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
         />
         <CheckMarkIcon
-          className="checkMark"
-          svgClassName="checkMarkSvg checkMarkSvg_isSelected"
+          className="Checkbox__checkMark"
+          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
       <span>
@@ -102,21 +102,21 @@ exports[`Checkbox inputProps should pass through other props to the input 1`] = 
 
 exports[`Checkbox should render with button style 1`] = `
 <div
-  className="root"
+  className="Checkbox__root"
 >
   <input
     checked={false}
-    className="input"
+    className="Checkbox__input"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
   />
   <label
-    className="label"
+    className="Checkbox__label"
     htmlFor="testCheckbox"
   >
     <span
-      className="button"
+      className="Checkbox__button"
     >
       Still in role
     </span>
@@ -137,32 +137,32 @@ exports[`Checkbox should render with button style 1`] = `
 
 exports[`Checkbox should render with className 1`] = `
 <div
-  className="root testClassname"
+  className="Checkbox__root testClassname"
 >
   <input
     checked={false}
-    className="input"
+    className="Checkbox__input"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
   />
   <label
-    className="label"
+    className="Checkbox__label"
     htmlFor="testCheckbox"
   >
     <div
-      className="standard"
+      className="Checkbox__standard"
     >
       <div
-        className="checkbox"
+        className="Checkbox__checkbox"
       >
         <CheckMarkIcon
-          className="checkMark"
-          svgClassName="checkMarkSvg checkMarkSvg_isHover"
+          className="Checkbox__checkMark"
+          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
         />
         <CheckMarkIcon
-          className="checkMark"
-          svgClassName="checkMarkSvg checkMarkSvg_isSelected"
+          className="Checkbox__checkMark"
+          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
       <span>
@@ -186,32 +186,32 @@ exports[`Checkbox should render with className 1`] = `
 
 exports[`Checkbox should render with simple props 1`] = `
 <div
-  className="root"
+  className="Checkbox__root"
 >
   <input
     checked={false}
-    className="input"
+    className="Checkbox__input"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
   />
   <label
-    className="label"
+    className="Checkbox__label"
     htmlFor="testCheckbox"
   >
     <div
-      className="standard"
+      className="Checkbox__standard"
     >
       <div
-        className="checkbox"
+        className="Checkbox__checkbox"
       >
         <CheckMarkIcon
-          className="checkMark"
-          svgClassName="checkMarkSvg checkMarkSvg_isHover"
+          className="Checkbox__checkMark"
+          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
         />
         <CheckMarkIcon
-          className="checkMark"
-          svgClassName="checkMarkSvg checkMarkSvg_isSelected"
+          className="Checkbox__checkMark"
+          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
       <span>
@@ -235,32 +235,32 @@ exports[`Checkbox should render with simple props 1`] = `
 
 exports[`Checkbox should render with standard checkbox style 1`] = `
 <div
-  className="root"
+  className="Checkbox__root"
 >
   <input
     checked={false}
-    className="input"
+    className="Checkbox__input"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
   />
   <label
-    className="label"
+    className="Checkbox__label"
     htmlFor="testCheckbox"
   >
     <div
-      className="standard"
+      className="Checkbox__standard"
     >
       <div
-        className="checkbox"
+        className="Checkbox__checkbox"
       >
         <CheckMarkIcon
-          className="checkMark"
-          svgClassName="checkMarkSvg checkMarkSvg_isHover"
+          className="Checkbox__checkMark"
+          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
         />
         <CheckMarkIcon
-          className="checkMark"
-          svgClassName="checkMarkSvg checkMarkSvg_isSelected"
+          className="Checkbox__checkMark"
+          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
       <span>

--- a/react/Columns/__snapshots__/Columns.test.js.snap
+++ b/react/Columns/__snapshots__/Columns.test.js.snap
@@ -2,16 +2,16 @@
 
 exports[`Columns: should render columns 1`] = `
 <div
-  className="columns"
+  className="Columns__columns"
 >
   <div
-    className="column"
+    className="Columns__column"
     key="0"
   >
     <div />
   </div>
   <div
-    className="column"
+    className="Columns__column"
     key="1"
   >
     <div />
@@ -21,10 +21,10 @@ exports[`Columns: should render columns 1`] = `
 
 exports[`Columns: should render columns in reverse 1`] = `
 <div
-  className="columns columns_reverse"
+  className="Columns__columns Columns__columns_reverse"
 >
   <div
-    className="column"
+    className="Columns__column"
     key="0"
   >
     <div
@@ -32,7 +32,7 @@ exports[`Columns: should render columns in reverse 1`] = `
     />
   </div>
   <div
-    className="column"
+    className="Columns__column"
     key="1"
   >
     <div
@@ -44,16 +44,16 @@ exports[`Columns: should render columns in reverse 1`] = `
 
 exports[`Columns: should render flexible columns 1`] = `
 <div
-  className="columns columns_flexible"
+  className="Columns__columns Columns__columns_flexible"
 >
   <div
-    className="column"
+    className="Columns__column"
     key="0"
   >
     <div />
   </div>
   <div
-    className="column"
+    className="Columns__column"
     key="1"
   >
     <div />
@@ -63,16 +63,16 @@ exports[`Columns: should render flexible columns 1`] = `
 
 exports[`Columns: should render tight columns 1`] = `
 <div
-  className="columns columns_tight"
+  className="Columns__columns Columns__columns_tight"
 >
   <div
-    className="column"
+    className="Columns__column"
     key="0"
   >
     <div />
   </div>
   <div
-    className="column"
+    className="Columns__column"
     key="1"
   >
     <div />

--- a/react/Dropdown/Dropdown.test.js
+++ b/react/Dropdown/Dropdown.test.js
@@ -40,7 +40,7 @@ describe('Dropdown', () => {
   function render(jsx) {
     element = jsx;
     dropdown = renderer.render(element);
-    input = findAllWithClass(dropdown, 'dropdown')[0] || null;
+    input = findAllWithClass(dropdown, 'Dropdown__dropdown')[0] || null;
     placeholder = findAllWithType(dropdown, 'option')[0] || null;
     optionGroup = findAllWithType(dropdown, 'optgroup')[0] || null;
     childOptions = findAllWithType(optionGroup, 'option') || null;

--- a/react/FieldLabel/FieldLabel.test.js
+++ b/react/FieldLabel/FieldLabel.test.js
@@ -34,7 +34,7 @@ describe('FieldLabel', () => {
     label = findAllWithType(fieldLabel, 'label')[0] || null;
     labelText = findAllWithType(fieldLabel, Strong)[0] || null;
     secondaryLabel = findAllWithType(fieldLabel, Secondary)[0] || null;
-    tertiaryLabel = findAllWithClass(fieldLabel, 'tertiary')[0] || null;
+    tertiaryLabel = findAllWithClass(fieldLabel, 'FieldLabel__tertiary')[0] || null;
   }
 
   it('should have a displayName', () => {

--- a/react/FieldMessage/FieldMessage.test.js
+++ b/react/FieldMessage/FieldMessage.test.js
@@ -28,8 +28,8 @@ describe('FieldMessage', () => {
   function render(jsx) {
     element = jsx;
     fieldMessage = renderer.render(element);
-    message = findAllWithClass(fieldMessage, 'message')[0] || null;
-    messageIcon = findAllWithClass(fieldMessage, 'messageIcon')[0] || null;
+    message = findAllWithClass(fieldMessage, 'TEST_MESSAGE_CLASS')[0] || null;
+    messageIcon = findAllWithClass(fieldMessage, 'FieldMessage__messageIcon')[0] || null;
   }
 
   function messageText() {
@@ -38,23 +38,23 @@ describe('FieldMessage', () => {
 
   describe('message', () => {
     it('should not be rendered by default', () => {
-      render(<FieldMessage messageProps={{ className: 'message' }} />);
+      render(<FieldMessage messageProps={{ className: 'TEST_MESSAGE_CLASS' }} />);
       expect(message).to.equal(null);
     });
 
     it('should have the right text when `message` is specified and no icon by default', () => {
-      render(<FieldMessage message="Something went wrong" messageProps={{ className: 'message' }} />);
+      render(<FieldMessage message="Something went wrong" messageProps={{ className: 'TEST_MESSAGE_CLASS' }} />);
       expect(messageText()).to.equal('Something went wrong');
       expect(messageIcon).to.equal(null);
     });
 
     it('should pass through className to the message', () => {
-      render(<FieldMessage message="Something went wrong" messageProps={{ className: 'message first-name-message' }} />);
+      render(<FieldMessage message="Something went wrong" messageProps={{ className: 'TEST_MESSAGE_CLASS first-name-message' }} />);
       expect(message.props.className).to.match(/first-name-message$/);
     });
 
     it('should default to secondary text', () => {
-      render(<FieldMessage message="Something went wrong" messageProps={{ className: 'message' }} />);
+      render(<FieldMessage message="Something went wrong" messageProps={{ className: 'TEST_MESSAGE_CLASS' }} />);
       expect(message.props.secondary).to.equal(true);
     });
 
@@ -70,7 +70,7 @@ describe('FieldMessage', () => {
 
     describe('messageProps', () => {
       it('should pass through other props to the message', () => {
-        render(<FieldMessage message="Something went wrong" messageProps={{ className: 'message', 'data-automation': 'first-name-message' }} />);
+        render(<FieldMessage message="Something went wrong" messageProps={{ className: 'TEST_MESSAGE_CLASS', 'data-automation': 'first-name-message' }} />);
         expect(message.props['data-automation']).to.equal('first-name-message');
       });
     });
@@ -78,7 +78,7 @@ describe('FieldMessage', () => {
     describe('valid', () => {
       describe('set to false', () => {
         it('FieldMessage should have a icon and set text as critical', () => {
-          render(<FieldMessage valid={false} message="Something went wrong" messageProps={{ className: 'message' }} />);
+          render(<FieldMessage valid={false} message="Something went wrong" messageProps={{ className: 'TEST_MESSAGE_CLASS' }} />);
           expect(messageIcon).not.to.equal(null);
           expect(message.props.critical).to.equal(true);
         });
@@ -86,7 +86,7 @@ describe('FieldMessage', () => {
 
       describe('set to true', () => {
         it('Message should have a icon and set text as positive', () => {
-          render(<FieldMessage valid={true} message="Something went right" messageProps={{ className: 'message' }} />);
+          render(<FieldMessage valid={true} message="Something went right" messageProps={{ className: 'TEST_MESSAGE_CLASS' }} />);
           expect(messageIcon).not.to.equal(null);
           expect(message.props.positive).to.equal(true);
         });
@@ -95,14 +95,14 @@ describe('FieldMessage', () => {
 
     describe('valid & messageProps secondary', () => {
       it('secondary messageProps trumps valid = true but still have icon', () => {
-        render(<FieldMessage valid={true} message="Something went right" messageProps={{ className: 'message', secondary: true }} />);
+        render(<FieldMessage valid={true} message="Something went right" messageProps={{ className: 'TEST_MESSAGE_CLASS', secondary: true }} />);
         expect(messageIcon).not.to.equal(null);
         expect(message.props.positive).not.to.equal(true);
         expect(message.props.secondary).to.equal(true);
       });
 
       it('secondary messageProps trumps valid = false but still have icon', () => {
-        render(<FieldMessage valid={false} message="Something went wrong" messageProps={{ className: 'message', secondary: true }} />);
+        render(<FieldMessage valid={false} message="Something went wrong" messageProps={{ className: 'TEST_MESSAGE_CLASS', secondary: true }} />);
         expect(messageIcon).not.to.equal(null);
         expect(message.props.critical).not.to.equal(true);
         expect(message.props.secondary).to.equal(true);

--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -3,15 +3,15 @@
 exports[`Footer: should render when authenticated 1`] = `
 <footer
   aria-labelledby="FooterHeading"
-  class="root"
+  class="Footer__root"
   role="contentinfo"
 >
   <span
-    class="print"
+    class="Hidden__print"
   >
     <section>
       <span
-        class="root"
+        class="ScreenReaderOnly__root"
       >
         <h1
           id="FooterHeading"
@@ -20,17 +20,17 @@ exports[`Footer: should render when authenticated 1`] = `
         </h1>
       </span>
       <div
-        class="content"
+        class="Footer__content"
       >
         <div
-          class="columns"
+          class="Footer__columns"
         >
           <nav
             aria-label="Tools"
-            class="category"
+            class="FooterNav__category"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Tools
             </h1>
@@ -39,7 +39,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:jobs"
                   href="/"
                 >
@@ -50,7 +50,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:profile"
                   href="/profile/"
                 >
@@ -61,7 +61,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:my+activity"
                   href="/myactivity"
                   rel="nofollow"
@@ -73,7 +73,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:favourite"
                   href="/my-activity/saved-jobs"
                   rel="nofollow"
@@ -85,7 +85,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:applied"
                   href="/my-activity/applied-jobs"
                   rel="nofollow"
@@ -97,7 +97,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:advice+tips"
                   href="/career-advice/"
                 >
@@ -108,7 +108,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:companies"
                   href="/companies/"
                 >
@@ -119,29 +119,29 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="PartnerSitesToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="PartnerSitesToggle"
                 >
                   SEEK sites
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:post+a+job+ad"
                       href="https://talent.seek.com.au/"
                     >
@@ -152,7 +152,7 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:nz+homepage"
                       href="https://www.seek.co.nz/"
                     >
@@ -163,7 +163,7 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:courses"
                       href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     >
@@ -174,7 +174,7 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:business+for+sale"
                       href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     >
@@ -185,7 +185,7 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:volunteering"
                       href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     >
@@ -198,19 +198,19 @@ exports[`Footer: should render when authenticated 1`] = `
           </nav>
           <nav
             aria-label="Company"
-            class="category secondary"
+            class="FooterNav__category FooterNav__secondary"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Company
             </h1>
             <ul>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:about+seek"
                   href="/about"
                 >
@@ -218,10 +218,10 @@ exports[`Footer: should render when authenticated 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:media"
                   href="/about/news"
                 >
@@ -229,10 +229,10 @@ exports[`Footer: should render when authenticated 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:investor+centre"
                   href="/about/investors"
                 >
@@ -240,39 +240,39 @@ exports[`Footer: should render when authenticated 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="ToggleContainer__secondary"
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="InternationalPartnersToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="InternationalPartnersToggle"
                 >
                   International partners
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:bdjobs"
                       href="https://www.bdjobs.com"
                     >
                       Bdjobs
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Bangladesh
                     </span>
@@ -281,14 +281,14 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:brighter+monday"
                       href="https://www.brightermonday.com"
                     >
                       Brighter Monday
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — E Africa
                     </span>
@@ -297,14 +297,14 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:catho"
                       href="https://www.catho.com.br"
                     >
                       Catho
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Brazil
                     </span>
@@ -313,14 +313,14 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobberman"
                       href="https://www.jobberman.com"
                     >
                       Jobberman
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — W Africa
                     </span>
@@ -329,14 +329,14 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobsdb"
                       href="https://www.jobsdb.com"
                     >
                       jobsDB
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — SE Asia
                     </span>
@@ -345,14 +345,14 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobstreet"
                       href="https://www.jobstreet.com"
                     >
                       JobStreet
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — SE Asia
                     </span>
@@ -361,14 +361,14 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+int"
                       href="https://www.jora.com"
                     >
                       Jora
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Worldwide
                     </span>
@@ -377,14 +377,14 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:occ+mundial"
                       href="https://www.occ.com.mx"
                     >
                       OCC Mundial
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Mexico
                     </span>
@@ -393,14 +393,14 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:workana"
                       href="https://www.workana.com"
                     >
                       Workana
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Latin America
                     </span>
@@ -409,14 +409,14 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:zhaopin"
                       href="https://www.zhaopin.com"
                     >
                       Zhaopin
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — China
                     </span>
@@ -425,14 +425,14 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+au"
                       href="https://au.jora.com"
                     >
                       Jora
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Australia
                     </span>
@@ -440,33 +440,33 @@ exports[`Footer: should render when authenticated 1`] = `
                 </ul>
               </li>
               <li
-                class="secondary"
+                class="ToggleContainer__secondary"
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   data-automation="partner-services-toggle"
                   id="PartnerServicesToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="PartnerServicesToggle"
                 >
                   Partner services
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobadder"
                       href="https://jobadder.com/au"
                     >
@@ -477,7 +477,7 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+local"
                       data-automation="jora-local-link"
                       href="http://www.joralocal.com.au"
@@ -489,7 +489,7 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:realestate+au"
                       href="https://www.realestate.com.au/buy"
                     >
@@ -500,7 +500,7 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:sidekicker"
                       href="https://www.sidekicker.com.au/"
                     >
@@ -511,7 +511,7 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:ximble"
                       href="https://www.ximble.com"
                     >
@@ -522,7 +522,7 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:sparkhire"
                       href="https://anz.sparkhire.com/"
                     >
@@ -535,10 +535,10 @@ exports[`Footer: should render when authenticated 1`] = `
           </nav>
           <nav
             aria-label="Connect"
-            class="category"
+            class="FooterNav__category"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Connect
             </h1>
@@ -547,7 +547,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:contact+us"
                   href="/contact-us"
                 >
@@ -555,10 +555,10 @@ exports[`Footer: should render when authenticated 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:work+for+seek"
                   href="/work-for-seek"
                 >
@@ -566,10 +566,10 @@ exports[`Footer: should render when authenticated 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:product+blog"
                   href="http://productblog.seek.com.au"
                 >
@@ -580,29 +580,29 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="SocialToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="SocialToggle"
                 >
                   Social
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:facebook"
                       href="https://www.facebook.com/SEEK/"
                     >
@@ -613,7 +613,7 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:instagram"
                       href="https://www.instagram.com/seekau/"
                     >
@@ -624,7 +624,7 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:twitter"
                       href="https://twitter.com/seekjobs"
                     >
@@ -635,7 +635,7 @@ exports[`Footer: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:youtube"
                       href="https://www.youtube.com/user/SEEKJobs"
                     >
@@ -648,10 +648,10 @@ exports[`Footer: should render when authenticated 1`] = `
           </nav>
           <nav
             aria-label="Employers"
-            class="category secondary"
+            class="FooterNav__category FooterNav__secondary"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Employers
             </h1>
@@ -660,7 +660,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:register+for+free"
                   href="https://talent.seek.com.au/"
                   rel="nofollow"
@@ -672,7 +672,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:post+a+job+ad"
                   href="https://talent.seek.com.au/"
                 >
@@ -683,7 +683,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:products+prices"
                   href="https://talent.seek.com.au/Support/OurProducts"
                 >
@@ -694,7 +694,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:customer+service"
                   href="https://talent.seek.com.au/ContactUs"
                 >
@@ -705,7 +705,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:insight+blog"
                   href="http://insightsresources.seek.com.au"
                 >
@@ -716,17 +716,17 @@ exports[`Footer: should render when authenticated 1`] = `
           </nav>
         </div>
         <nav
-          class="copyright"
+          class="Footer__copyright"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             <h1>
               Additional Links
             </h1>
           </span>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:privacy"
             href="/privacy"
             rel="nofollow"
@@ -734,7 +734,7 @@ exports[`Footer: should render when authenticated 1`] = `
             Privacy
           </a>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:terms+conditions"
             href="/terms"
             rel="nofollow"
@@ -742,7 +742,7 @@ exports[`Footer: should render when authenticated 1`] = `
             Terms & Conditions
           </a>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:seek+safely"
             href="/safe-job-searching"
             rel="nofollow"
@@ -750,14 +750,14 @@ exports[`Footer: should render when authenticated 1`] = `
             Protect yourself online
           </a>
           <a
-            class="copyrightLink secondaryLink"
+            class="Footer__copyrightLink Footer__secondaryLink"
             data-analytics="toolbar:site+map"
             href="/sitemap"
           >
             Site Map
           </a>
           <p
-            class="copyrightMessage"
+            class="Footer__copyrightMessage"
           >
             © SEEK. All rights reserved.
           </p>
@@ -771,15 +771,15 @@ exports[`Footer: should render when authenticated 1`] = `
 exports[`Footer: should render when authentication is pending 1`] = `
 <footer
   aria-labelledby="FooterHeading"
-  class="root"
+  class="Footer__root"
   role="contentinfo"
 >
   <span
-    class="print"
+    class="Hidden__print"
   >
     <section>
       <span
-        class="root"
+        class="ScreenReaderOnly__root"
       >
         <h1
           id="FooterHeading"
@@ -788,17 +788,17 @@ exports[`Footer: should render when authentication is pending 1`] = `
         </h1>
       </span>
       <div
-        class="content"
+        class="Footer__content"
       >
         <div
-          class="columns"
+          class="Footer__columns"
         >
           <nav
             aria-label="Tools"
-            class="category"
+            class="FooterNav__category"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Tools
             </h1>
@@ -807,7 +807,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:jobs"
                   href="/"
                 >
@@ -818,7 +818,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:profile"
                   href="/profile/"
                 >
@@ -829,7 +829,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:my+activity"
                   href="/sign-in?returnUrl=%2Fmyactivity"
                   rel="nofollow"
@@ -841,7 +841,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:favourite"
                   href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                   rel="nofollow"
@@ -853,7 +853,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:applied"
                   href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                   rel="nofollow"
@@ -865,7 +865,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:advice+tips"
                   href="/career-advice/"
                 >
@@ -876,7 +876,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:companies"
                   href="/companies/"
                 >
@@ -887,29 +887,29 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="PartnerSitesToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="PartnerSitesToggle"
                 >
                   SEEK sites
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:post+a+job+ad"
                       href="https://talent.seek.com.au/"
                     >
@@ -920,7 +920,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:nz+homepage"
                       href="https://www.seek.co.nz/"
                     >
@@ -931,7 +931,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:courses"
                       href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     >
@@ -942,7 +942,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:business+for+sale"
                       href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     >
@@ -953,7 +953,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:volunteering"
                       href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     >
@@ -966,19 +966,19 @@ exports[`Footer: should render when authentication is pending 1`] = `
           </nav>
           <nav
             aria-label="Company"
-            class="category secondary"
+            class="FooterNav__category FooterNav__secondary"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Company
             </h1>
             <ul>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:about+seek"
                   href="/about"
                 >
@@ -986,10 +986,10 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:media"
                   href="/about/news"
                 >
@@ -997,10 +997,10 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:investor+centre"
                   href="/about/investors"
                 >
@@ -1008,39 +1008,39 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="ToggleContainer__secondary"
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="InternationalPartnersToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="InternationalPartnersToggle"
                 >
                   International partners
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:bdjobs"
                       href="https://www.bdjobs.com"
                     >
                       Bdjobs
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Bangladesh
                     </span>
@@ -1049,14 +1049,14 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:brighter+monday"
                       href="https://www.brightermonday.com"
                     >
                       Brighter Monday
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — E Africa
                     </span>
@@ -1065,14 +1065,14 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:catho"
                       href="https://www.catho.com.br"
                     >
                       Catho
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Brazil
                     </span>
@@ -1081,14 +1081,14 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobberman"
                       href="https://www.jobberman.com"
                     >
                       Jobberman
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — W Africa
                     </span>
@@ -1097,14 +1097,14 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobsdb"
                       href="https://www.jobsdb.com"
                     >
                       jobsDB
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — SE Asia
                     </span>
@@ -1113,14 +1113,14 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobstreet"
                       href="https://www.jobstreet.com"
                     >
                       JobStreet
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — SE Asia
                     </span>
@@ -1129,14 +1129,14 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+int"
                       href="https://www.jora.com"
                     >
                       Jora
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Worldwide
                     </span>
@@ -1145,14 +1145,14 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:occ+mundial"
                       href="https://www.occ.com.mx"
                     >
                       OCC Mundial
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Mexico
                     </span>
@@ -1161,14 +1161,14 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:workana"
                       href="https://www.workana.com"
                     >
                       Workana
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Latin America
                     </span>
@@ -1177,14 +1177,14 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:zhaopin"
                       href="https://www.zhaopin.com"
                     >
                       Zhaopin
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — China
                     </span>
@@ -1193,14 +1193,14 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+au"
                       href="https://au.jora.com"
                     >
                       Jora
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Australia
                     </span>
@@ -1208,33 +1208,33 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 </ul>
               </li>
               <li
-                class="secondary"
+                class="ToggleContainer__secondary"
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   data-automation="partner-services-toggle"
                   id="PartnerServicesToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="PartnerServicesToggle"
                 >
                   Partner services
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobadder"
                       href="https://jobadder.com/au"
                     >
@@ -1245,7 +1245,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+local"
                       data-automation="jora-local-link"
                       href="http://www.joralocal.com.au"
@@ -1257,7 +1257,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:realestate+au"
                       href="https://www.realestate.com.au/buy"
                     >
@@ -1268,7 +1268,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:sidekicker"
                       href="https://www.sidekicker.com.au/"
                     >
@@ -1279,7 +1279,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:ximble"
                       href="https://www.ximble.com"
                     >
@@ -1290,7 +1290,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:sparkhire"
                       href="https://anz.sparkhire.com/"
                     >
@@ -1303,10 +1303,10 @@ exports[`Footer: should render when authentication is pending 1`] = `
           </nav>
           <nav
             aria-label="Connect"
-            class="category"
+            class="FooterNav__category"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Connect
             </h1>
@@ -1315,7 +1315,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:contact+us"
                   href="/contact-us"
                 >
@@ -1323,10 +1323,10 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:work+for+seek"
                   href="/work-for-seek"
                 >
@@ -1334,10 +1334,10 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:product+blog"
                   href="http://productblog.seek.com.au"
                 >
@@ -1348,29 +1348,29 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="SocialToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="SocialToggle"
                 >
                   Social
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:facebook"
                       href="https://www.facebook.com/SEEK/"
                     >
@@ -1381,7 +1381,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:instagram"
                       href="https://www.instagram.com/seekau/"
                     >
@@ -1392,7 +1392,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:twitter"
                       href="https://twitter.com/seekjobs"
                     >
@@ -1403,7 +1403,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:youtube"
                       href="https://www.youtube.com/user/SEEKJobs"
                     >
@@ -1416,10 +1416,10 @@ exports[`Footer: should render when authentication is pending 1`] = `
           </nav>
           <nav
             aria-label="Employers"
-            class="category secondary"
+            class="FooterNav__category FooterNav__secondary"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Employers
             </h1>
@@ -1428,7 +1428,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:register+for+free"
                   href="https://talent.seek.com.au/"
                   rel="nofollow"
@@ -1440,7 +1440,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:post+a+job+ad"
                   href="https://talent.seek.com.au/"
                 >
@@ -1451,7 +1451,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:products+prices"
                   href="https://talent.seek.com.au/Support/OurProducts"
                 >
@@ -1462,7 +1462,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:customer+service"
                   href="https://talent.seek.com.au/ContactUs"
                 >
@@ -1473,7 +1473,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:insight+blog"
                   href="http://insightsresources.seek.com.au"
                 >
@@ -1484,17 +1484,17 @@ exports[`Footer: should render when authentication is pending 1`] = `
           </nav>
         </div>
         <nav
-          class="copyright"
+          class="Footer__copyright"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             <h1>
               Additional Links
             </h1>
           </span>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:privacy"
             href="/privacy"
             rel="nofollow"
@@ -1502,7 +1502,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
             Privacy
           </a>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:terms+conditions"
             href="/terms"
             rel="nofollow"
@@ -1510,7 +1510,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
             Terms & Conditions
           </a>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:seek+safely"
             href="/safe-job-searching"
             rel="nofollow"
@@ -1518,14 +1518,14 @@ exports[`Footer: should render when authentication is pending 1`] = `
             Protect yourself online
           </a>
           <a
-            class="copyrightLink secondaryLink"
+            class="Footer__copyrightLink Footer__secondaryLink"
             data-analytics="toolbar:site+map"
             href="/sitemap"
           >
             Site Map
           </a>
           <p
-            class="copyrightMessage"
+            class="Footer__copyrightMessage"
           >
             © SEEK. All rights reserved.
           </p>
@@ -1539,15 +1539,15 @@ exports[`Footer: should render when authentication is pending 1`] = `
 exports[`Footer: should render when unauthenticated 1`] = `
 <footer
   aria-labelledby="FooterHeading"
-  class="root"
+  class="Footer__root"
   role="contentinfo"
 >
   <span
-    class="print"
+    class="Hidden__print"
   >
     <section>
       <span
-        class="root"
+        class="ScreenReaderOnly__root"
       >
         <h1
           id="FooterHeading"
@@ -1556,17 +1556,17 @@ exports[`Footer: should render when unauthenticated 1`] = `
         </h1>
       </span>
       <div
-        class="content"
+        class="Footer__content"
       >
         <div
-          class="columns"
+          class="Footer__columns"
         >
           <nav
             aria-label="Tools"
-            class="category"
+            class="FooterNav__category"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Tools
             </h1>
@@ -1575,7 +1575,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:jobs"
                   href="/"
                 >
@@ -1586,7 +1586,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:profile"
                   href="/profile/"
                 >
@@ -1597,7 +1597,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:my+activity"
                   href="/sign-in?returnUrl=%2Fmyactivity"
                   rel="nofollow"
@@ -1609,7 +1609,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:favourite"
                   href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                   rel="nofollow"
@@ -1621,7 +1621,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:applied"
                   href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                   rel="nofollow"
@@ -1633,7 +1633,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:advice+tips"
                   href="/career-advice/"
                 >
@@ -1644,7 +1644,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:companies"
                   href="/companies/"
                 >
@@ -1655,29 +1655,29 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="PartnerSitesToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="PartnerSitesToggle"
                 >
                   SEEK sites
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:post+a+job+ad"
                       href="https://talent.seek.com.au/"
                     >
@@ -1688,7 +1688,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:nz+homepage"
                       href="https://www.seek.co.nz/"
                     >
@@ -1699,7 +1699,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:courses"
                       href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     >
@@ -1710,7 +1710,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:business+for+sale"
                       href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     >
@@ -1721,7 +1721,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:volunteering"
                       href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     >
@@ -1734,19 +1734,19 @@ exports[`Footer: should render when unauthenticated 1`] = `
           </nav>
           <nav
             aria-label="Company"
-            class="category secondary"
+            class="FooterNav__category FooterNav__secondary"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Company
             </h1>
             <ul>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:about+seek"
                   href="/about"
                 >
@@ -1754,10 +1754,10 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:media"
                   href="/about/news"
                 >
@@ -1765,10 +1765,10 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:investor+centre"
                   href="/about/investors"
                 >
@@ -1776,39 +1776,39 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="ToggleContainer__secondary"
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="InternationalPartnersToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="InternationalPartnersToggle"
                 >
                   International partners
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:bdjobs"
                       href="https://www.bdjobs.com"
                     >
                       Bdjobs
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Bangladesh
                     </span>
@@ -1817,14 +1817,14 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:brighter+monday"
                       href="https://www.brightermonday.com"
                     >
                       Brighter Monday
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — E Africa
                     </span>
@@ -1833,14 +1833,14 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:catho"
                       href="https://www.catho.com.br"
                     >
                       Catho
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Brazil
                     </span>
@@ -1849,14 +1849,14 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobberman"
                       href="https://www.jobberman.com"
                     >
                       Jobberman
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — W Africa
                     </span>
@@ -1865,14 +1865,14 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobsdb"
                       href="https://www.jobsdb.com"
                     >
                       jobsDB
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — SE Asia
                     </span>
@@ -1881,14 +1881,14 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobstreet"
                       href="https://www.jobstreet.com"
                     >
                       JobStreet
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — SE Asia
                     </span>
@@ -1897,14 +1897,14 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+int"
                       href="https://www.jora.com"
                     >
                       Jora
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Worldwide
                     </span>
@@ -1913,14 +1913,14 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:occ+mundial"
                       href="https://www.occ.com.mx"
                     >
                       OCC Mundial
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Mexico
                     </span>
@@ -1929,14 +1929,14 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:workana"
                       href="https://www.workana.com"
                     >
                       Workana
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Latin America
                     </span>
@@ -1945,14 +1945,14 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:zhaopin"
                       href="https://www.zhaopin.com"
                     >
                       Zhaopin
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — China
                     </span>
@@ -1961,14 +1961,14 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+au"
                       href="https://au.jora.com"
                     >
                       Jora
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Australia
                     </span>
@@ -1976,33 +1976,33 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 </ul>
               </li>
               <li
-                class="secondary"
+                class="ToggleContainer__secondary"
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   data-automation="partner-services-toggle"
                   id="PartnerServicesToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="PartnerServicesToggle"
                 >
                   Partner services
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobadder"
                       href="https://jobadder.com/au"
                     >
@@ -2013,7 +2013,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+local"
                       data-automation="jora-local-link"
                       href="http://www.joralocal.com.au"
@@ -2025,7 +2025,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:realestate+au"
                       href="https://www.realestate.com.au/buy"
                     >
@@ -2036,7 +2036,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:sidekicker"
                       href="https://www.sidekicker.com.au/"
                     >
@@ -2047,7 +2047,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:ximble"
                       href="https://www.ximble.com"
                     >
@@ -2058,7 +2058,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:sparkhire"
                       href="https://anz.sparkhire.com/"
                     >
@@ -2071,10 +2071,10 @@ exports[`Footer: should render when unauthenticated 1`] = `
           </nav>
           <nav
             aria-label="Connect"
-            class="category"
+            class="FooterNav__category"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Connect
             </h1>
@@ -2083,7 +2083,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:contact+us"
                   href="/contact-us"
                 >
@@ -2091,10 +2091,10 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:work+for+seek"
                   href="/work-for-seek"
                 >
@@ -2102,10 +2102,10 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:product+blog"
                   href="http://productblog.seek.com.au"
                 >
@@ -2116,29 +2116,29 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="SocialToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="SocialToggle"
                 >
                   Social
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:facebook"
                       href="https://www.facebook.com/SEEK/"
                     >
@@ -2149,7 +2149,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:instagram"
                       href="https://www.instagram.com/seekau/"
                     >
@@ -2160,7 +2160,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:twitter"
                       href="https://twitter.com/seekjobs"
                     >
@@ -2171,7 +2171,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:youtube"
                       href="https://www.youtube.com/user/SEEKJobs"
                     >
@@ -2184,10 +2184,10 @@ exports[`Footer: should render when unauthenticated 1`] = `
           </nav>
           <nav
             aria-label="Employers"
-            class="category secondary"
+            class="FooterNav__category FooterNav__secondary"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Employers
             </h1>
@@ -2196,7 +2196,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:register+for+free"
                   href="https://talent.seek.com.au/"
                   rel="nofollow"
@@ -2208,7 +2208,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:post+a+job+ad"
                   href="https://talent.seek.com.au/"
                 >
@@ -2219,7 +2219,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:products+prices"
                   href="https://talent.seek.com.au/Support/OurProducts"
                 >
@@ -2230,7 +2230,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:customer+service"
                   href="https://talent.seek.com.au/ContactUs"
                 >
@@ -2241,7 +2241,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:insight+blog"
                   href="http://insightsresources.seek.com.au"
                 >
@@ -2252,17 +2252,17 @@ exports[`Footer: should render when unauthenticated 1`] = `
           </nav>
         </div>
         <nav
-          class="copyright"
+          class="Footer__copyright"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             <h1>
               Additional Links
             </h1>
           </span>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:privacy"
             href="/privacy"
             rel="nofollow"
@@ -2270,7 +2270,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
             Privacy
           </a>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:terms+conditions"
             href="/terms"
             rel="nofollow"
@@ -2278,7 +2278,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
             Terms & Conditions
           </a>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:seek+safely"
             href="/safe-job-searching"
             rel="nofollow"
@@ -2286,14 +2286,14 @@ exports[`Footer: should render when unauthenticated 1`] = `
             Protect yourself online
           </a>
           <a
-            class="copyrightLink secondaryLink"
+            class="Footer__copyrightLink Footer__secondaryLink"
             data-analytics="toolbar:site+map"
             href="/sitemap"
           >
             Site Map
           </a>
           <p
-            class="copyrightMessage"
+            class="Footer__copyrightMessage"
           >
             © SEEK. All rights reserved.
           </p>
@@ -2307,15 +2307,15 @@ exports[`Footer: should render when unauthenticated 1`] = `
 exports[`Footer: should render with locale of AU 1`] = `
 <footer
   aria-labelledby="FooterHeading"
-  class="root"
+  class="Footer__root"
   role="contentinfo"
 >
   <span
-    class="print"
+    class="Hidden__print"
   >
     <section>
       <span
-        class="root"
+        class="ScreenReaderOnly__root"
       >
         <h1
           id="FooterHeading"
@@ -2324,17 +2324,17 @@ exports[`Footer: should render with locale of AU 1`] = `
         </h1>
       </span>
       <div
-        class="content"
+        class="Footer__content"
       >
         <div
-          class="columns"
+          class="Footer__columns"
         >
           <nav
             aria-label="Tools"
-            class="category"
+            class="FooterNav__category"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Tools
             </h1>
@@ -2343,7 +2343,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:jobs"
                   href="/"
                 >
@@ -2354,7 +2354,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:profile"
                   href="/profile/"
                 >
@@ -2365,7 +2365,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:my+activity"
                   href="/sign-in?returnUrl=%2Fmyactivity"
                   rel="nofollow"
@@ -2377,7 +2377,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:favourite"
                   href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                   rel="nofollow"
@@ -2389,7 +2389,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:applied"
                   href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                   rel="nofollow"
@@ -2401,7 +2401,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:advice+tips"
                   href="/career-advice/"
                 >
@@ -2412,7 +2412,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:companies"
                   href="/companies/"
                 >
@@ -2423,29 +2423,29 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="PartnerSitesToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="PartnerSitesToggle"
                 >
                   SEEK sites
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:post+a+job+ad"
                       href="https://talent.seek.com.au/"
                     >
@@ -2456,7 +2456,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:nz+homepage"
                       href="https://www.seek.co.nz/"
                     >
@@ -2467,7 +2467,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:courses"
                       href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     >
@@ -2478,7 +2478,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:business+for+sale"
                       href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     >
@@ -2489,7 +2489,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:volunteering"
                       href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     >
@@ -2502,19 +2502,19 @@ exports[`Footer: should render with locale of AU 1`] = `
           </nav>
           <nav
             aria-label="Company"
-            class="category secondary"
+            class="FooterNav__category FooterNav__secondary"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Company
             </h1>
             <ul>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:about+seek"
                   href="/about"
                 >
@@ -2522,10 +2522,10 @@ exports[`Footer: should render with locale of AU 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:media"
                   href="/about/news"
                 >
@@ -2533,10 +2533,10 @@ exports[`Footer: should render with locale of AU 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:investor+centre"
                   href="/about/investors"
                 >
@@ -2544,39 +2544,39 @@ exports[`Footer: should render with locale of AU 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="ToggleContainer__secondary"
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="InternationalPartnersToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="InternationalPartnersToggle"
                 >
                   International partners
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:bdjobs"
                       href="https://www.bdjobs.com"
                     >
                       Bdjobs
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Bangladesh
                     </span>
@@ -2585,14 +2585,14 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:brighter+monday"
                       href="https://www.brightermonday.com"
                     >
                       Brighter Monday
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — E Africa
                     </span>
@@ -2601,14 +2601,14 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:catho"
                       href="https://www.catho.com.br"
                     >
                       Catho
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Brazil
                     </span>
@@ -2617,14 +2617,14 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobberman"
                       href="https://www.jobberman.com"
                     >
                       Jobberman
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — W Africa
                     </span>
@@ -2633,14 +2633,14 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobsdb"
                       href="https://www.jobsdb.com"
                     >
                       jobsDB
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — SE Asia
                     </span>
@@ -2649,14 +2649,14 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobstreet"
                       href="https://www.jobstreet.com"
                     >
                       JobStreet
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — SE Asia
                     </span>
@@ -2665,14 +2665,14 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+int"
                       href="https://www.jora.com"
                     >
                       Jora
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Worldwide
                     </span>
@@ -2681,14 +2681,14 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:occ+mundial"
                       href="https://www.occ.com.mx"
                     >
                       OCC Mundial
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Mexico
                     </span>
@@ -2697,14 +2697,14 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:workana"
                       href="https://www.workana.com"
                     >
                       Workana
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Latin America
                     </span>
@@ -2713,14 +2713,14 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:zhaopin"
                       href="https://www.zhaopin.com"
                     >
                       Zhaopin
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — China
                     </span>
@@ -2729,14 +2729,14 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+au"
                       href="https://au.jora.com"
                     >
                       Jora
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Australia
                     </span>
@@ -2744,33 +2744,33 @@ exports[`Footer: should render with locale of AU 1`] = `
                 </ul>
               </li>
               <li
-                class="secondary"
+                class="ToggleContainer__secondary"
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   data-automation="partner-services-toggle"
                   id="PartnerServicesToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="PartnerServicesToggle"
                 >
                   Partner services
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobadder"
                       href="https://jobadder.com/au"
                     >
@@ -2781,7 +2781,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+local"
                       data-automation="jora-local-link"
                       href="http://www.joralocal.com.au"
@@ -2793,7 +2793,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:realestate+au"
                       href="https://www.realestate.com.au/buy"
                     >
@@ -2804,7 +2804,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:sidekicker"
                       href="https://www.sidekicker.com.au/"
                     >
@@ -2815,7 +2815,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:ximble"
                       href="https://www.ximble.com"
                     >
@@ -2826,7 +2826,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:sparkhire"
                       href="https://anz.sparkhire.com/"
                     >
@@ -2839,10 +2839,10 @@ exports[`Footer: should render with locale of AU 1`] = `
           </nav>
           <nav
             aria-label="Connect"
-            class="category"
+            class="FooterNav__category"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Connect
             </h1>
@@ -2851,7 +2851,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:contact+us"
                   href="/contact-us"
                 >
@@ -2859,10 +2859,10 @@ exports[`Footer: should render with locale of AU 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:work+for+seek"
                   href="/work-for-seek"
                 >
@@ -2870,10 +2870,10 @@ exports[`Footer: should render with locale of AU 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:product+blog"
                   href="http://productblog.seek.com.au"
                 >
@@ -2884,29 +2884,29 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="SocialToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="SocialToggle"
                 >
                   Social
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:facebook"
                       href="https://www.facebook.com/SEEK/"
                     >
@@ -2917,7 +2917,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:instagram"
                       href="https://www.instagram.com/seekau/"
                     >
@@ -2928,7 +2928,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:twitter"
                       href="https://twitter.com/seekjobs"
                     >
@@ -2939,7 +2939,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:youtube"
                       href="https://www.youtube.com/user/SEEKJobs"
                     >
@@ -2952,10 +2952,10 @@ exports[`Footer: should render with locale of AU 1`] = `
           </nav>
           <nav
             aria-label="Employers"
-            class="category secondary"
+            class="FooterNav__category FooterNav__secondary"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Employers
             </h1>
@@ -2964,7 +2964,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:register+for+free"
                   href="https://talent.seek.com.au/"
                   rel="nofollow"
@@ -2976,7 +2976,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:post+a+job+ad"
                   href="https://talent.seek.com.au/"
                 >
@@ -2987,7 +2987,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:products+prices"
                   href="https://talent.seek.com.au/Support/OurProducts"
                 >
@@ -2998,7 +2998,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:customer+service"
                   href="https://talent.seek.com.au/ContactUs"
                 >
@@ -3009,7 +3009,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:insight+blog"
                   href="http://insightsresources.seek.com.au"
                 >
@@ -3020,17 +3020,17 @@ exports[`Footer: should render with locale of AU 1`] = `
           </nav>
         </div>
         <nav
-          class="copyright"
+          class="Footer__copyright"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             <h1>
               Additional Links
             </h1>
           </span>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:privacy"
             href="/privacy"
             rel="nofollow"
@@ -3038,7 +3038,7 @@ exports[`Footer: should render with locale of AU 1`] = `
             Privacy
           </a>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:terms+conditions"
             href="/terms"
             rel="nofollow"
@@ -3046,7 +3046,7 @@ exports[`Footer: should render with locale of AU 1`] = `
             Terms & Conditions
           </a>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:seek+safely"
             href="/safe-job-searching"
             rel="nofollow"
@@ -3054,14 +3054,14 @@ exports[`Footer: should render with locale of AU 1`] = `
             Protect yourself online
           </a>
           <a
-            class="copyrightLink secondaryLink"
+            class="Footer__copyrightLink Footer__secondaryLink"
             data-analytics="toolbar:site+map"
             href="/sitemap"
           >
             Site Map
           </a>
           <p
-            class="copyrightMessage"
+            class="Footer__copyrightMessage"
           >
             © SEEK. All rights reserved.
           </p>
@@ -3075,15 +3075,15 @@ exports[`Footer: should render with locale of AU 1`] = `
 exports[`Footer: should render with locale of NZ 1`] = `
 <footer
   aria-labelledby="FooterHeading"
-  class="root"
+  class="Footer__root"
   role="contentinfo"
 >
   <span
-    class="print"
+    class="Hidden__print"
   >
     <section>
       <span
-        class="root"
+        class="ScreenReaderOnly__root"
       >
         <h1
           id="FooterHeading"
@@ -3092,17 +3092,17 @@ exports[`Footer: should render with locale of NZ 1`] = `
         </h1>
       </span>
       <div
-        class="content"
+        class="Footer__content"
       >
         <div
-          class="columns"
+          class="Footer__columns"
         >
           <nav
             aria-label="Tools"
-            class="category"
+            class="FooterNav__category"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Tools
             </h1>
@@ -3111,7 +3111,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:jobs"
                   href="/"
                 >
@@ -3122,7 +3122,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:profile"
                   href="/profile/"
                 >
@@ -3133,7 +3133,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:my+activity"
                   href="/sign-in?returnUrl=%2Fmyactivity"
                   rel="nofollow"
@@ -3145,7 +3145,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:favourite"
                   href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                   rel="nofollow"
@@ -3157,7 +3157,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:applied"
                   href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                   rel="nofollow"
@@ -3169,7 +3169,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:advice+tips"
                   href="/career-advice/"
                 >
@@ -3180,29 +3180,29 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="PartnerSitesToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="PartnerSitesToggle"
                 >
                   SEEK sites
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:post+a+job+ad"
                       href="https://talent.seek.co.nz/"
                     >
@@ -3213,7 +3213,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:au+homepage"
                       href="https://www.seek.com.au/"
                     >
@@ -3224,7 +3224,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:courses"
                       href="https://www.seeklearning.co.nz/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     >
@@ -3235,7 +3235,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:business+for+sale"
                       href="https://www.seekbusiness.co.nz/?tracking=sk:main:nz:nav:bus"
                     >
@@ -3246,7 +3246,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:volunteering"
                       href="https://www.volunteer.co.nz/?tracking=SKMNZ:main+header"
                     >
@@ -3259,19 +3259,19 @@ exports[`Footer: should render with locale of NZ 1`] = `
           </nav>
           <nav
             aria-label="Company"
-            class="category secondary"
+            class="FooterNav__category FooterNav__secondary"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Company
             </h1>
             <ul>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:about+seek"
                   href="/about"
                 >
@@ -3279,10 +3279,10 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:media"
                   href="/about/news"
                 >
@@ -3290,10 +3290,10 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:investor+centre"
                   href="/about/investors"
                 >
@@ -3301,39 +3301,39 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="ToggleContainer__secondary"
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="InternationalPartnersToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="InternationalPartnersToggle"
                 >
                   International partners
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:bdjobs"
                       href="https://www.bdjobs.com"
                     >
                       Bdjobs
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Bangladesh
                     </span>
@@ -3342,14 +3342,14 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:brighter+monday"
                       href="https://www.brightermonday.com"
                     >
                       Brighter Monday
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — E Africa
                     </span>
@@ -3358,14 +3358,14 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:catho"
                       href="https://www.catho.com.br"
                     >
                       Catho
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Brazil
                     </span>
@@ -3374,14 +3374,14 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobberman"
                       href="https://www.jobberman.com"
                     >
                       Jobberman
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — W Africa
                     </span>
@@ -3390,14 +3390,14 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobsdb"
                       href="https://www.jobsdb.com"
                     >
                       jobsDB
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — SE Asia
                     </span>
@@ -3406,14 +3406,14 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jobstreet"
                       href="https://www.jobstreet.com"
                     >
                       JobStreet
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — SE Asia
                     </span>
@@ -3422,14 +3422,14 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+int"
                       href="https://www.jora.com"
                     >
                       Jora
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Worldwide
                     </span>
@@ -3438,14 +3438,14 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:occ+mundial"
                       href="https://www.occ.com.mx"
                     >
                       OCC Mundial
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Mexico
                     </span>
@@ -3454,14 +3454,14 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:workana"
                       href="https://www.workana.com"
                     >
                       Workana
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Latin America
                     </span>
@@ -3470,14 +3470,14 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:zhaopin"
                       href="https://www.zhaopin.com"
                     >
                       Zhaopin
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — China
                     </span>
@@ -3486,14 +3486,14 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:jora+au"
                       href="https://au.jora.com"
                     >
                       Jora
                     </a>
                     <span
-                      class="partnerCountry"
+                      class="FooterLink__partnerCountry"
                     >
                        — Australia
                     </span>
@@ -3504,10 +3504,10 @@ exports[`Footer: should render with locale of NZ 1`] = `
           </nav>
           <nav
             aria-label="Connect"
-            class="category"
+            class="FooterNav__category"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Connect
             </h1>
@@ -3516,7 +3516,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:contact+us"
                   href="/contact-us"
                 >
@@ -3524,10 +3524,10 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:work+for+seek"
                   href="/work-for-seek"
                 >
@@ -3535,10 +3535,10 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 </a>
               </li>
               <li
-                class="secondary"
+                class="FooterLink__secondary"
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:product+blog"
                   href="http://productblog.seek.com.au"
                 >
@@ -3549,29 +3549,29 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <input
-                  class="toggle"
+                  class="ToggleContainer__toggle"
                   id="SocialToggle"
                   type="checkbox"
                 />
                 <label
-                  class="toggleLink toggleLabel"
+                  class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                   for="SocialToggle"
                 >
                   Social
                   <span
-                    class="root root chevron"
+                    class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                   >
                     mock svg
                   </span>
                 </label>
                 <ul
-                  class="toggleContainer"
+                  class="ToggleContainer__toggleContainer"
                 >
                   <li
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:facebook"
                       href="https://www.facebook.com/seeknz/"
                     >
@@ -3582,7 +3582,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:instagram"
                       href="https://www.instagram.com/seeknz/"
                     >
@@ -3593,7 +3593,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:twitter"
                       href="https://twitter.com/seekjobsnz"
                     >
@@ -3604,7 +3604,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="link"
+                      class="FooterLink__link"
                       data-analytics="toolbar:youtube"
                       href="https://www.youtube.com/user/SEEKJobs"
                     >
@@ -3617,10 +3617,10 @@ exports[`Footer: should render with locale of NZ 1`] = `
           </nav>
           <nav
             aria-label="Employers"
-            class="category secondary"
+            class="FooterNav__category FooterNav__secondary"
           >
             <h1
-              class="heading"
+              class="FooterNav__heading"
             >
               Employers
             </h1>
@@ -3629,7 +3629,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:register+for+free"
                   href="https://talent.seek.co.nz/"
                   rel="nofollow"
@@ -3641,7 +3641,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:post+a+job+ad"
                   href="https://talent.seek.co.nz/"
                 >
@@ -3652,7 +3652,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:products+prices"
                   href="https://talent.seek.co.nz/Support/OurProducts"
                 >
@@ -3663,7 +3663,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:customer+service"
                   href="https://talent.seek.co.nz/ContactUs"
                 >
@@ -3674,7 +3674,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class=""
               >
                 <a
-                  class="link"
+                  class="FooterLink__link"
                   data-analytics="toolbar:insight+blog"
                   href="http://insightsresources.seek.co.nz"
                 >
@@ -3685,17 +3685,17 @@ exports[`Footer: should render with locale of NZ 1`] = `
           </nav>
         </div>
         <nav
-          class="copyright"
+          class="Footer__copyright"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             <h1>
               Additional Links
             </h1>
           </span>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:privacy"
             href="/privacy"
             rel="nofollow"
@@ -3703,7 +3703,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
             Privacy
           </a>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:terms+conditions"
             href="/terms"
             rel="nofollow"
@@ -3711,7 +3711,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
             Terms & Conditions
           </a>
           <a
-            class="copyrightLink"
+            class="Footer__copyrightLink"
             data-analytics="toolbar:seek+safely"
             href="/safe-job-searching"
             rel="nofollow"
@@ -3719,14 +3719,14 @@ exports[`Footer: should render with locale of NZ 1`] = `
             Protect yourself online
           </a>
           <a
-            class="copyrightLink secondaryLink"
+            class="Footer__copyrightLink Footer__secondaryLink"
             data-analytics="toolbar:site+map"
             href="/sitemap"
           >
             Site Map
           </a>
           <p
-            class="copyrightMessage"
+            class="Footer__copyrightMessage"
           >
             © SEEK. All rights reserved.
           </p>

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -3,24 +3,24 @@
 exports[`Header: should append returnUrl to signin and register links if present 1`] = `
 <header
   aria-label="Primary navigation"
-  class="root"
+  class="Header__root"
   role="banner"
 >
   <section
-    class="content"
+    class="Header__content"
   >
     <div
-      class="banner"
+      class="Header__banner"
     >
       <h1
-        class="logo"
+        class="Header__logo"
         data-automation="logo"
       >
         <div
           class=""
         >
           <svg
-            class="logoSvg root"
+            class="Header__logoSvg Logo__root"
             height="68.031"
             id="sk-logo-pos"
             viewBox="0 0 170.079 68.031"
@@ -30,7 +30,7 @@ exports[`Header: should append returnUrl to signin and register links if present
             y="0px"
           >
             <g
-              class="logoText"
+              class="Logo__logoText"
             >
               <path
                 d="M86.641,45.601c-3.697,0-7.037-0.408-10.012-3.385l3.834-3.833c1.942,1.938,4.467,2.208,6.269,2.208 c2.031,0,4.148-0.675,4.148-2.434c0-1.174-0.629-1.985-2.479-2.167l-3.699-0.36c-4.24-0.404-6.854-2.253-6.854-6.586 c0-4.869,4.282-7.485,9.064-7.485c3.653,0,6.72,0.632,8.976,2.75l-3.607,3.653c-1.354-1.217-3.43-1.576-5.459-1.576 c-2.344,0-3.336,1.082-3.336,2.254c0,0.857,0.361,1.85,2.436,2.03l3.7,0.361c4.643,0.45,6.992,2.932,6.992,6.9 C96.612,43.118,92.19,45.601,86.641,45.601z"
@@ -46,45 +46,45 @@ exports[`Header: should append returnUrl to signin and register links if present
               />
             </g>
             <path
-              class="logoIcon"
+              class="Logo__logoIcon"
               d="M34.015,1.51c-17.952,0-32.506,14.552-32.506,32.507c0,17.952,14.554,32.505,32.506,32.505 c17.958,0,32.508-14.553,32.508-32.505C66.523,16.062,51.972,1.51,34.015,1.51z M8.262,41.733c-0.281,0-0.511-0.226-0.511-0.504 c0-0.281,0.229-0.511,0.511-0.511c0.278,0,0.504,0.229,0.504,0.511C8.766,41.508,8.541,41.733,8.262,41.733z M8.262,34.907 c-0.281,0-0.511-0.229-0.511-0.51s0.229-0.509,0.511-0.509c0.278,0,0.504,0.228,0.504,0.509S8.541,34.907,8.262,34.907z M8.262,28.077c-0.281,0-0.511-0.229-0.511-0.509c0-0.281,0.229-0.507,0.511-0.507c0.278,0,0.504,0.226,0.504,0.507 C8.766,27.849,8.541,28.077,8.262,28.077z M11.764,41.991c-0.422,0-0.762-0.342-0.762-0.762c0-0.422,0.34-0.765,0.762-0.765 c0.421,0,0.762,0.343,0.762,0.765C12.526,41.649,12.186,41.991,11.764,41.991z M11.764,35.158c-0.422,0-0.762-0.339-0.762-0.761 c0-0.42,0.34-0.761,0.762-0.761c0.421,0,0.762,0.341,0.762,0.761C12.526,34.819,12.186,35.158,11.764,35.158z M11.764,28.33 c-0.422,0-0.762-0.341-0.762-0.762c0-0.422,0.34-0.763,0.762-0.763c0.421,0,0.762,0.341,0.762,0.763 C12.526,27.989,12.186,28.33,11.764,28.33z M15.867,42.246c-0.562,0-1.019-0.455-1.019-1.017c0-0.561,0.457-1.018,1.019-1.018 c0.558,0,1.016,0.457,1.016,1.018C16.882,41.791,16.424,42.246,15.867,42.246z M15.867,35.412c-0.562,0-1.019-0.453-1.019-1.015 c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016C16.882,34.959,16.424,35.412,15.867,35.412z M15.867,28.583 c-0.562,0-1.019-0.451-1.019-1.015c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016 C16.882,28.132,16.424,28.583,15.867,28.583z M20.18,42.497c-0.702,0-1.27-0.567-1.27-1.268c0-0.705,0.568-1.27,1.27-1.27 c0.704,0,1.27,0.564,1.27,1.27C21.45,41.93,20.884,42.497,20.18,42.497z M20.18,35.669c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.269,1.27-1.269c0.704,0,1.27,0.565,1.27,1.269S20.884,35.669,20.18,35.669z M20.18,28.84c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.271,1.27-1.271c0.704,0,1.27,0.567,1.27,1.271S20.884,28.84,20.18,28.84z M25.234,42.752c-0.842,0-1.523-0.681-1.523-1.522 c0-0.845,0.682-1.523,1.523-1.523c0.84,0,1.522,0.679,1.522,1.523C26.756,42.071,26.074,42.752,25.234,42.752z M25.234,35.922 c-0.842,0-1.523-0.684-1.523-1.524c0-0.842,0.682-1.523,1.523-1.523c0.84,0,1.522,0.682,1.522,1.523 C26.756,35.238,26.074,35.922,25.234,35.922z M25.234,29.093c-0.842,0-1.523-0.683-1.523-1.524s0.682-1.525,1.523-1.525 c0.84,0,1.522,0.684,1.522,1.525S26.074,29.093,25.234,29.093z M30.523,43.005c-0.983,0-1.778-0.792-1.778-1.775 c0-0.982,0.795-1.78,1.778-1.78c0.985,0,1.779,0.798,1.779,1.78C32.302,42.213,31.508,43.005,30.523,43.005z M30.523,36.176 c-0.983,0-1.778-0.796-1.778-1.778s0.795-1.776,1.778-1.776c0.985,0,1.779,0.794,1.779,1.776S31.508,36.176,30.523,36.176z M30.523,29.346c-0.983,0-1.778-0.796-1.778-1.777s0.795-1.776,1.778-1.776c0.985,0,1.779,0.795,1.779,1.776 S31.508,29.346,30.523,29.346z M36.812,56.922c-1.121,0-2.027-0.911-2.027-2.034c0-1.119,0.906-2.027,2.027-2.027 c1.125,0,2.035,0.908,2.035,2.027C38.847,56.011,37.938,56.922,36.812,56.922z M36.812,50.091c-1.121,0-2.027-0.91-2.027-2.03 c0-1.122,0.906-2.036,2.027-2.036c1.125,0,2.035,0.914,2.035,2.036C38.847,49.181,37.938,50.091,36.812,50.091z M36.812,43.26 c-1.121,0-2.027-0.909-2.027-2.03c0-1.123,0.906-2.033,2.027-2.033c1.125,0,2.035,0.91,2.035,2.033 C38.847,42.351,37.938,43.26,36.812,43.26z M36.812,36.43c-1.121,0-2.027-0.91-2.027-2.032c0-1.124,0.906-2.03,2.027-2.03 c1.125,0,2.035,0.906,2.035,2.03C38.847,35.52,37.938,36.43,36.812,36.43z M36.812,29.6c-1.121,0-2.027-0.908-2.027-2.031 c0-1.122,0.906-2.031,2.027-2.031c1.125,0,2.035,0.909,2.035,2.031C38.847,28.691,37.938,29.6,36.812,29.6z M36.812,22.77 c-1.121,0-2.027-0.912-2.027-2.032c0-1.123,0.906-2.03,2.027-2.03c1.125,0,2.035,0.907,2.035,2.03 C38.847,21.857,37.938,22.77,36.812,22.77z M36.812,15.938c-1.121,0-2.027-0.91-2.027-2.029c0-1.123,0.906-2.033,2.027-2.033 c1.125,0,2.035,0.91,2.035,2.033C38.847,15.027,37.938,15.938,36.812,15.938z M43.342,50.3c-1.233,0-2.238-1.002-2.238-2.239 c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242C45.585,49.298,44.582,50.3,43.342,50.3z M43.342,43.469 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,42.466,44.582,43.469,43.342,43.469z M43.342,36.64c-1.233,0-2.238-1.004-2.238-2.242c0-1.237,1.004-2.238,2.238-2.238 c1.24,0,2.243,1.001,2.243,2.238C45.585,35.636,44.582,36.64,43.342,36.64z M43.342,29.807c-1.233,0-2.238-1.002-2.238-2.238 c0-1.238,1.004-2.24,2.238-2.24c1.24,0,2.243,1.002,2.243,2.24C45.585,28.805,44.582,29.807,43.342,29.807z M43.342,22.977 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,21.974,44.582,22.977,43.342,22.977z M50.351,43.765c-1.393,0-2.517-1.126-2.517-2.517c0-1.389,1.124-2.516,2.517-2.516 c1.391,0,2.513,1.127,2.513,2.516C52.863,42.639,51.742,43.765,50.351,43.765z M50.351,36.933c-1.393,0-2.517-1.123-2.517-2.515 c0-1.386,1.124-2.517,2.517-2.517c1.391,0,2.513,1.131,2.513,2.517C52.863,35.81,51.742,36.933,50.351,36.933z M50.351,30.104 c-1.393,0-2.517-1.125-2.517-2.515c0-1.393,1.124-2.517,2.517-2.517c1.391,0,2.513,1.124,2.513,2.517 C52.863,28.979,51.742,30.104,50.351,30.104z M57.49,37.219c-1.519,0-2.756-1.234-2.756-2.754c0-1.523,1.238-2.757,2.756-2.757 c1.521,0,2.754,1.233,2.754,2.757C60.244,35.984,59.012,37.219,57.49,37.219z"
             />
           </svg>
         </div>
         <a
-          class="logoLink"
+          class="Header__logoLink"
           data-analytics="header:jobs"
           href="/"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             SEEK
           </span>
         </a>
       </h1>
       <span
-        class="logoNote screen"
+        class="Header__logoNote Hidden__screen"
       >
         Australia’s #1 job site
       </span>
       <span
-        class="userWrapper print"
+        class="Header__userWrapper Hidden__print"
       >
         <div
-          class="user"
+          class="Header__user"
         >
           <div
-            class="userAccountWrapper"
+            class="Header__userAccountWrapper"
           >
             <nav
               aria-labelledby="UserMenu"
-              class="root"
+              class="UserAccount__root"
               data-automation="user-account"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="UserMenu"
@@ -94,32 +94,32 @@ exports[`Header: should append returnUrl to signin and register links if present
               </span>
               <input
                 autocomplete="off"
-                class="toggle"
+                class="UserAccount__toggle"
                 id="user-account-menu-toggle"
                 type="checkbox"
               />
               <div
-                class="menuBackdrop"
+                class="UserAccount__menuBackdrop"
               >
                 <label
-                  class="menuBackdropLabel"
+                  class="UserAccount__menuBackdropLabel"
                   data-automation="user-account-menu-backdrop"
                   for="user-account-menu-toggle"
                 >
                   <span
-                    class="root"
+                    class="ScreenReaderOnly__root"
                   >
                     Show user menu
                   </span>
                 </label>
               </div>
               <label
-                class="toggleLabel"
+                class="UserAccount__toggleLabel"
                 data-automation="user-account-menu-toggle"
                 for="user-account-menu-toggle"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   Show user menu
                 </span>
@@ -127,30 +127,30 @@ exports[`Header: should append returnUrl to signin and register links if present
                   data-hj-masked="true"
                 >
                   <span
-                    class="mobileMenuLabel"
+                    class="UserAccount__mobileMenuLabel"
                   />
                   <span
-                    class="desktopMenuLabel"
+                    class="UserAccount__desktopMenuLabel"
                     data-automation="user-account-name"
                   />
                 </span>
                 <span
-                  class="root root chevron"
+                  class="Icon__root ChevronIcon__root UserAccount__chevron"
                 >
                   mock svg
                 </span>
               </label>
               <div
-                class="toggleContainer"
+                class="UserAccount__toggleContainer"
               >
                 <ul
-                  class="root"
+                  class="UserAccountMenu__root"
                 >
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:jobs"
                       href="/"
                     >
@@ -158,7 +158,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                         Job Search
                       </span>
                       <span
-                        class="root icon jobSearch"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__jobSearch"
                       >
                         mock svg
                       </span>
@@ -168,7 +168,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                     class=""
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:profile"
                       href="/profile/"
                     >
@@ -176,17 +176,17 @@ exports[`Header: should append returnUrl to signin and register links if present
                         Profile
                       </span>
                       <span
-                        class="root icon profile"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__profile"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+searches"
                       href="/myactivity"
                     >
@@ -194,7 +194,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                         Saved Searches
                       </span>
                       <span
-                        class="root icon saveSearches"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveSearches"
                       >
                         mock svg
                       </span>
@@ -204,45 +204,45 @@ exports[`Header: should append returnUrl to signin and register links if present
                     class=""
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
                         Saved 
                         <span
-                          class="desktop"
+                          class="Hidden__desktop"
                         >
                           & Applied 
                         </span>
                         Jobs
                       </span>
                       <span
-                        class="root icon saveJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
                       Applied Jobs
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -250,89 +250,89 @@ exports[`Header: should append returnUrl to signin and register links if present
                         Recommended Jobs
                       </span>
                       <span
-                        class="root icon recommendedJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__recommendedJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
                       Company Reviews
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:settings"
                       href="/settings/"
                     >
                       Settings
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <span
-                      class="item pendingAuth"
+                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="root _small"
+                        class="Loader__root Loader___small"
                       >
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                       </div>
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </span>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:advice"
                       href="/career-advice/"
                     >
                       Career Advice
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
@@ -341,15 +341,15 @@ exports[`Header: should append returnUrl to signin and register links if present
             </nav>
           </div>
           <div
-            class="signInRegisterWrapper"
+            class="Header__signInRegisterWrapper"
           >
             <nav
               aria-labelledby="SignInOrRegister"
-              class="root"
+              class="SignInRegister__root"
               data-automation="sign-in-register"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="SignInOrRegister"
@@ -358,7 +358,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                 </h1>
               </span>
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:sign-in"
                 href="/sign-in?returnUrl=%2Fjobs"
                 rel="nofollow"
@@ -368,7 +368,7 @@ exports[`Header: should append returnUrl to signin and register links if present
               </a>
                or 
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:register"
                 href="/sign-up?returnUrl=%2Fjobs"
                 rel="nofollow"
@@ -379,14 +379,14 @@ exports[`Header: should append returnUrl to signin and register links if present
             </nav>
           </div>
           <span
-            class="divider"
+            class="Header__divider"
           />
         </div>
         <div
-          class="employerSite"
+          class="Header__employerSite"
         >
           <a
-            class="employerLink"
+            class="Header__employerLink"
             data-analytics="header:employer+site"
             href="https://talent.seek.com.au/"
           >
@@ -396,15 +396,15 @@ exports[`Header: should append returnUrl to signin and register links if present
       </span>
     </div>
     <span
-      class="navigation print"
+      class="Header__navigation Hidden__print"
     >
       <nav
         aria-labelledby="MainNavigation"
-        class="root divider"
+        class="Navigation__root Navigation__divider"
         role="navigation"
       >
         <span
-          class="root"
+          class="ScreenReaderOnly__root"
         >
           <h1
             id="MainNavigation"
@@ -413,14 +413,14 @@ exports[`Header: should append returnUrl to signin and register links if present
           </h1>
         </span>
         <ul
-          class="list"
+          class="Navigation__list"
           data-automation="nav-tabs"
         >
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:jobs"
               href="/"
             >
@@ -428,11 +428,11 @@ exports[`Header: should append returnUrl to signin and register links if present
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
               aria-label="One fifty K jobs"
-              class="link"
+              class="Navigation__link"
               data-analytics="header:high+salary"
               href="/150kjobs"
             >
@@ -440,10 +440,10 @@ exports[`Header: should append returnUrl to signin and register links if present
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:profile"
               href="/profile/"
             >
@@ -451,10 +451,10 @@ exports[`Header: should append returnUrl to signin and register links if present
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:companies"
               href="/companies/"
             >
@@ -462,10 +462,10 @@ exports[`Header: should append returnUrl to signin and register links if present
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:advice"
               href="/career-advice/"
             >
@@ -476,23 +476,23 @@ exports[`Header: should append returnUrl to signin and register links if present
       </nav>
     </span>
     <div
-      class="topBanner"
+      class="Header__topBanner"
     >
       <div
-        class="root mobile print"
+        class="PartnerSites__root Hidden__mobile Hidden__print"
       >
         <div
-          class="content"
+          class="PageBlock__content"
         >
           <div
-            class="content"
+            class="PartnerSites__content"
           >
             <nav
               aria-labelledby="Sites"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="Sites"
@@ -501,11 +501,11 @@ exports[`Header: should append returnUrl to signin and register links if present
                 </h1>
               </span>
               <ul
-                class="list"
+                class="Sites__list"
               >
                 <li>
                   <span
-                    class="link link_isActive"
+                    class="Sites__link Sites__link_isActive"
                     title="SEEK Jobs"
                   >
                     Jobs
@@ -513,7 +513,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                 </li>
                 <li>
                   <a
-                    class="link link_isLearning"
+                    class="Sites__link Sites__link_isLearning"
                     data-analytics="header:courses"
                     href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     title="SEEK Learning"
@@ -523,7 +523,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                 </li>
                 <li>
                   <a
-                    class="link link_isBusiness"
+                    class="Sites__link Sites__link_isBusiness"
                     data-analytics="header:business+for+sale"
                     href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     title="SEEK Business"
@@ -533,7 +533,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                 </li>
                 <li>
                   <a
-                    class="link link_isVolunteering"
+                    class="Sites__link Sites__link_isVolunteering"
                     data-analytics="header:volunteering"
                     href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     title="SEEK Volunteer"
@@ -544,14 +544,14 @@ exports[`Header: should append returnUrl to signin and register links if present
               </ul>
             </nav>
             <div
-              class="locale"
+              class="PartnerSites__locale"
             >
               <nav
                 aria-labelledby="Locales"
                 role="navigation"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   <h1
                     id="Locales"
@@ -560,18 +560,18 @@ exports[`Header: should append returnUrl to signin and register links if present
                   </h1>
                 </span>
                 <ul
-                  class="list"
+                  class="Locales__list"
                 >
                   <li>
                     <span
-                      class="locale_isActive"
+                      class="Locales__locale_isActive"
                     >
                       AU
                     </span>
                   </li>
                   <li>
                     <a
-                      class="localeLink"
+                      class="Locales__localeLink"
                       data-analytics="header:nz+homepage"
                       href="https://www.seek.co.nz"
                       title="SEEK New Zealand"
@@ -593,24 +593,24 @@ exports[`Header: should append returnUrl to signin and register links if present
 exports[`Header: should render first part of email address when username isn't present 1`] = `
 <header
   aria-label="Primary navigation"
-  class="root"
+  class="Header__root"
   role="banner"
 >
   <section
-    class="content"
+    class="Header__content"
   >
     <div
-      class="banner"
+      class="Header__banner"
     >
       <h1
-        class="logo"
+        class="Header__logo"
         data-automation="logo"
       >
         <div
           class=""
         >
           <svg
-            class="logoSvg root"
+            class="Header__logoSvg Logo__root"
             height="68.031"
             id="sk-logo-pos"
             viewBox="0 0 170.079 68.031"
@@ -620,7 +620,7 @@ exports[`Header: should render first part of email address when username isn't p
             y="0px"
           >
             <g
-              class="logoText"
+              class="Logo__logoText"
             >
               <path
                 d="M86.641,45.601c-3.697,0-7.037-0.408-10.012-3.385l3.834-3.833c1.942,1.938,4.467,2.208,6.269,2.208 c2.031,0,4.148-0.675,4.148-2.434c0-1.174-0.629-1.985-2.479-2.167l-3.699-0.36c-4.24-0.404-6.854-2.253-6.854-6.586 c0-4.869,4.282-7.485,9.064-7.485c3.653,0,6.72,0.632,8.976,2.75l-3.607,3.653c-1.354-1.217-3.43-1.576-5.459-1.576 c-2.344,0-3.336,1.082-3.336,2.254c0,0.857,0.361,1.85,2.436,2.03l3.7,0.361c4.643,0.45,6.992,2.932,6.992,6.9 C96.612,43.118,92.19,45.601,86.641,45.601z"
@@ -636,45 +636,45 @@ exports[`Header: should render first part of email address when username isn't p
               />
             </g>
             <path
-              class="logoIcon"
+              class="Logo__logoIcon"
               d="M34.015,1.51c-17.952,0-32.506,14.552-32.506,32.507c0,17.952,14.554,32.505,32.506,32.505 c17.958,0,32.508-14.553,32.508-32.505C66.523,16.062,51.972,1.51,34.015,1.51z M8.262,41.733c-0.281,0-0.511-0.226-0.511-0.504 c0-0.281,0.229-0.511,0.511-0.511c0.278,0,0.504,0.229,0.504,0.511C8.766,41.508,8.541,41.733,8.262,41.733z M8.262,34.907 c-0.281,0-0.511-0.229-0.511-0.51s0.229-0.509,0.511-0.509c0.278,0,0.504,0.228,0.504,0.509S8.541,34.907,8.262,34.907z M8.262,28.077c-0.281,0-0.511-0.229-0.511-0.509c0-0.281,0.229-0.507,0.511-0.507c0.278,0,0.504,0.226,0.504,0.507 C8.766,27.849,8.541,28.077,8.262,28.077z M11.764,41.991c-0.422,0-0.762-0.342-0.762-0.762c0-0.422,0.34-0.765,0.762-0.765 c0.421,0,0.762,0.343,0.762,0.765C12.526,41.649,12.186,41.991,11.764,41.991z M11.764,35.158c-0.422,0-0.762-0.339-0.762-0.761 c0-0.42,0.34-0.761,0.762-0.761c0.421,0,0.762,0.341,0.762,0.761C12.526,34.819,12.186,35.158,11.764,35.158z M11.764,28.33 c-0.422,0-0.762-0.341-0.762-0.762c0-0.422,0.34-0.763,0.762-0.763c0.421,0,0.762,0.341,0.762,0.763 C12.526,27.989,12.186,28.33,11.764,28.33z M15.867,42.246c-0.562,0-1.019-0.455-1.019-1.017c0-0.561,0.457-1.018,1.019-1.018 c0.558,0,1.016,0.457,1.016,1.018C16.882,41.791,16.424,42.246,15.867,42.246z M15.867,35.412c-0.562,0-1.019-0.453-1.019-1.015 c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016C16.882,34.959,16.424,35.412,15.867,35.412z M15.867,28.583 c-0.562,0-1.019-0.451-1.019-1.015c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016 C16.882,28.132,16.424,28.583,15.867,28.583z M20.18,42.497c-0.702,0-1.27-0.567-1.27-1.268c0-0.705,0.568-1.27,1.27-1.27 c0.704,0,1.27,0.564,1.27,1.27C21.45,41.93,20.884,42.497,20.18,42.497z M20.18,35.669c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.269,1.27-1.269c0.704,0,1.27,0.565,1.27,1.269S20.884,35.669,20.18,35.669z M20.18,28.84c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.271,1.27-1.271c0.704,0,1.27,0.567,1.27,1.271S20.884,28.84,20.18,28.84z M25.234,42.752c-0.842,0-1.523-0.681-1.523-1.522 c0-0.845,0.682-1.523,1.523-1.523c0.84,0,1.522,0.679,1.522,1.523C26.756,42.071,26.074,42.752,25.234,42.752z M25.234,35.922 c-0.842,0-1.523-0.684-1.523-1.524c0-0.842,0.682-1.523,1.523-1.523c0.84,0,1.522,0.682,1.522,1.523 C26.756,35.238,26.074,35.922,25.234,35.922z M25.234,29.093c-0.842,0-1.523-0.683-1.523-1.524s0.682-1.525,1.523-1.525 c0.84,0,1.522,0.684,1.522,1.525S26.074,29.093,25.234,29.093z M30.523,43.005c-0.983,0-1.778-0.792-1.778-1.775 c0-0.982,0.795-1.78,1.778-1.78c0.985,0,1.779,0.798,1.779,1.78C32.302,42.213,31.508,43.005,30.523,43.005z M30.523,36.176 c-0.983,0-1.778-0.796-1.778-1.778s0.795-1.776,1.778-1.776c0.985,0,1.779,0.794,1.779,1.776S31.508,36.176,30.523,36.176z M30.523,29.346c-0.983,0-1.778-0.796-1.778-1.777s0.795-1.776,1.778-1.776c0.985,0,1.779,0.795,1.779,1.776 S31.508,29.346,30.523,29.346z M36.812,56.922c-1.121,0-2.027-0.911-2.027-2.034c0-1.119,0.906-2.027,2.027-2.027 c1.125,0,2.035,0.908,2.035,2.027C38.847,56.011,37.938,56.922,36.812,56.922z M36.812,50.091c-1.121,0-2.027-0.91-2.027-2.03 c0-1.122,0.906-2.036,2.027-2.036c1.125,0,2.035,0.914,2.035,2.036C38.847,49.181,37.938,50.091,36.812,50.091z M36.812,43.26 c-1.121,0-2.027-0.909-2.027-2.03c0-1.123,0.906-2.033,2.027-2.033c1.125,0,2.035,0.91,2.035,2.033 C38.847,42.351,37.938,43.26,36.812,43.26z M36.812,36.43c-1.121,0-2.027-0.91-2.027-2.032c0-1.124,0.906-2.03,2.027-2.03 c1.125,0,2.035,0.906,2.035,2.03C38.847,35.52,37.938,36.43,36.812,36.43z M36.812,29.6c-1.121,0-2.027-0.908-2.027-2.031 c0-1.122,0.906-2.031,2.027-2.031c1.125,0,2.035,0.909,2.035,2.031C38.847,28.691,37.938,29.6,36.812,29.6z M36.812,22.77 c-1.121,0-2.027-0.912-2.027-2.032c0-1.123,0.906-2.03,2.027-2.03c1.125,0,2.035,0.907,2.035,2.03 C38.847,21.857,37.938,22.77,36.812,22.77z M36.812,15.938c-1.121,0-2.027-0.91-2.027-2.029c0-1.123,0.906-2.033,2.027-2.033 c1.125,0,2.035,0.91,2.035,2.033C38.847,15.027,37.938,15.938,36.812,15.938z M43.342,50.3c-1.233,0-2.238-1.002-2.238-2.239 c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242C45.585,49.298,44.582,50.3,43.342,50.3z M43.342,43.469 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,42.466,44.582,43.469,43.342,43.469z M43.342,36.64c-1.233,0-2.238-1.004-2.238-2.242c0-1.237,1.004-2.238,2.238-2.238 c1.24,0,2.243,1.001,2.243,2.238C45.585,35.636,44.582,36.64,43.342,36.64z M43.342,29.807c-1.233,0-2.238-1.002-2.238-2.238 c0-1.238,1.004-2.24,2.238-2.24c1.24,0,2.243,1.002,2.243,2.24C45.585,28.805,44.582,29.807,43.342,29.807z M43.342,22.977 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,21.974,44.582,22.977,43.342,22.977z M50.351,43.765c-1.393,0-2.517-1.126-2.517-2.517c0-1.389,1.124-2.516,2.517-2.516 c1.391,0,2.513,1.127,2.513,2.516C52.863,42.639,51.742,43.765,50.351,43.765z M50.351,36.933c-1.393,0-2.517-1.123-2.517-2.515 c0-1.386,1.124-2.517,2.517-2.517c1.391,0,2.513,1.131,2.513,2.517C52.863,35.81,51.742,36.933,50.351,36.933z M50.351,30.104 c-1.393,0-2.517-1.125-2.517-2.515c0-1.393,1.124-2.517,2.517-2.517c1.391,0,2.513,1.124,2.513,2.517 C52.863,28.979,51.742,30.104,50.351,30.104z M57.49,37.219c-1.519,0-2.756-1.234-2.756-2.754c0-1.523,1.238-2.757,2.756-2.757 c1.521,0,2.754,1.233,2.754,2.757C60.244,35.984,59.012,37.219,57.49,37.219z"
             />
           </svg>
         </div>
         <a
-          class="logoLink"
+          class="Header__logoLink"
           data-analytics="header:jobs"
           href="/"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             SEEK
           </span>
         </a>
       </h1>
       <span
-        class="logoNote screen"
+        class="Header__logoNote Hidden__screen"
       >
         Australia’s #1 job site
       </span>
       <span
-        class="userWrapper print"
+        class="Header__userWrapper Hidden__print"
       >
         <div
-          class="user user_isAuthenticated user_isReady"
+          class="Header__user Header__user_isAuthenticated Header__user_isReady"
         >
           <div
-            class="userAccountWrapper"
+            class="Header__userAccountWrapper"
           >
             <nav
               aria-labelledby="UserMenu"
-              class="root"
+              class="UserAccount__root"
               data-automation="user-account"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="UserMenu"
@@ -684,32 +684,32 @@ exports[`Header: should render first part of email address when username isn't p
               </span>
               <input
                 autocomplete="off"
-                class="toggle"
+                class="UserAccount__toggle"
                 id="user-account-menu-toggle"
                 type="checkbox"
               />
               <div
-                class="menuBackdrop"
+                class="UserAccount__menuBackdrop"
               >
                 <label
-                  class="menuBackdropLabel"
+                  class="UserAccount__menuBackdropLabel"
                   data-automation="user-account-menu-backdrop"
                   for="user-account-menu-toggle"
                 >
                   <span
-                    class="root"
+                    class="ScreenReaderOnly__root"
                   >
                     Show user menu
                   </span>
                 </label>
               </div>
               <label
-                class="toggleLabel"
+                class="UserAccount__toggleLabel"
                 data-automation="user-account-menu-toggle"
                 for="user-account-menu-toggle"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   Show user menu
                 </span>
@@ -717,34 +717,34 @@ exports[`Header: should render first part of email address when username isn't p
                   data-hj-masked="true"
                 >
                   <span
-                    class="mobileMenuLabel"
+                    class="UserAccount__mobileMenuLabel"
                   >
                     leeroybrown
                   </span>
                   <span
-                    class="desktopMenuLabel"
+                    class="UserAccount__desktopMenuLabel"
                     data-automation="user-account-name"
                   >
                     leeroybrown
                   </span>
                 </span>
                 <span
-                  class="root root chevron"
+                  class="Icon__root ChevronIcon__root UserAccount__chevron"
                 >
                   mock svg
                 </span>
               </label>
               <div
-                class="toggleContainer"
+                class="UserAccount__toggleContainer"
               >
                 <ul
-                  class="root"
+                  class="UserAccountMenu__root"
                 >
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:jobs"
                       href="/"
                     >
@@ -752,7 +752,7 @@ exports[`Header: should render first part of email address when username isn't p
                         Job Search
                       </span>
                       <span
-                        class="root icon jobSearch"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__jobSearch"
                       >
                         mock svg
                       </span>
@@ -762,7 +762,7 @@ exports[`Header: should render first part of email address when username isn't p
                     class=""
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:profile"
                       href="/profile/"
                     >
@@ -770,17 +770,17 @@ exports[`Header: should render first part of email address when username isn't p
                         Profile
                       </span>
                       <span
-                        class="root icon profile"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__profile"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+searches"
                       href="/myactivity"
                     >
@@ -788,7 +788,7 @@ exports[`Header: should render first part of email address when username isn't p
                         Saved Searches
                       </span>
                       <span
-                        class="root icon saveSearches"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveSearches"
                       >
                         mock svg
                       </span>
@@ -798,45 +798,45 @@ exports[`Header: should render first part of email address when username isn't p
                     class=""
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+jobs"
                       href="/my-activity/saved-jobs"
                     >
                       <span>
                         Saved 
                         <span
-                          class="desktop"
+                          class="Hidden__desktop"
                         >
                           & Applied 
                         </span>
                         Jobs
                       </span>
                       <span
-                        class="root icon saveJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:applied+jobs"
                       href="/my-activity/applied-jobs"
                     >
                       Applied Jobs
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:recommended+jobs"
                       href="/recommended"
                     >
@@ -844,93 +844,93 @@ exports[`Header: should render first part of email address when username isn't p
                         Recommended Jobs
                       </span>
                       <span
-                        class="root icon recommendedJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__recommendedJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
                       Company Reviews
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:settings"
                       href="/settings/"
                     >
                       Settings
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:sign-out"
                       href="/Login/Logout"
                     >
                       Sign Out
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:advice"
                       href="/career-advice/"
                     >
                       Career Advice
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:sign-out"
                       href="/Login/Logout"
                     >
                       Sign Out
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
@@ -939,15 +939,15 @@ exports[`Header: should render first part of email address when username isn't p
             </nav>
           </div>
           <div
-            class="signInRegisterWrapper"
+            class="Header__signInRegisterWrapper"
           >
             <nav
               aria-labelledby="SignInOrRegister"
-              class="root"
+              class="SignInRegister__root"
               data-automation="sign-in-register"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="SignInOrRegister"
@@ -956,7 +956,7 @@ exports[`Header: should render first part of email address when username isn't p
                 </h1>
               </span>
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:sign-in"
                 href="/sign-in"
                 rel="nofollow"
@@ -966,7 +966,7 @@ exports[`Header: should render first part of email address when username isn't p
               </a>
                or 
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:register"
                 href="/sign-up"
                 rel="nofollow"
@@ -977,14 +977,14 @@ exports[`Header: should render first part of email address when username isn't p
             </nav>
           </div>
           <span
-            class="divider"
+            class="Header__divider"
           />
         </div>
         <div
-          class="employerSite"
+          class="Header__employerSite"
         >
           <a
-            class="employerLink"
+            class="Header__employerLink"
             data-analytics="header:employer+site"
             href="https://talent.seek.com.au/"
           >
@@ -994,15 +994,15 @@ exports[`Header: should render first part of email address when username isn't p
       </span>
     </div>
     <span
-      class="navigation print"
+      class="Header__navigation Hidden__print"
     >
       <nav
         aria-labelledby="MainNavigation"
-        class="root divider"
+        class="Navigation__root Navigation__divider"
         role="navigation"
       >
         <span
-          class="root"
+          class="ScreenReaderOnly__root"
         >
           <h1
             id="MainNavigation"
@@ -1011,14 +1011,14 @@ exports[`Header: should render first part of email address when username isn't p
           </h1>
         </span>
         <ul
-          class="list"
+          class="Navigation__list"
           data-automation="nav-tabs"
         >
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:jobs"
               href="/"
             >
@@ -1026,11 +1026,11 @@ exports[`Header: should render first part of email address when username isn't p
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
               aria-label="One fifty K jobs"
-              class="link"
+              class="Navigation__link"
               data-analytics="header:high+salary"
               href="/150kjobs"
             >
@@ -1038,10 +1038,10 @@ exports[`Header: should render first part of email address when username isn't p
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:profile"
               href="/profile/"
             >
@@ -1049,10 +1049,10 @@ exports[`Header: should render first part of email address when username isn't p
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:companies"
               href="/companies/"
             >
@@ -1060,10 +1060,10 @@ exports[`Header: should render first part of email address when username isn't p
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:advice"
               href="/career-advice/"
             >
@@ -1074,23 +1074,23 @@ exports[`Header: should render first part of email address when username isn't p
       </nav>
     </span>
     <div
-      class="topBanner"
+      class="Header__topBanner"
     >
       <div
-        class="root mobile print"
+        class="PartnerSites__root Hidden__mobile Hidden__print"
       >
         <div
-          class="content"
+          class="PageBlock__content"
         >
           <div
-            class="content"
+            class="PartnerSites__content"
           >
             <nav
               aria-labelledby="Sites"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="Sites"
@@ -1099,11 +1099,11 @@ exports[`Header: should render first part of email address when username isn't p
                 </h1>
               </span>
               <ul
-                class="list"
+                class="Sites__list"
               >
                 <li>
                   <span
-                    class="link link_isActive"
+                    class="Sites__link Sites__link_isActive"
                     title="SEEK Jobs"
                   >
                     Jobs
@@ -1111,7 +1111,7 @@ exports[`Header: should render first part of email address when username isn't p
                 </li>
                 <li>
                   <a
-                    class="link link_isLearning"
+                    class="Sites__link Sites__link_isLearning"
                     data-analytics="header:courses"
                     href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     title="SEEK Learning"
@@ -1121,7 +1121,7 @@ exports[`Header: should render first part of email address when username isn't p
                 </li>
                 <li>
                   <a
-                    class="link link_isBusiness"
+                    class="Sites__link Sites__link_isBusiness"
                     data-analytics="header:business+for+sale"
                     href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     title="SEEK Business"
@@ -1131,7 +1131,7 @@ exports[`Header: should render first part of email address when username isn't p
                 </li>
                 <li>
                   <a
-                    class="link link_isVolunteering"
+                    class="Sites__link Sites__link_isVolunteering"
                     data-analytics="header:volunteering"
                     href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     title="SEEK Volunteer"
@@ -1142,14 +1142,14 @@ exports[`Header: should render first part of email address when username isn't p
               </ul>
             </nav>
             <div
-              class="locale"
+              class="PartnerSites__locale"
             >
               <nav
                 aria-labelledby="Locales"
                 role="navigation"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   <h1
                     id="Locales"
@@ -1158,18 +1158,18 @@ exports[`Header: should render first part of email address when username isn't p
                   </h1>
                 </span>
                 <ul
-                  class="list"
+                  class="Locales__list"
                 >
                   <li>
                     <span
-                      class="locale_isActive"
+                      class="Locales__locale_isActive"
                     >
                       AU
                     </span>
                   </li>
                   <li>
                     <a
-                      class="localeLink"
+                      class="Locales__localeLink"
                       data-analytics="header:nz+homepage"
                       href="https://www.seek.co.nz"
                       title="SEEK New Zealand"
@@ -1191,24 +1191,24 @@ exports[`Header: should render first part of email address when username isn't p
 exports[`Header: should render when activeTab is 'Profile' 1`] = `
 <header
   aria-label="Primary navigation"
-  class="root"
+  class="Header__root"
   role="banner"
 >
   <section
-    class="content"
+    class="Header__content"
   >
     <div
-      class="banner"
+      class="Header__banner"
     >
       <h1
-        class="logo"
+        class="Header__logo"
         data-automation="logo"
       >
         <div
           class=""
         >
           <svg
-            class="logoSvg root"
+            class="Header__logoSvg Logo__root"
             height="68.031"
             id="sk-logo-pos"
             viewBox="0 0 170.079 68.031"
@@ -1218,7 +1218,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
             y="0px"
           >
             <g
-              class="logoText"
+              class="Logo__logoText"
             >
               <path
                 d="M86.641,45.601c-3.697,0-7.037-0.408-10.012-3.385l3.834-3.833c1.942,1.938,4.467,2.208,6.269,2.208 c2.031,0,4.148-0.675,4.148-2.434c0-1.174-0.629-1.985-2.479-2.167l-3.699-0.36c-4.24-0.404-6.854-2.253-6.854-6.586 c0-4.869,4.282-7.485,9.064-7.485c3.653,0,6.72,0.632,8.976,2.75l-3.607,3.653c-1.354-1.217-3.43-1.576-5.459-1.576 c-2.344,0-3.336,1.082-3.336,2.254c0,0.857,0.361,1.85,2.436,2.03l3.7,0.361c4.643,0.45,6.992,2.932,6.992,6.9 C96.612,43.118,92.19,45.601,86.641,45.601z"
@@ -1234,45 +1234,45 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
               />
             </g>
             <path
-              class="logoIcon"
+              class="Logo__logoIcon"
               d="M34.015,1.51c-17.952,0-32.506,14.552-32.506,32.507c0,17.952,14.554,32.505,32.506,32.505 c17.958,0,32.508-14.553,32.508-32.505C66.523,16.062,51.972,1.51,34.015,1.51z M8.262,41.733c-0.281,0-0.511-0.226-0.511-0.504 c0-0.281,0.229-0.511,0.511-0.511c0.278,0,0.504,0.229,0.504,0.511C8.766,41.508,8.541,41.733,8.262,41.733z M8.262,34.907 c-0.281,0-0.511-0.229-0.511-0.51s0.229-0.509,0.511-0.509c0.278,0,0.504,0.228,0.504,0.509S8.541,34.907,8.262,34.907z M8.262,28.077c-0.281,0-0.511-0.229-0.511-0.509c0-0.281,0.229-0.507,0.511-0.507c0.278,0,0.504,0.226,0.504,0.507 C8.766,27.849,8.541,28.077,8.262,28.077z M11.764,41.991c-0.422,0-0.762-0.342-0.762-0.762c0-0.422,0.34-0.765,0.762-0.765 c0.421,0,0.762,0.343,0.762,0.765C12.526,41.649,12.186,41.991,11.764,41.991z M11.764,35.158c-0.422,0-0.762-0.339-0.762-0.761 c0-0.42,0.34-0.761,0.762-0.761c0.421,0,0.762,0.341,0.762,0.761C12.526,34.819,12.186,35.158,11.764,35.158z M11.764,28.33 c-0.422,0-0.762-0.341-0.762-0.762c0-0.422,0.34-0.763,0.762-0.763c0.421,0,0.762,0.341,0.762,0.763 C12.526,27.989,12.186,28.33,11.764,28.33z M15.867,42.246c-0.562,0-1.019-0.455-1.019-1.017c0-0.561,0.457-1.018,1.019-1.018 c0.558,0,1.016,0.457,1.016,1.018C16.882,41.791,16.424,42.246,15.867,42.246z M15.867,35.412c-0.562,0-1.019-0.453-1.019-1.015 c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016C16.882,34.959,16.424,35.412,15.867,35.412z M15.867,28.583 c-0.562,0-1.019-0.451-1.019-1.015c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016 C16.882,28.132,16.424,28.583,15.867,28.583z M20.18,42.497c-0.702,0-1.27-0.567-1.27-1.268c0-0.705,0.568-1.27,1.27-1.27 c0.704,0,1.27,0.564,1.27,1.27C21.45,41.93,20.884,42.497,20.18,42.497z M20.18,35.669c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.269,1.27-1.269c0.704,0,1.27,0.565,1.27,1.269S20.884,35.669,20.18,35.669z M20.18,28.84c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.271,1.27-1.271c0.704,0,1.27,0.567,1.27,1.271S20.884,28.84,20.18,28.84z M25.234,42.752c-0.842,0-1.523-0.681-1.523-1.522 c0-0.845,0.682-1.523,1.523-1.523c0.84,0,1.522,0.679,1.522,1.523C26.756,42.071,26.074,42.752,25.234,42.752z M25.234,35.922 c-0.842,0-1.523-0.684-1.523-1.524c0-0.842,0.682-1.523,1.523-1.523c0.84,0,1.522,0.682,1.522,1.523 C26.756,35.238,26.074,35.922,25.234,35.922z M25.234,29.093c-0.842,0-1.523-0.683-1.523-1.524s0.682-1.525,1.523-1.525 c0.84,0,1.522,0.684,1.522,1.525S26.074,29.093,25.234,29.093z M30.523,43.005c-0.983,0-1.778-0.792-1.778-1.775 c0-0.982,0.795-1.78,1.778-1.78c0.985,0,1.779,0.798,1.779,1.78C32.302,42.213,31.508,43.005,30.523,43.005z M30.523,36.176 c-0.983,0-1.778-0.796-1.778-1.778s0.795-1.776,1.778-1.776c0.985,0,1.779,0.794,1.779,1.776S31.508,36.176,30.523,36.176z M30.523,29.346c-0.983,0-1.778-0.796-1.778-1.777s0.795-1.776,1.778-1.776c0.985,0,1.779,0.795,1.779,1.776 S31.508,29.346,30.523,29.346z M36.812,56.922c-1.121,0-2.027-0.911-2.027-2.034c0-1.119,0.906-2.027,2.027-2.027 c1.125,0,2.035,0.908,2.035,2.027C38.847,56.011,37.938,56.922,36.812,56.922z M36.812,50.091c-1.121,0-2.027-0.91-2.027-2.03 c0-1.122,0.906-2.036,2.027-2.036c1.125,0,2.035,0.914,2.035,2.036C38.847,49.181,37.938,50.091,36.812,50.091z M36.812,43.26 c-1.121,0-2.027-0.909-2.027-2.03c0-1.123,0.906-2.033,2.027-2.033c1.125,0,2.035,0.91,2.035,2.033 C38.847,42.351,37.938,43.26,36.812,43.26z M36.812,36.43c-1.121,0-2.027-0.91-2.027-2.032c0-1.124,0.906-2.03,2.027-2.03 c1.125,0,2.035,0.906,2.035,2.03C38.847,35.52,37.938,36.43,36.812,36.43z M36.812,29.6c-1.121,0-2.027-0.908-2.027-2.031 c0-1.122,0.906-2.031,2.027-2.031c1.125,0,2.035,0.909,2.035,2.031C38.847,28.691,37.938,29.6,36.812,29.6z M36.812,22.77 c-1.121,0-2.027-0.912-2.027-2.032c0-1.123,0.906-2.03,2.027-2.03c1.125,0,2.035,0.907,2.035,2.03 C38.847,21.857,37.938,22.77,36.812,22.77z M36.812,15.938c-1.121,0-2.027-0.91-2.027-2.029c0-1.123,0.906-2.033,2.027-2.033 c1.125,0,2.035,0.91,2.035,2.033C38.847,15.027,37.938,15.938,36.812,15.938z M43.342,50.3c-1.233,0-2.238-1.002-2.238-2.239 c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242C45.585,49.298,44.582,50.3,43.342,50.3z M43.342,43.469 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,42.466,44.582,43.469,43.342,43.469z M43.342,36.64c-1.233,0-2.238-1.004-2.238-2.242c0-1.237,1.004-2.238,2.238-2.238 c1.24,0,2.243,1.001,2.243,2.238C45.585,35.636,44.582,36.64,43.342,36.64z M43.342,29.807c-1.233,0-2.238-1.002-2.238-2.238 c0-1.238,1.004-2.24,2.238-2.24c1.24,0,2.243,1.002,2.243,2.24C45.585,28.805,44.582,29.807,43.342,29.807z M43.342,22.977 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,21.974,44.582,22.977,43.342,22.977z M50.351,43.765c-1.393,0-2.517-1.126-2.517-2.517c0-1.389,1.124-2.516,2.517-2.516 c1.391,0,2.513,1.127,2.513,2.516C52.863,42.639,51.742,43.765,50.351,43.765z M50.351,36.933c-1.393,0-2.517-1.123-2.517-2.515 c0-1.386,1.124-2.517,2.517-2.517c1.391,0,2.513,1.131,2.513,2.517C52.863,35.81,51.742,36.933,50.351,36.933z M50.351,30.104 c-1.393,0-2.517-1.125-2.517-2.515c0-1.393,1.124-2.517,2.517-2.517c1.391,0,2.513,1.124,2.513,2.517 C52.863,28.979,51.742,30.104,50.351,30.104z M57.49,37.219c-1.519,0-2.756-1.234-2.756-2.754c0-1.523,1.238-2.757,2.756-2.757 c1.521,0,2.754,1.233,2.754,2.757C60.244,35.984,59.012,37.219,57.49,37.219z"
             />
           </svg>
         </div>
         <a
-          class="logoLink"
+          class="Header__logoLink"
           data-analytics="header:jobs"
           href="/"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             SEEK
           </span>
         </a>
       </h1>
       <span
-        class="logoNote screen"
+        class="Header__logoNote Hidden__screen"
       >
         Australia’s #1 job site
       </span>
       <span
-        class="userWrapper print"
+        class="Header__userWrapper Hidden__print"
       >
         <div
-          class="user"
+          class="Header__user"
         >
           <div
-            class="userAccountWrapper"
+            class="Header__userAccountWrapper"
           >
             <nav
               aria-labelledby="UserMenu"
-              class="root"
+              class="UserAccount__root"
               data-automation="user-account"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="UserMenu"
@@ -1282,32 +1282,32 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
               </span>
               <input
                 autocomplete="off"
-                class="toggle"
+                class="UserAccount__toggle"
                 id="user-account-menu-toggle"
                 type="checkbox"
               />
               <div
-                class="menuBackdrop"
+                class="UserAccount__menuBackdrop"
               >
                 <label
-                  class="menuBackdropLabel"
+                  class="UserAccount__menuBackdropLabel"
                   data-automation="user-account-menu-backdrop"
                   for="user-account-menu-toggle"
                 >
                   <span
-                    class="root"
+                    class="ScreenReaderOnly__root"
                   >
                     Show user menu
                   </span>
                 </label>
               </div>
               <label
-                class="toggleLabel"
+                class="UserAccount__toggleLabel"
                 data-automation="user-account-menu-toggle"
                 for="user-account-menu-toggle"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   Show user menu
                 </span>
@@ -1315,30 +1315,30 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                   data-hj-masked="true"
                 >
                   <span
-                    class="mobileMenuLabel"
+                    class="UserAccount__mobileMenuLabel"
                   />
                   <span
-                    class="desktopMenuLabel"
+                    class="UserAccount__desktopMenuLabel"
                     data-automation="user-account-name"
                   />
                 </span>
                 <span
-                  class="root root chevron"
+                  class="Icon__root ChevronIcon__root UserAccount__chevron"
                 >
                   mock svg
                 </span>
               </label>
               <div
-                class="toggleContainer"
+                class="UserAccount__toggleContainer"
               >
                 <ul
-                  class="root"
+                  class="UserAccountMenu__root"
                 >
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:jobs"
                       href="/"
                     >
@@ -1346,17 +1346,17 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                         Job Search
                       </span>
                       <span
-                        class="root icon jobSearch"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__jobSearch"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="activeTab"
+                    class="UserAccountMenu__activeTab"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:profile"
                       href="/profile/"
                     >
@@ -1364,17 +1364,17 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                         Profile
                       </span>
                       <span
-                        class="root icon profile"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__profile"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+searches"
                       href="/myactivity"
                     >
@@ -1382,7 +1382,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                         Saved Searches
                       </span>
                       <span
-                        class="root icon saveSearches"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveSearches"
                       >
                         mock svg
                       </span>
@@ -1392,45 +1392,45 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                     class=""
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
                         Saved 
                         <span
-                          class="desktop"
+                          class="Hidden__desktop"
                         >
                           & Applied 
                         </span>
                         Jobs
                       </span>
                       <span
-                        class="root icon saveJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
                       Applied Jobs
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -1438,89 +1438,89 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                         Recommended Jobs
                       </span>
                       <span
-                        class="root icon recommendedJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__recommendedJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
                       Company Reviews
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:settings"
                       href="/settings/"
                     >
                       Settings
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <span
-                      class="item pendingAuth"
+                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="root _small"
+                        class="Loader__root Loader___small"
                       >
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                       </div>
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </span>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:advice"
                       href="/career-advice/"
                     >
                       Career Advice
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
@@ -1529,15 +1529,15 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
             </nav>
           </div>
           <div
-            class="signInRegisterWrapper"
+            class="Header__signInRegisterWrapper"
           >
             <nav
               aria-labelledby="SignInOrRegister"
-              class="root"
+              class="SignInRegister__root"
               data-automation="sign-in-register"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="SignInOrRegister"
@@ -1546,7 +1546,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                 </h1>
               </span>
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:sign-in"
                 href="/sign-in"
                 rel="nofollow"
@@ -1556,7 +1556,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
               </a>
                or 
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:register"
                 href="/sign-up"
                 rel="nofollow"
@@ -1567,14 +1567,14 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
             </nav>
           </div>
           <span
-            class="divider"
+            class="Header__divider"
           />
         </div>
         <div
-          class="employerSite"
+          class="Header__employerSite"
         >
           <a
-            class="employerLink"
+            class="Header__employerLink"
             data-analytics="header:employer+site"
             href="https://talent.seek.com.au/"
           >
@@ -1584,15 +1584,15 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
       </span>
     </div>
     <span
-      class="navigation print"
+      class="Header__navigation Hidden__print"
     >
       <nav
         aria-labelledby="MainNavigation"
-        class="root divider"
+        class="Navigation__root Navigation__divider"
         role="navigation"
       >
         <span
-          class="root"
+          class="ScreenReaderOnly__root"
         >
           <h1
             id="MainNavigation"
@@ -1601,14 +1601,14 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
           </h1>
         </span>
         <ul
-          class="list"
+          class="Navigation__list"
           data-automation="nav-tabs"
         >
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:jobs"
               href="/"
             >
@@ -1616,11 +1616,11 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
               aria-label="One fifty K jobs"
-              class="link"
+              class="Navigation__link"
               data-analytics="header:high+salary"
               href="/150kjobs"
             >
@@ -1628,10 +1628,10 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link link_isActive"
+              class="Navigation__link Navigation__link_isActive"
               data-analytics="header:profile"
               href="/profile/"
             >
@@ -1639,10 +1639,10 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:companies"
               href="/companies/"
             >
@@ -1650,10 +1650,10 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:advice"
               href="/career-advice/"
             >
@@ -1664,23 +1664,23 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
       </nav>
     </span>
     <div
-      class="topBanner"
+      class="Header__topBanner"
     >
       <div
-        class="root mobile print"
+        class="PartnerSites__root Hidden__mobile Hidden__print"
       >
         <div
-          class="content"
+          class="PageBlock__content"
         >
           <div
-            class="content"
+            class="PartnerSites__content"
           >
             <nav
               aria-labelledby="Sites"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="Sites"
@@ -1689,11 +1689,11 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                 </h1>
               </span>
               <ul
-                class="list"
+                class="Sites__list"
               >
                 <li>
                   <span
-                    class="link link_isActive"
+                    class="Sites__link Sites__link_isActive"
                     title="SEEK Jobs"
                   >
                     Jobs
@@ -1701,7 +1701,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isLearning"
+                    class="Sites__link Sites__link_isLearning"
                     data-analytics="header:courses"
                     href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     title="SEEK Learning"
@@ -1711,7 +1711,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isBusiness"
+                    class="Sites__link Sites__link_isBusiness"
                     data-analytics="header:business+for+sale"
                     href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     title="SEEK Business"
@@ -1721,7 +1721,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isVolunteering"
+                    class="Sites__link Sites__link_isVolunteering"
                     data-analytics="header:volunteering"
                     href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     title="SEEK Volunteer"
@@ -1732,14 +1732,14 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
               </ul>
             </nav>
             <div
-              class="locale"
+              class="PartnerSites__locale"
             >
               <nav
                 aria-labelledby="Locales"
                 role="navigation"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   <h1
                     id="Locales"
@@ -1748,18 +1748,18 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                   </h1>
                 </span>
                 <ul
-                  class="list"
+                  class="Locales__list"
                 >
                   <li>
                     <span
-                      class="locale_isActive"
+                      class="Locales__locale_isActive"
                     >
                       AU
                     </span>
                   </li>
                   <li>
                     <a
-                      class="localeLink"
+                      class="Locales__localeLink"
                       data-analytics="header:nz+homepage"
                       href="https://www.seek.co.nz"
                       title="SEEK New Zealand"
@@ -1781,24 +1781,24 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
 exports[`Header: should render when authenticated 1`] = `
 <header
   aria-label="Primary navigation"
-  class="root"
+  class="Header__root"
   role="banner"
 >
   <section
-    class="content"
+    class="Header__content"
   >
     <div
-      class="banner"
+      class="Header__banner"
     >
       <h1
-        class="logo"
+        class="Header__logo"
         data-automation="logo"
       >
         <div
           class=""
         >
           <svg
-            class="logoSvg root"
+            class="Header__logoSvg Logo__root"
             height="68.031"
             id="sk-logo-pos"
             viewBox="0 0 170.079 68.031"
@@ -1808,7 +1808,7 @@ exports[`Header: should render when authenticated 1`] = `
             y="0px"
           >
             <g
-              class="logoText"
+              class="Logo__logoText"
             >
               <path
                 d="M86.641,45.601c-3.697,0-7.037-0.408-10.012-3.385l3.834-3.833c1.942,1.938,4.467,2.208,6.269,2.208 c2.031,0,4.148-0.675,4.148-2.434c0-1.174-0.629-1.985-2.479-2.167l-3.699-0.36c-4.24-0.404-6.854-2.253-6.854-6.586 c0-4.869,4.282-7.485,9.064-7.485c3.653,0,6.72,0.632,8.976,2.75l-3.607,3.653c-1.354-1.217-3.43-1.576-5.459-1.576 c-2.344,0-3.336,1.082-3.336,2.254c0,0.857,0.361,1.85,2.436,2.03l3.7,0.361c4.643,0.45,6.992,2.932,6.992,6.9 C96.612,43.118,92.19,45.601,86.641,45.601z"
@@ -1824,45 +1824,45 @@ exports[`Header: should render when authenticated 1`] = `
               />
             </g>
             <path
-              class="logoIcon"
+              class="Logo__logoIcon"
               d="M34.015,1.51c-17.952,0-32.506,14.552-32.506,32.507c0,17.952,14.554,32.505,32.506,32.505 c17.958,0,32.508-14.553,32.508-32.505C66.523,16.062,51.972,1.51,34.015,1.51z M8.262,41.733c-0.281,0-0.511-0.226-0.511-0.504 c0-0.281,0.229-0.511,0.511-0.511c0.278,0,0.504,0.229,0.504,0.511C8.766,41.508,8.541,41.733,8.262,41.733z M8.262,34.907 c-0.281,0-0.511-0.229-0.511-0.51s0.229-0.509,0.511-0.509c0.278,0,0.504,0.228,0.504,0.509S8.541,34.907,8.262,34.907z M8.262,28.077c-0.281,0-0.511-0.229-0.511-0.509c0-0.281,0.229-0.507,0.511-0.507c0.278,0,0.504,0.226,0.504,0.507 C8.766,27.849,8.541,28.077,8.262,28.077z M11.764,41.991c-0.422,0-0.762-0.342-0.762-0.762c0-0.422,0.34-0.765,0.762-0.765 c0.421,0,0.762,0.343,0.762,0.765C12.526,41.649,12.186,41.991,11.764,41.991z M11.764,35.158c-0.422,0-0.762-0.339-0.762-0.761 c0-0.42,0.34-0.761,0.762-0.761c0.421,0,0.762,0.341,0.762,0.761C12.526,34.819,12.186,35.158,11.764,35.158z M11.764,28.33 c-0.422,0-0.762-0.341-0.762-0.762c0-0.422,0.34-0.763,0.762-0.763c0.421,0,0.762,0.341,0.762,0.763 C12.526,27.989,12.186,28.33,11.764,28.33z M15.867,42.246c-0.562,0-1.019-0.455-1.019-1.017c0-0.561,0.457-1.018,1.019-1.018 c0.558,0,1.016,0.457,1.016,1.018C16.882,41.791,16.424,42.246,15.867,42.246z M15.867,35.412c-0.562,0-1.019-0.453-1.019-1.015 c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016C16.882,34.959,16.424,35.412,15.867,35.412z M15.867,28.583 c-0.562,0-1.019-0.451-1.019-1.015c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016 C16.882,28.132,16.424,28.583,15.867,28.583z M20.18,42.497c-0.702,0-1.27-0.567-1.27-1.268c0-0.705,0.568-1.27,1.27-1.27 c0.704,0,1.27,0.564,1.27,1.27C21.45,41.93,20.884,42.497,20.18,42.497z M20.18,35.669c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.269,1.27-1.269c0.704,0,1.27,0.565,1.27,1.269S20.884,35.669,20.18,35.669z M20.18,28.84c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.271,1.27-1.271c0.704,0,1.27,0.567,1.27,1.271S20.884,28.84,20.18,28.84z M25.234,42.752c-0.842,0-1.523-0.681-1.523-1.522 c0-0.845,0.682-1.523,1.523-1.523c0.84,0,1.522,0.679,1.522,1.523C26.756,42.071,26.074,42.752,25.234,42.752z M25.234,35.922 c-0.842,0-1.523-0.684-1.523-1.524c0-0.842,0.682-1.523,1.523-1.523c0.84,0,1.522,0.682,1.522,1.523 C26.756,35.238,26.074,35.922,25.234,35.922z M25.234,29.093c-0.842,0-1.523-0.683-1.523-1.524s0.682-1.525,1.523-1.525 c0.84,0,1.522,0.684,1.522,1.525S26.074,29.093,25.234,29.093z M30.523,43.005c-0.983,0-1.778-0.792-1.778-1.775 c0-0.982,0.795-1.78,1.778-1.78c0.985,0,1.779,0.798,1.779,1.78C32.302,42.213,31.508,43.005,30.523,43.005z M30.523,36.176 c-0.983,0-1.778-0.796-1.778-1.778s0.795-1.776,1.778-1.776c0.985,0,1.779,0.794,1.779,1.776S31.508,36.176,30.523,36.176z M30.523,29.346c-0.983,0-1.778-0.796-1.778-1.777s0.795-1.776,1.778-1.776c0.985,0,1.779,0.795,1.779,1.776 S31.508,29.346,30.523,29.346z M36.812,56.922c-1.121,0-2.027-0.911-2.027-2.034c0-1.119,0.906-2.027,2.027-2.027 c1.125,0,2.035,0.908,2.035,2.027C38.847,56.011,37.938,56.922,36.812,56.922z M36.812,50.091c-1.121,0-2.027-0.91-2.027-2.03 c0-1.122,0.906-2.036,2.027-2.036c1.125,0,2.035,0.914,2.035,2.036C38.847,49.181,37.938,50.091,36.812,50.091z M36.812,43.26 c-1.121,0-2.027-0.909-2.027-2.03c0-1.123,0.906-2.033,2.027-2.033c1.125,0,2.035,0.91,2.035,2.033 C38.847,42.351,37.938,43.26,36.812,43.26z M36.812,36.43c-1.121,0-2.027-0.91-2.027-2.032c0-1.124,0.906-2.03,2.027-2.03 c1.125,0,2.035,0.906,2.035,2.03C38.847,35.52,37.938,36.43,36.812,36.43z M36.812,29.6c-1.121,0-2.027-0.908-2.027-2.031 c0-1.122,0.906-2.031,2.027-2.031c1.125,0,2.035,0.909,2.035,2.031C38.847,28.691,37.938,29.6,36.812,29.6z M36.812,22.77 c-1.121,0-2.027-0.912-2.027-2.032c0-1.123,0.906-2.03,2.027-2.03c1.125,0,2.035,0.907,2.035,2.03 C38.847,21.857,37.938,22.77,36.812,22.77z M36.812,15.938c-1.121,0-2.027-0.91-2.027-2.029c0-1.123,0.906-2.033,2.027-2.033 c1.125,0,2.035,0.91,2.035,2.033C38.847,15.027,37.938,15.938,36.812,15.938z M43.342,50.3c-1.233,0-2.238-1.002-2.238-2.239 c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242C45.585,49.298,44.582,50.3,43.342,50.3z M43.342,43.469 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,42.466,44.582,43.469,43.342,43.469z M43.342,36.64c-1.233,0-2.238-1.004-2.238-2.242c0-1.237,1.004-2.238,2.238-2.238 c1.24,0,2.243,1.001,2.243,2.238C45.585,35.636,44.582,36.64,43.342,36.64z M43.342,29.807c-1.233,0-2.238-1.002-2.238-2.238 c0-1.238,1.004-2.24,2.238-2.24c1.24,0,2.243,1.002,2.243,2.24C45.585,28.805,44.582,29.807,43.342,29.807z M43.342,22.977 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,21.974,44.582,22.977,43.342,22.977z M50.351,43.765c-1.393,0-2.517-1.126-2.517-2.517c0-1.389,1.124-2.516,2.517-2.516 c1.391,0,2.513,1.127,2.513,2.516C52.863,42.639,51.742,43.765,50.351,43.765z M50.351,36.933c-1.393,0-2.517-1.123-2.517-2.515 c0-1.386,1.124-2.517,2.517-2.517c1.391,0,2.513,1.131,2.513,2.517C52.863,35.81,51.742,36.933,50.351,36.933z M50.351,30.104 c-1.393,0-2.517-1.125-2.517-2.515c0-1.393,1.124-2.517,2.517-2.517c1.391,0,2.513,1.124,2.513,2.517 C52.863,28.979,51.742,30.104,50.351,30.104z M57.49,37.219c-1.519,0-2.756-1.234-2.756-2.754c0-1.523,1.238-2.757,2.756-2.757 c1.521,0,2.754,1.233,2.754,2.757C60.244,35.984,59.012,37.219,57.49,37.219z"
             />
           </svg>
         </div>
         <a
-          class="logoLink"
+          class="Header__logoLink"
           data-analytics="header:jobs"
           href="/"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             SEEK
           </span>
         </a>
       </h1>
       <span
-        class="logoNote screen"
+        class="Header__logoNote Hidden__screen"
       >
         Australia’s #1 job site
       </span>
       <span
-        class="userWrapper print"
+        class="Header__userWrapper Hidden__print"
       >
         <div
-          class="user user_isAuthenticated user_isReady"
+          class="Header__user Header__user_isAuthenticated Header__user_isReady"
         >
           <div
-            class="userAccountWrapper"
+            class="Header__userAccountWrapper"
           >
             <nav
               aria-labelledby="UserMenu"
-              class="root"
+              class="UserAccount__root"
               data-automation="user-account"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="UserMenu"
@@ -1872,32 +1872,32 @@ exports[`Header: should render when authenticated 1`] = `
               </span>
               <input
                 autocomplete="off"
-                class="toggle"
+                class="UserAccount__toggle"
                 id="user-account-menu-toggle"
                 type="checkbox"
               />
               <div
-                class="menuBackdrop"
+                class="UserAccount__menuBackdrop"
               >
                 <label
-                  class="menuBackdropLabel"
+                  class="UserAccount__menuBackdropLabel"
                   data-automation="user-account-menu-backdrop"
                   for="user-account-menu-toggle"
                 >
                   <span
-                    class="root"
+                    class="ScreenReaderOnly__root"
                   >
                     Show user menu
                   </span>
                 </label>
               </div>
               <label
-                class="toggleLabel"
+                class="UserAccount__toggleLabel"
                 data-automation="user-account-menu-toggle"
                 for="user-account-menu-toggle"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   Show user menu
                 </span>
@@ -1905,34 +1905,34 @@ exports[`Header: should render when authenticated 1`] = `
                   data-hj-masked="true"
                 >
                   <span
-                    class="mobileMenuLabel"
+                    class="UserAccount__mobileMenuLabel"
                   >
                     Leeroy
                   </span>
                   <span
-                    class="desktopMenuLabel"
+                    class="UserAccount__desktopMenuLabel"
                     data-automation="user-account-name"
                   >
                     Leeroy
                   </span>
                 </span>
                 <span
-                  class="root root chevron"
+                  class="Icon__root ChevronIcon__root UserAccount__chevron"
                 >
                   mock svg
                 </span>
               </label>
               <div
-                class="toggleContainer"
+                class="UserAccount__toggleContainer"
               >
                 <ul
-                  class="root"
+                  class="UserAccountMenu__root"
                 >
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:jobs"
                       href="/"
                     >
@@ -1940,7 +1940,7 @@ exports[`Header: should render when authenticated 1`] = `
                         Job Search
                       </span>
                       <span
-                        class="root icon jobSearch"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__jobSearch"
                       >
                         mock svg
                       </span>
@@ -1950,7 +1950,7 @@ exports[`Header: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:profile"
                       href="/profile/"
                     >
@@ -1958,17 +1958,17 @@ exports[`Header: should render when authenticated 1`] = `
                         Profile
                       </span>
                       <span
-                        class="root icon profile"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__profile"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+searches"
                       href="/myactivity"
                     >
@@ -1976,7 +1976,7 @@ exports[`Header: should render when authenticated 1`] = `
                         Saved Searches
                       </span>
                       <span
-                        class="root icon saveSearches"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveSearches"
                       >
                         mock svg
                       </span>
@@ -1986,45 +1986,45 @@ exports[`Header: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+jobs"
                       href="/my-activity/saved-jobs"
                     >
                       <span>
                         Saved 
                         <span
-                          class="desktop"
+                          class="Hidden__desktop"
                         >
                           & Applied 
                         </span>
                         Jobs
                       </span>
                       <span
-                        class="root icon saveJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:applied+jobs"
                       href="/my-activity/applied-jobs"
                     >
                       Applied Jobs
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:recommended+jobs"
                       href="/recommended"
                     >
@@ -2032,93 +2032,93 @@ exports[`Header: should render when authenticated 1`] = `
                         Recommended Jobs
                       </span>
                       <span
-                        class="root icon recommendedJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__recommendedJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
                       Company Reviews
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:settings"
                       href="/settings/"
                     >
                       Settings
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:sign-out"
                       href="/login/LogoutWithReturnUrl?returnUrl=%2Fjobs"
                     >
                       Sign Out
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:advice"
                       href="/career-advice/"
                     >
                       Career Advice
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:sign-out"
                       href="/login/LogoutWithReturnUrl?returnUrl=%2Fjobs"
                     >
                       Sign Out
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
@@ -2127,15 +2127,15 @@ exports[`Header: should render when authenticated 1`] = `
             </nav>
           </div>
           <div
-            class="signInRegisterWrapper"
+            class="Header__signInRegisterWrapper"
           >
             <nav
               aria-labelledby="SignInOrRegister"
-              class="root"
+              class="SignInRegister__root"
               data-automation="sign-in-register"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="SignInOrRegister"
@@ -2144,7 +2144,7 @@ exports[`Header: should render when authenticated 1`] = `
                 </h1>
               </span>
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:sign-in"
                 href="/sign-in?returnUrl=%2Fjobs"
                 rel="nofollow"
@@ -2154,7 +2154,7 @@ exports[`Header: should render when authenticated 1`] = `
               </a>
                or 
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:register"
                 href="/sign-up?returnUrl=%2Fjobs"
                 rel="nofollow"
@@ -2165,14 +2165,14 @@ exports[`Header: should render when authenticated 1`] = `
             </nav>
           </div>
           <span
-            class="divider"
+            class="Header__divider"
           />
         </div>
         <div
-          class="employerSite"
+          class="Header__employerSite"
         >
           <a
-            class="employerLink"
+            class="Header__employerLink"
             data-analytics="header:employer+site"
             href="https://talent.seek.com.au/"
           >
@@ -2182,15 +2182,15 @@ exports[`Header: should render when authenticated 1`] = `
       </span>
     </div>
     <span
-      class="navigation print"
+      class="Header__navigation Hidden__print"
     >
       <nav
         aria-labelledby="MainNavigation"
-        class="root divider"
+        class="Navigation__root Navigation__divider"
         role="navigation"
       >
         <span
-          class="root"
+          class="ScreenReaderOnly__root"
         >
           <h1
             id="MainNavigation"
@@ -2199,14 +2199,14 @@ exports[`Header: should render when authenticated 1`] = `
           </h1>
         </span>
         <ul
-          class="list"
+          class="Navigation__list"
           data-automation="nav-tabs"
         >
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:jobs"
               href="/"
             >
@@ -2214,11 +2214,11 @@ exports[`Header: should render when authenticated 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
               aria-label="One fifty K jobs"
-              class="link"
+              class="Navigation__link"
               data-analytics="header:high+salary"
               href="/150kjobs"
             >
@@ -2226,10 +2226,10 @@ exports[`Header: should render when authenticated 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:profile"
               href="/profile/"
             >
@@ -2237,10 +2237,10 @@ exports[`Header: should render when authenticated 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:companies"
               href="/companies/"
             >
@@ -2248,10 +2248,10 @@ exports[`Header: should render when authenticated 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:advice"
               href="/career-advice/"
             >
@@ -2262,23 +2262,23 @@ exports[`Header: should render when authenticated 1`] = `
       </nav>
     </span>
     <div
-      class="topBanner"
+      class="Header__topBanner"
     >
       <div
-        class="root mobile print"
+        class="PartnerSites__root Hidden__mobile Hidden__print"
       >
         <div
-          class="content"
+          class="PageBlock__content"
         >
           <div
-            class="content"
+            class="PartnerSites__content"
           >
             <nav
               aria-labelledby="Sites"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="Sites"
@@ -2287,11 +2287,11 @@ exports[`Header: should render when authenticated 1`] = `
                 </h1>
               </span>
               <ul
-                class="list"
+                class="Sites__list"
               >
                 <li>
                   <span
-                    class="link link_isActive"
+                    class="Sites__link Sites__link_isActive"
                     title="SEEK Jobs"
                   >
                     Jobs
@@ -2299,7 +2299,7 @@ exports[`Header: should render when authenticated 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isLearning"
+                    class="Sites__link Sites__link_isLearning"
                     data-analytics="header:courses"
                     href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     title="SEEK Learning"
@@ -2309,7 +2309,7 @@ exports[`Header: should render when authenticated 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isBusiness"
+                    class="Sites__link Sites__link_isBusiness"
                     data-analytics="header:business+for+sale"
                     href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     title="SEEK Business"
@@ -2319,7 +2319,7 @@ exports[`Header: should render when authenticated 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isVolunteering"
+                    class="Sites__link Sites__link_isVolunteering"
                     data-analytics="header:volunteering"
                     href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     title="SEEK Volunteer"
@@ -2330,14 +2330,14 @@ exports[`Header: should render when authenticated 1`] = `
               </ul>
             </nav>
             <div
-              class="locale"
+              class="PartnerSites__locale"
             >
               <nav
                 aria-labelledby="Locales"
                 role="navigation"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   <h1
                     id="Locales"
@@ -2346,18 +2346,18 @@ exports[`Header: should render when authenticated 1`] = `
                   </h1>
                 </span>
                 <ul
-                  class="list"
+                  class="Locales__list"
                 >
                   <li>
                     <span
-                      class="locale_isActive"
+                      class="Locales__locale_isActive"
                     >
                       AU
                     </span>
                   </li>
                   <li>
                     <a
-                      class="localeLink"
+                      class="Locales__localeLink"
                       data-analytics="header:nz+homepage"
                       href="https://www.seek.co.nz"
                       title="SEEK New Zealand"
@@ -2379,24 +2379,24 @@ exports[`Header: should render when authenticated 1`] = `
 exports[`Header: should render when authenticated but username and email is not yet provided 1`] = `
 <header
   aria-label="Primary navigation"
-  class="root"
+  class="Header__root"
   role="banner"
 >
   <section
-    class="content"
+    class="Header__content"
   >
     <div
-      class="banner"
+      class="Header__banner"
     >
       <h1
-        class="logo"
+        class="Header__logo"
         data-automation="logo"
       >
         <div
           class=""
         >
           <svg
-            class="logoSvg root"
+            class="Header__logoSvg Logo__root"
             height="68.031"
             id="sk-logo-pos"
             viewBox="0 0 170.079 68.031"
@@ -2406,7 +2406,7 @@ exports[`Header: should render when authenticated but username and email is not 
             y="0px"
           >
             <g
-              class="logoText"
+              class="Logo__logoText"
             >
               <path
                 d="M86.641,45.601c-3.697,0-7.037-0.408-10.012-3.385l3.834-3.833c1.942,1.938,4.467,2.208,6.269,2.208 c2.031,0,4.148-0.675,4.148-2.434c0-1.174-0.629-1.985-2.479-2.167l-3.699-0.36c-4.24-0.404-6.854-2.253-6.854-6.586 c0-4.869,4.282-7.485,9.064-7.485c3.653,0,6.72,0.632,8.976,2.75l-3.607,3.653c-1.354-1.217-3.43-1.576-5.459-1.576 c-2.344,0-3.336,1.082-3.336,2.254c0,0.857,0.361,1.85,2.436,2.03l3.7,0.361c4.643,0.45,6.992,2.932,6.992,6.9 C96.612,43.118,92.19,45.601,86.641,45.601z"
@@ -2422,45 +2422,45 @@ exports[`Header: should render when authenticated but username and email is not 
               />
             </g>
             <path
-              class="logoIcon"
+              class="Logo__logoIcon"
               d="M34.015,1.51c-17.952,0-32.506,14.552-32.506,32.507c0,17.952,14.554,32.505,32.506,32.505 c17.958,0,32.508-14.553,32.508-32.505C66.523,16.062,51.972,1.51,34.015,1.51z M8.262,41.733c-0.281,0-0.511-0.226-0.511-0.504 c0-0.281,0.229-0.511,0.511-0.511c0.278,0,0.504,0.229,0.504,0.511C8.766,41.508,8.541,41.733,8.262,41.733z M8.262,34.907 c-0.281,0-0.511-0.229-0.511-0.51s0.229-0.509,0.511-0.509c0.278,0,0.504,0.228,0.504,0.509S8.541,34.907,8.262,34.907z M8.262,28.077c-0.281,0-0.511-0.229-0.511-0.509c0-0.281,0.229-0.507,0.511-0.507c0.278,0,0.504,0.226,0.504,0.507 C8.766,27.849,8.541,28.077,8.262,28.077z M11.764,41.991c-0.422,0-0.762-0.342-0.762-0.762c0-0.422,0.34-0.765,0.762-0.765 c0.421,0,0.762,0.343,0.762,0.765C12.526,41.649,12.186,41.991,11.764,41.991z M11.764,35.158c-0.422,0-0.762-0.339-0.762-0.761 c0-0.42,0.34-0.761,0.762-0.761c0.421,0,0.762,0.341,0.762,0.761C12.526,34.819,12.186,35.158,11.764,35.158z M11.764,28.33 c-0.422,0-0.762-0.341-0.762-0.762c0-0.422,0.34-0.763,0.762-0.763c0.421,0,0.762,0.341,0.762,0.763 C12.526,27.989,12.186,28.33,11.764,28.33z M15.867,42.246c-0.562,0-1.019-0.455-1.019-1.017c0-0.561,0.457-1.018,1.019-1.018 c0.558,0,1.016,0.457,1.016,1.018C16.882,41.791,16.424,42.246,15.867,42.246z M15.867,35.412c-0.562,0-1.019-0.453-1.019-1.015 c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016C16.882,34.959,16.424,35.412,15.867,35.412z M15.867,28.583 c-0.562,0-1.019-0.451-1.019-1.015c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016 C16.882,28.132,16.424,28.583,15.867,28.583z M20.18,42.497c-0.702,0-1.27-0.567-1.27-1.268c0-0.705,0.568-1.27,1.27-1.27 c0.704,0,1.27,0.564,1.27,1.27C21.45,41.93,20.884,42.497,20.18,42.497z M20.18,35.669c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.269,1.27-1.269c0.704,0,1.27,0.565,1.27,1.269S20.884,35.669,20.18,35.669z M20.18,28.84c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.271,1.27-1.271c0.704,0,1.27,0.567,1.27,1.271S20.884,28.84,20.18,28.84z M25.234,42.752c-0.842,0-1.523-0.681-1.523-1.522 c0-0.845,0.682-1.523,1.523-1.523c0.84,0,1.522,0.679,1.522,1.523C26.756,42.071,26.074,42.752,25.234,42.752z M25.234,35.922 c-0.842,0-1.523-0.684-1.523-1.524c0-0.842,0.682-1.523,1.523-1.523c0.84,0,1.522,0.682,1.522,1.523 C26.756,35.238,26.074,35.922,25.234,35.922z M25.234,29.093c-0.842,0-1.523-0.683-1.523-1.524s0.682-1.525,1.523-1.525 c0.84,0,1.522,0.684,1.522,1.525S26.074,29.093,25.234,29.093z M30.523,43.005c-0.983,0-1.778-0.792-1.778-1.775 c0-0.982,0.795-1.78,1.778-1.78c0.985,0,1.779,0.798,1.779,1.78C32.302,42.213,31.508,43.005,30.523,43.005z M30.523,36.176 c-0.983,0-1.778-0.796-1.778-1.778s0.795-1.776,1.778-1.776c0.985,0,1.779,0.794,1.779,1.776S31.508,36.176,30.523,36.176z M30.523,29.346c-0.983,0-1.778-0.796-1.778-1.777s0.795-1.776,1.778-1.776c0.985,0,1.779,0.795,1.779,1.776 S31.508,29.346,30.523,29.346z M36.812,56.922c-1.121,0-2.027-0.911-2.027-2.034c0-1.119,0.906-2.027,2.027-2.027 c1.125,0,2.035,0.908,2.035,2.027C38.847,56.011,37.938,56.922,36.812,56.922z M36.812,50.091c-1.121,0-2.027-0.91-2.027-2.03 c0-1.122,0.906-2.036,2.027-2.036c1.125,0,2.035,0.914,2.035,2.036C38.847,49.181,37.938,50.091,36.812,50.091z M36.812,43.26 c-1.121,0-2.027-0.909-2.027-2.03c0-1.123,0.906-2.033,2.027-2.033c1.125,0,2.035,0.91,2.035,2.033 C38.847,42.351,37.938,43.26,36.812,43.26z M36.812,36.43c-1.121,0-2.027-0.91-2.027-2.032c0-1.124,0.906-2.03,2.027-2.03 c1.125,0,2.035,0.906,2.035,2.03C38.847,35.52,37.938,36.43,36.812,36.43z M36.812,29.6c-1.121,0-2.027-0.908-2.027-2.031 c0-1.122,0.906-2.031,2.027-2.031c1.125,0,2.035,0.909,2.035,2.031C38.847,28.691,37.938,29.6,36.812,29.6z M36.812,22.77 c-1.121,0-2.027-0.912-2.027-2.032c0-1.123,0.906-2.03,2.027-2.03c1.125,0,2.035,0.907,2.035,2.03 C38.847,21.857,37.938,22.77,36.812,22.77z M36.812,15.938c-1.121,0-2.027-0.91-2.027-2.029c0-1.123,0.906-2.033,2.027-2.033 c1.125,0,2.035,0.91,2.035,2.033C38.847,15.027,37.938,15.938,36.812,15.938z M43.342,50.3c-1.233,0-2.238-1.002-2.238-2.239 c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242C45.585,49.298,44.582,50.3,43.342,50.3z M43.342,43.469 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,42.466,44.582,43.469,43.342,43.469z M43.342,36.64c-1.233,0-2.238-1.004-2.238-2.242c0-1.237,1.004-2.238,2.238-2.238 c1.24,0,2.243,1.001,2.243,2.238C45.585,35.636,44.582,36.64,43.342,36.64z M43.342,29.807c-1.233,0-2.238-1.002-2.238-2.238 c0-1.238,1.004-2.24,2.238-2.24c1.24,0,2.243,1.002,2.243,2.24C45.585,28.805,44.582,29.807,43.342,29.807z M43.342,22.977 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,21.974,44.582,22.977,43.342,22.977z M50.351,43.765c-1.393,0-2.517-1.126-2.517-2.517c0-1.389,1.124-2.516,2.517-2.516 c1.391,0,2.513,1.127,2.513,2.516C52.863,42.639,51.742,43.765,50.351,43.765z M50.351,36.933c-1.393,0-2.517-1.123-2.517-2.515 c0-1.386,1.124-2.517,2.517-2.517c1.391,0,2.513,1.131,2.513,2.517C52.863,35.81,51.742,36.933,50.351,36.933z M50.351,30.104 c-1.393,0-2.517-1.125-2.517-2.515c0-1.393,1.124-2.517,2.517-2.517c1.391,0,2.513,1.124,2.513,2.517 C52.863,28.979,51.742,30.104,50.351,30.104z M57.49,37.219c-1.519,0-2.756-1.234-2.756-2.754c0-1.523,1.238-2.757,2.756-2.757 c1.521,0,2.754,1.233,2.754,2.757C60.244,35.984,59.012,37.219,57.49,37.219z"
             />
           </svg>
         </div>
         <a
-          class="logoLink"
+          class="Header__logoLink"
           data-analytics="header:jobs"
           href="/"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             SEEK
           </span>
         </a>
       </h1>
       <span
-        class="logoNote screen"
+        class="Header__logoNote Hidden__screen"
       >
         Australia’s #1 job site
       </span>
       <span
-        class="userWrapper print"
+        class="Header__userWrapper Hidden__print"
       >
         <div
-          class="user"
+          class="Header__user"
         >
           <div
-            class="userAccountWrapper"
+            class="Header__userAccountWrapper"
           >
             <nav
               aria-labelledby="UserMenu"
-              class="root"
+              class="UserAccount__root"
               data-automation="user-account"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="UserMenu"
@@ -2470,32 +2470,32 @@ exports[`Header: should render when authenticated but username and email is not 
               </span>
               <input
                 autocomplete="off"
-                class="toggle"
+                class="UserAccount__toggle"
                 id="user-account-menu-toggle"
                 type="checkbox"
               />
               <div
-                class="menuBackdrop"
+                class="UserAccount__menuBackdrop"
               >
                 <label
-                  class="menuBackdropLabel"
+                  class="UserAccount__menuBackdropLabel"
                   data-automation="user-account-menu-backdrop"
                   for="user-account-menu-toggle"
                 >
                   <span
-                    class="root"
+                    class="ScreenReaderOnly__root"
                   >
                     Show user menu
                   </span>
                 </label>
               </div>
               <label
-                class="toggleLabel"
+                class="UserAccount__toggleLabel"
                 data-automation="user-account-menu-toggle"
                 for="user-account-menu-toggle"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   Show user menu
                 </span>
@@ -2503,30 +2503,30 @@ exports[`Header: should render when authenticated but username and email is not 
                   data-hj-masked="true"
                 >
                   <span
-                    class="mobileMenuLabel"
+                    class="UserAccount__mobileMenuLabel"
                   />
                   <span
-                    class="desktopMenuLabel"
+                    class="UserAccount__desktopMenuLabel"
                     data-automation="user-account-name"
                   />
                 </span>
                 <span
-                  class="root root chevron"
+                  class="Icon__root ChevronIcon__root UserAccount__chevron"
                 >
                   mock svg
                 </span>
               </label>
               <div
-                class="toggleContainer"
+                class="UserAccount__toggleContainer"
               >
                 <ul
-                  class="root"
+                  class="UserAccountMenu__root"
                 >
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:jobs"
                       href="/"
                     >
@@ -2534,7 +2534,7 @@ exports[`Header: should render when authenticated but username and email is not 
                         Job Search
                       </span>
                       <span
-                        class="root icon jobSearch"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__jobSearch"
                       >
                         mock svg
                       </span>
@@ -2544,7 +2544,7 @@ exports[`Header: should render when authenticated but username and email is not 
                     class=""
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:profile"
                       href="/profile/"
                     >
@@ -2552,17 +2552,17 @@ exports[`Header: should render when authenticated but username and email is not 
                         Profile
                       </span>
                       <span
-                        class="root icon profile"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__profile"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+searches"
                       href="/myactivity"
                     >
@@ -2570,7 +2570,7 @@ exports[`Header: should render when authenticated but username and email is not 
                         Saved Searches
                       </span>
                       <span
-                        class="root icon saveSearches"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveSearches"
                       >
                         mock svg
                       </span>
@@ -2580,45 +2580,45 @@ exports[`Header: should render when authenticated but username and email is not 
                     class=""
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+jobs"
                       href="/my-activity/saved-jobs"
                     >
                       <span>
                         Saved 
                         <span
-                          class="desktop"
+                          class="Hidden__desktop"
                         >
                           & Applied 
                         </span>
                         Jobs
                       </span>
                       <span
-                        class="root icon saveJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:applied+jobs"
                       href="/my-activity/applied-jobs"
                     >
                       Applied Jobs
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:recommended+jobs"
                       href="/recommended"
                     >
@@ -2626,93 +2626,93 @@ exports[`Header: should render when authenticated but username and email is not 
                         Recommended Jobs
                       </span>
                       <span
-                        class="root icon recommendedJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__recommendedJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
                       Company Reviews
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:settings"
                       href="/settings/"
                     >
                       Settings
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:sign-out"
                       href="/Login/Logout"
                     >
                       Sign Out
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:advice"
                       href="/career-advice/"
                     >
                       Career Advice
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:sign-out"
                       href="/Login/Logout"
                     >
                       Sign Out
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
@@ -2721,15 +2721,15 @@ exports[`Header: should render when authenticated but username and email is not 
             </nav>
           </div>
           <div
-            class="signInRegisterWrapper"
+            class="Header__signInRegisterWrapper"
           >
             <nav
               aria-labelledby="SignInOrRegister"
-              class="root"
+              class="SignInRegister__root"
               data-automation="sign-in-register"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="SignInOrRegister"
@@ -2738,7 +2738,7 @@ exports[`Header: should render when authenticated but username and email is not 
                 </h1>
               </span>
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:sign-in"
                 href="/sign-in"
                 rel="nofollow"
@@ -2748,7 +2748,7 @@ exports[`Header: should render when authenticated but username and email is not 
               </a>
                or 
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:register"
                 href="/sign-up"
                 rel="nofollow"
@@ -2759,14 +2759,14 @@ exports[`Header: should render when authenticated but username and email is not 
             </nav>
           </div>
           <span
-            class="divider"
+            class="Header__divider"
           />
         </div>
         <div
-          class="employerSite"
+          class="Header__employerSite"
         >
           <a
-            class="employerLink"
+            class="Header__employerLink"
             data-analytics="header:employer+site"
             href="https://talent.seek.com.au/"
           >
@@ -2776,15 +2776,15 @@ exports[`Header: should render when authenticated but username and email is not 
       </span>
     </div>
     <span
-      class="navigation print"
+      class="Header__navigation Hidden__print"
     >
       <nav
         aria-labelledby="MainNavigation"
-        class="root divider"
+        class="Navigation__root Navigation__divider"
         role="navigation"
       >
         <span
-          class="root"
+          class="ScreenReaderOnly__root"
         >
           <h1
             id="MainNavigation"
@@ -2793,14 +2793,14 @@ exports[`Header: should render when authenticated but username and email is not 
           </h1>
         </span>
         <ul
-          class="list"
+          class="Navigation__list"
           data-automation="nav-tabs"
         >
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:jobs"
               href="/"
             >
@@ -2808,11 +2808,11 @@ exports[`Header: should render when authenticated but username and email is not 
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
               aria-label="One fifty K jobs"
-              class="link"
+              class="Navigation__link"
               data-analytics="header:high+salary"
               href="/150kjobs"
             >
@@ -2820,10 +2820,10 @@ exports[`Header: should render when authenticated but username and email is not 
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:profile"
               href="/profile/"
             >
@@ -2831,10 +2831,10 @@ exports[`Header: should render when authenticated but username and email is not 
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:companies"
               href="/companies/"
             >
@@ -2842,10 +2842,10 @@ exports[`Header: should render when authenticated but username and email is not 
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:advice"
               href="/career-advice/"
             >
@@ -2856,23 +2856,23 @@ exports[`Header: should render when authenticated but username and email is not 
       </nav>
     </span>
     <div
-      class="topBanner"
+      class="Header__topBanner"
     >
       <div
-        class="root mobile print"
+        class="PartnerSites__root Hidden__mobile Hidden__print"
       >
         <div
-          class="content"
+          class="PageBlock__content"
         >
           <div
-            class="content"
+            class="PartnerSites__content"
           >
             <nav
               aria-labelledby="Sites"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="Sites"
@@ -2881,11 +2881,11 @@ exports[`Header: should render when authenticated but username and email is not 
                 </h1>
               </span>
               <ul
-                class="list"
+                class="Sites__list"
               >
                 <li>
                   <span
-                    class="link link_isActive"
+                    class="Sites__link Sites__link_isActive"
                     title="SEEK Jobs"
                   >
                     Jobs
@@ -2893,7 +2893,7 @@ exports[`Header: should render when authenticated but username and email is not 
                 </li>
                 <li>
                   <a
-                    class="link link_isLearning"
+                    class="Sites__link Sites__link_isLearning"
                     data-analytics="header:courses"
                     href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     title="SEEK Learning"
@@ -2903,7 +2903,7 @@ exports[`Header: should render when authenticated but username and email is not 
                 </li>
                 <li>
                   <a
-                    class="link link_isBusiness"
+                    class="Sites__link Sites__link_isBusiness"
                     data-analytics="header:business+for+sale"
                     href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     title="SEEK Business"
@@ -2913,7 +2913,7 @@ exports[`Header: should render when authenticated but username and email is not 
                 </li>
                 <li>
                   <a
-                    class="link link_isVolunteering"
+                    class="Sites__link Sites__link_isVolunteering"
                     data-analytics="header:volunteering"
                     href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     title="SEEK Volunteer"
@@ -2924,14 +2924,14 @@ exports[`Header: should render when authenticated but username and email is not 
               </ul>
             </nav>
             <div
-              class="locale"
+              class="PartnerSites__locale"
             >
               <nav
                 aria-labelledby="Locales"
                 role="navigation"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   <h1
                     id="Locales"
@@ -2940,18 +2940,18 @@ exports[`Header: should render when authenticated but username and email is not 
                   </h1>
                 </span>
                 <ul
-                  class="list"
+                  class="Locales__list"
                 >
                   <li>
                     <span
-                      class="locale_isActive"
+                      class="Locales__locale_isActive"
                     >
                       AU
                     </span>
                   </li>
                   <li>
                     <a
-                      class="localeLink"
+                      class="Locales__localeLink"
                       data-analytics="header:nz+homepage"
                       href="https://www.seek.co.nz"
                       title="SEEK New Zealand"
@@ -2973,24 +2973,24 @@ exports[`Header: should render when authenticated but username and email is not 
 exports[`Header: should render when authentication is pending 1`] = `
 <header
   aria-label="Primary navigation"
-  class="root"
+  class="Header__root"
   role="banner"
 >
   <section
-    class="content"
+    class="Header__content"
   >
     <div
-      class="banner"
+      class="Header__banner"
     >
       <h1
-        class="logo"
+        class="Header__logo"
         data-automation="logo"
       >
         <div
           class=""
         >
           <svg
-            class="logoSvg root"
+            class="Header__logoSvg Logo__root"
             height="68.031"
             id="sk-logo-pos"
             viewBox="0 0 170.079 68.031"
@@ -3000,7 +3000,7 @@ exports[`Header: should render when authentication is pending 1`] = `
             y="0px"
           >
             <g
-              class="logoText"
+              class="Logo__logoText"
             >
               <path
                 d="M86.641,45.601c-3.697,0-7.037-0.408-10.012-3.385l3.834-3.833c1.942,1.938,4.467,2.208,6.269,2.208 c2.031,0,4.148-0.675,4.148-2.434c0-1.174-0.629-1.985-2.479-2.167l-3.699-0.36c-4.24-0.404-6.854-2.253-6.854-6.586 c0-4.869,4.282-7.485,9.064-7.485c3.653,0,6.72,0.632,8.976,2.75l-3.607,3.653c-1.354-1.217-3.43-1.576-5.459-1.576 c-2.344,0-3.336,1.082-3.336,2.254c0,0.857,0.361,1.85,2.436,2.03l3.7,0.361c4.643,0.45,6.992,2.932,6.992,6.9 C96.612,43.118,92.19,45.601,86.641,45.601z"
@@ -3016,45 +3016,45 @@ exports[`Header: should render when authentication is pending 1`] = `
               />
             </g>
             <path
-              class="logoIcon"
+              class="Logo__logoIcon"
               d="M34.015,1.51c-17.952,0-32.506,14.552-32.506,32.507c0,17.952,14.554,32.505,32.506,32.505 c17.958,0,32.508-14.553,32.508-32.505C66.523,16.062,51.972,1.51,34.015,1.51z M8.262,41.733c-0.281,0-0.511-0.226-0.511-0.504 c0-0.281,0.229-0.511,0.511-0.511c0.278,0,0.504,0.229,0.504,0.511C8.766,41.508,8.541,41.733,8.262,41.733z M8.262,34.907 c-0.281,0-0.511-0.229-0.511-0.51s0.229-0.509,0.511-0.509c0.278,0,0.504,0.228,0.504,0.509S8.541,34.907,8.262,34.907z M8.262,28.077c-0.281,0-0.511-0.229-0.511-0.509c0-0.281,0.229-0.507,0.511-0.507c0.278,0,0.504,0.226,0.504,0.507 C8.766,27.849,8.541,28.077,8.262,28.077z M11.764,41.991c-0.422,0-0.762-0.342-0.762-0.762c0-0.422,0.34-0.765,0.762-0.765 c0.421,0,0.762,0.343,0.762,0.765C12.526,41.649,12.186,41.991,11.764,41.991z M11.764,35.158c-0.422,0-0.762-0.339-0.762-0.761 c0-0.42,0.34-0.761,0.762-0.761c0.421,0,0.762,0.341,0.762,0.761C12.526,34.819,12.186,35.158,11.764,35.158z M11.764,28.33 c-0.422,0-0.762-0.341-0.762-0.762c0-0.422,0.34-0.763,0.762-0.763c0.421,0,0.762,0.341,0.762,0.763 C12.526,27.989,12.186,28.33,11.764,28.33z M15.867,42.246c-0.562,0-1.019-0.455-1.019-1.017c0-0.561,0.457-1.018,1.019-1.018 c0.558,0,1.016,0.457,1.016,1.018C16.882,41.791,16.424,42.246,15.867,42.246z M15.867,35.412c-0.562,0-1.019-0.453-1.019-1.015 c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016C16.882,34.959,16.424,35.412,15.867,35.412z M15.867,28.583 c-0.562,0-1.019-0.451-1.019-1.015c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016 C16.882,28.132,16.424,28.583,15.867,28.583z M20.18,42.497c-0.702,0-1.27-0.567-1.27-1.268c0-0.705,0.568-1.27,1.27-1.27 c0.704,0,1.27,0.564,1.27,1.27C21.45,41.93,20.884,42.497,20.18,42.497z M20.18,35.669c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.269,1.27-1.269c0.704,0,1.27,0.565,1.27,1.269S20.884,35.669,20.18,35.669z M20.18,28.84c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.271,1.27-1.271c0.704,0,1.27,0.567,1.27,1.271S20.884,28.84,20.18,28.84z M25.234,42.752c-0.842,0-1.523-0.681-1.523-1.522 c0-0.845,0.682-1.523,1.523-1.523c0.84,0,1.522,0.679,1.522,1.523C26.756,42.071,26.074,42.752,25.234,42.752z M25.234,35.922 c-0.842,0-1.523-0.684-1.523-1.524c0-0.842,0.682-1.523,1.523-1.523c0.84,0,1.522,0.682,1.522,1.523 C26.756,35.238,26.074,35.922,25.234,35.922z M25.234,29.093c-0.842,0-1.523-0.683-1.523-1.524s0.682-1.525,1.523-1.525 c0.84,0,1.522,0.684,1.522,1.525S26.074,29.093,25.234,29.093z M30.523,43.005c-0.983,0-1.778-0.792-1.778-1.775 c0-0.982,0.795-1.78,1.778-1.78c0.985,0,1.779,0.798,1.779,1.78C32.302,42.213,31.508,43.005,30.523,43.005z M30.523,36.176 c-0.983,0-1.778-0.796-1.778-1.778s0.795-1.776,1.778-1.776c0.985,0,1.779,0.794,1.779,1.776S31.508,36.176,30.523,36.176z M30.523,29.346c-0.983,0-1.778-0.796-1.778-1.777s0.795-1.776,1.778-1.776c0.985,0,1.779,0.795,1.779,1.776 S31.508,29.346,30.523,29.346z M36.812,56.922c-1.121,0-2.027-0.911-2.027-2.034c0-1.119,0.906-2.027,2.027-2.027 c1.125,0,2.035,0.908,2.035,2.027C38.847,56.011,37.938,56.922,36.812,56.922z M36.812,50.091c-1.121,0-2.027-0.91-2.027-2.03 c0-1.122,0.906-2.036,2.027-2.036c1.125,0,2.035,0.914,2.035,2.036C38.847,49.181,37.938,50.091,36.812,50.091z M36.812,43.26 c-1.121,0-2.027-0.909-2.027-2.03c0-1.123,0.906-2.033,2.027-2.033c1.125,0,2.035,0.91,2.035,2.033 C38.847,42.351,37.938,43.26,36.812,43.26z M36.812,36.43c-1.121,0-2.027-0.91-2.027-2.032c0-1.124,0.906-2.03,2.027-2.03 c1.125,0,2.035,0.906,2.035,2.03C38.847,35.52,37.938,36.43,36.812,36.43z M36.812,29.6c-1.121,0-2.027-0.908-2.027-2.031 c0-1.122,0.906-2.031,2.027-2.031c1.125,0,2.035,0.909,2.035,2.031C38.847,28.691,37.938,29.6,36.812,29.6z M36.812,22.77 c-1.121,0-2.027-0.912-2.027-2.032c0-1.123,0.906-2.03,2.027-2.03c1.125,0,2.035,0.907,2.035,2.03 C38.847,21.857,37.938,22.77,36.812,22.77z M36.812,15.938c-1.121,0-2.027-0.91-2.027-2.029c0-1.123,0.906-2.033,2.027-2.033 c1.125,0,2.035,0.91,2.035,2.033C38.847,15.027,37.938,15.938,36.812,15.938z M43.342,50.3c-1.233,0-2.238-1.002-2.238-2.239 c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242C45.585,49.298,44.582,50.3,43.342,50.3z M43.342,43.469 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,42.466,44.582,43.469,43.342,43.469z M43.342,36.64c-1.233,0-2.238-1.004-2.238-2.242c0-1.237,1.004-2.238,2.238-2.238 c1.24,0,2.243,1.001,2.243,2.238C45.585,35.636,44.582,36.64,43.342,36.64z M43.342,29.807c-1.233,0-2.238-1.002-2.238-2.238 c0-1.238,1.004-2.24,2.238-2.24c1.24,0,2.243,1.002,2.243,2.24C45.585,28.805,44.582,29.807,43.342,29.807z M43.342,22.977 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,21.974,44.582,22.977,43.342,22.977z M50.351,43.765c-1.393,0-2.517-1.126-2.517-2.517c0-1.389,1.124-2.516,2.517-2.516 c1.391,0,2.513,1.127,2.513,2.516C52.863,42.639,51.742,43.765,50.351,43.765z M50.351,36.933c-1.393,0-2.517-1.123-2.517-2.515 c0-1.386,1.124-2.517,2.517-2.517c1.391,0,2.513,1.131,2.513,2.517C52.863,35.81,51.742,36.933,50.351,36.933z M50.351,30.104 c-1.393,0-2.517-1.125-2.517-2.515c0-1.393,1.124-2.517,2.517-2.517c1.391,0,2.513,1.124,2.513,2.517 C52.863,28.979,51.742,30.104,50.351,30.104z M57.49,37.219c-1.519,0-2.756-1.234-2.756-2.754c0-1.523,1.238-2.757,2.756-2.757 c1.521,0,2.754,1.233,2.754,2.757C60.244,35.984,59.012,37.219,57.49,37.219z"
             />
           </svg>
         </div>
         <a
-          class="logoLink"
+          class="Header__logoLink"
           data-analytics="header:jobs"
           href="/"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             SEEK
           </span>
         </a>
       </h1>
       <span
-        class="logoNote screen"
+        class="Header__logoNote Hidden__screen"
       >
         Australia’s #1 job site
       </span>
       <span
-        class="userWrapper print"
+        class="Header__userWrapper Hidden__print"
       >
         <div
-          class="user"
+          class="Header__user"
         >
           <div
-            class="userAccountWrapper"
+            class="Header__userAccountWrapper"
           >
             <nav
               aria-labelledby="UserMenu"
-              class="root"
+              class="UserAccount__root"
               data-automation="user-account"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="UserMenu"
@@ -3064,32 +3064,32 @@ exports[`Header: should render when authentication is pending 1`] = `
               </span>
               <input
                 autocomplete="off"
-                class="toggle"
+                class="UserAccount__toggle"
                 id="user-account-menu-toggle"
                 type="checkbox"
               />
               <div
-                class="menuBackdrop"
+                class="UserAccount__menuBackdrop"
               >
                 <label
-                  class="menuBackdropLabel"
+                  class="UserAccount__menuBackdropLabel"
                   data-automation="user-account-menu-backdrop"
                   for="user-account-menu-toggle"
                 >
                   <span
-                    class="root"
+                    class="ScreenReaderOnly__root"
                   >
                     Show user menu
                   </span>
                 </label>
               </div>
               <label
-                class="toggleLabel"
+                class="UserAccount__toggleLabel"
                 data-automation="user-account-menu-toggle"
                 for="user-account-menu-toggle"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   Show user menu
                 </span>
@@ -3097,30 +3097,30 @@ exports[`Header: should render when authentication is pending 1`] = `
                   data-hj-masked="true"
                 >
                   <span
-                    class="mobileMenuLabel"
+                    class="UserAccount__mobileMenuLabel"
                   />
                   <span
-                    class="desktopMenuLabel"
+                    class="UserAccount__desktopMenuLabel"
                     data-automation="user-account-name"
                   />
                 </span>
                 <span
-                  class="root root chevron"
+                  class="Icon__root ChevronIcon__root UserAccount__chevron"
                 >
                   mock svg
                 </span>
               </label>
               <div
-                class="toggleContainer"
+                class="UserAccount__toggleContainer"
               >
                 <ul
-                  class="root"
+                  class="UserAccountMenu__root"
                 >
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:jobs"
                       href="/"
                     >
@@ -3128,7 +3128,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                         Job Search
                       </span>
                       <span
-                        class="root icon jobSearch"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__jobSearch"
                       >
                         mock svg
                       </span>
@@ -3138,7 +3138,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:profile"
                       href="/profile/"
                     >
@@ -3146,17 +3146,17 @@ exports[`Header: should render when authentication is pending 1`] = `
                         Profile
                       </span>
                       <span
-                        class="root icon profile"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__profile"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+searches"
                       href="/myactivity"
                     >
@@ -3164,7 +3164,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                         Saved Searches
                       </span>
                       <span
-                        class="root icon saveSearches"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveSearches"
                       >
                         mock svg
                       </span>
@@ -3174,45 +3174,45 @@ exports[`Header: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
                         Saved 
                         <span
-                          class="desktop"
+                          class="Hidden__desktop"
                         >
                           & Applied 
                         </span>
                         Jobs
                       </span>
                       <span
-                        class="root icon saveJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
                       Applied Jobs
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -3220,89 +3220,89 @@ exports[`Header: should render when authentication is pending 1`] = `
                         Recommended Jobs
                       </span>
                       <span
-                        class="root icon recommendedJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__recommendedJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
                       Company Reviews
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:settings"
                       href="/settings/"
                     >
                       Settings
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <span
-                      class="item pendingAuth"
+                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="root _small"
+                        class="Loader__root Loader___small"
                       >
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                       </div>
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </span>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:advice"
                       href="/career-advice/"
                     >
                       Career Advice
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
@@ -3311,15 +3311,15 @@ exports[`Header: should render when authentication is pending 1`] = `
             </nav>
           </div>
           <div
-            class="signInRegisterWrapper"
+            class="Header__signInRegisterWrapper"
           >
             <nav
               aria-labelledby="SignInOrRegister"
-              class="root"
+              class="SignInRegister__root"
               data-automation="sign-in-register"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="SignInOrRegister"
@@ -3328,7 +3328,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                 </h1>
               </span>
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:sign-in"
                 href="/sign-in"
                 rel="nofollow"
@@ -3338,7 +3338,7 @@ exports[`Header: should render when authentication is pending 1`] = `
               </a>
                or 
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:register"
                 href="/sign-up"
                 rel="nofollow"
@@ -3349,14 +3349,14 @@ exports[`Header: should render when authentication is pending 1`] = `
             </nav>
           </div>
           <span
-            class="divider"
+            class="Header__divider"
           />
         </div>
         <div
-          class="employerSite"
+          class="Header__employerSite"
         >
           <a
-            class="employerLink"
+            class="Header__employerLink"
             data-analytics="header:employer+site"
             href="https://talent.seek.com.au/"
           >
@@ -3366,15 +3366,15 @@ exports[`Header: should render when authentication is pending 1`] = `
       </span>
     </div>
     <span
-      class="navigation print"
+      class="Header__navigation Hidden__print"
     >
       <nav
         aria-labelledby="MainNavigation"
-        class="root divider"
+        class="Navigation__root Navigation__divider"
         role="navigation"
       >
         <span
-          class="root"
+          class="ScreenReaderOnly__root"
         >
           <h1
             id="MainNavigation"
@@ -3383,14 +3383,14 @@ exports[`Header: should render when authentication is pending 1`] = `
           </h1>
         </span>
         <ul
-          class="list"
+          class="Navigation__list"
           data-automation="nav-tabs"
         >
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:jobs"
               href="/"
             >
@@ -3398,11 +3398,11 @@ exports[`Header: should render when authentication is pending 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
               aria-label="One fifty K jobs"
-              class="link"
+              class="Navigation__link"
               data-analytics="header:high+salary"
               href="/150kjobs"
             >
@@ -3410,10 +3410,10 @@ exports[`Header: should render when authentication is pending 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:profile"
               href="/profile/"
             >
@@ -3421,10 +3421,10 @@ exports[`Header: should render when authentication is pending 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:companies"
               href="/companies/"
             >
@@ -3432,10 +3432,10 @@ exports[`Header: should render when authentication is pending 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:advice"
               href="/career-advice/"
             >
@@ -3446,23 +3446,23 @@ exports[`Header: should render when authentication is pending 1`] = `
       </nav>
     </span>
     <div
-      class="topBanner"
+      class="Header__topBanner"
     >
       <div
-        class="root mobile print"
+        class="PartnerSites__root Hidden__mobile Hidden__print"
       >
         <div
-          class="content"
+          class="PageBlock__content"
         >
           <div
-            class="content"
+            class="PartnerSites__content"
           >
             <nav
               aria-labelledby="Sites"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="Sites"
@@ -3471,11 +3471,11 @@ exports[`Header: should render when authentication is pending 1`] = `
                 </h1>
               </span>
               <ul
-                class="list"
+                class="Sites__list"
               >
                 <li>
                   <span
-                    class="link link_isActive"
+                    class="Sites__link Sites__link_isActive"
                     title="SEEK Jobs"
                   >
                     Jobs
@@ -3483,7 +3483,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isLearning"
+                    class="Sites__link Sites__link_isLearning"
                     data-analytics="header:courses"
                     href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     title="SEEK Learning"
@@ -3493,7 +3493,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isBusiness"
+                    class="Sites__link Sites__link_isBusiness"
                     data-analytics="header:business+for+sale"
                     href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     title="SEEK Business"
@@ -3503,7 +3503,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isVolunteering"
+                    class="Sites__link Sites__link_isVolunteering"
                     data-analytics="header:volunteering"
                     href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     title="SEEK Volunteer"
@@ -3514,14 +3514,14 @@ exports[`Header: should render when authentication is pending 1`] = `
               </ul>
             </nav>
             <div
-              class="locale"
+              class="PartnerSites__locale"
             >
               <nav
                 aria-labelledby="Locales"
                 role="navigation"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   <h1
                     id="Locales"
@@ -3530,18 +3530,18 @@ exports[`Header: should render when authentication is pending 1`] = `
                   </h1>
                 </span>
                 <ul
-                  class="list"
+                  class="Locales__list"
                 >
                   <li>
                     <span
-                      class="locale_isActive"
+                      class="Locales__locale_isActive"
                     >
                       AU
                     </span>
                   </li>
                   <li>
                     <a
-                      class="localeLink"
+                      class="Locales__localeLink"
                       data-analytics="header:nz+homepage"
                       href="https://www.seek.co.nz"
                       title="SEEK New Zealand"
@@ -3563,24 +3563,24 @@ exports[`Header: should render when authentication is pending 1`] = `
 exports[`Header: should render when unauthenticated 1`] = `
 <header
   aria-label="Primary navigation"
-  class="root"
+  class="Header__root"
   role="banner"
 >
   <section
-    class="content"
+    class="Header__content"
   >
     <div
-      class="banner"
+      class="Header__banner"
     >
       <h1
-        class="logo"
+        class="Header__logo"
         data-automation="logo"
       >
         <div
           class=""
         >
           <svg
-            class="logoSvg root"
+            class="Header__logoSvg Logo__root"
             height="68.031"
             id="sk-logo-pos"
             viewBox="0 0 170.079 68.031"
@@ -3590,7 +3590,7 @@ exports[`Header: should render when unauthenticated 1`] = `
             y="0px"
           >
             <g
-              class="logoText"
+              class="Logo__logoText"
             >
               <path
                 d="M86.641,45.601c-3.697,0-7.037-0.408-10.012-3.385l3.834-3.833c1.942,1.938,4.467,2.208,6.269,2.208 c2.031,0,4.148-0.675,4.148-2.434c0-1.174-0.629-1.985-2.479-2.167l-3.699-0.36c-4.24-0.404-6.854-2.253-6.854-6.586 c0-4.869,4.282-7.485,9.064-7.485c3.653,0,6.72,0.632,8.976,2.75l-3.607,3.653c-1.354-1.217-3.43-1.576-5.459-1.576 c-2.344,0-3.336,1.082-3.336,2.254c0,0.857,0.361,1.85,2.436,2.03l3.7,0.361c4.643,0.45,6.992,2.932,6.992,6.9 C96.612,43.118,92.19,45.601,86.641,45.601z"
@@ -3606,45 +3606,45 @@ exports[`Header: should render when unauthenticated 1`] = `
               />
             </g>
             <path
-              class="logoIcon"
+              class="Logo__logoIcon"
               d="M34.015,1.51c-17.952,0-32.506,14.552-32.506,32.507c0,17.952,14.554,32.505,32.506,32.505 c17.958,0,32.508-14.553,32.508-32.505C66.523,16.062,51.972,1.51,34.015,1.51z M8.262,41.733c-0.281,0-0.511-0.226-0.511-0.504 c0-0.281,0.229-0.511,0.511-0.511c0.278,0,0.504,0.229,0.504,0.511C8.766,41.508,8.541,41.733,8.262,41.733z M8.262,34.907 c-0.281,0-0.511-0.229-0.511-0.51s0.229-0.509,0.511-0.509c0.278,0,0.504,0.228,0.504,0.509S8.541,34.907,8.262,34.907z M8.262,28.077c-0.281,0-0.511-0.229-0.511-0.509c0-0.281,0.229-0.507,0.511-0.507c0.278,0,0.504,0.226,0.504,0.507 C8.766,27.849,8.541,28.077,8.262,28.077z M11.764,41.991c-0.422,0-0.762-0.342-0.762-0.762c0-0.422,0.34-0.765,0.762-0.765 c0.421,0,0.762,0.343,0.762,0.765C12.526,41.649,12.186,41.991,11.764,41.991z M11.764,35.158c-0.422,0-0.762-0.339-0.762-0.761 c0-0.42,0.34-0.761,0.762-0.761c0.421,0,0.762,0.341,0.762,0.761C12.526,34.819,12.186,35.158,11.764,35.158z M11.764,28.33 c-0.422,0-0.762-0.341-0.762-0.762c0-0.422,0.34-0.763,0.762-0.763c0.421,0,0.762,0.341,0.762,0.763 C12.526,27.989,12.186,28.33,11.764,28.33z M15.867,42.246c-0.562,0-1.019-0.455-1.019-1.017c0-0.561,0.457-1.018,1.019-1.018 c0.558,0,1.016,0.457,1.016,1.018C16.882,41.791,16.424,42.246,15.867,42.246z M15.867,35.412c-0.562,0-1.019-0.453-1.019-1.015 c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016C16.882,34.959,16.424,35.412,15.867,35.412z M15.867,28.583 c-0.562,0-1.019-0.451-1.019-1.015c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016 C16.882,28.132,16.424,28.583,15.867,28.583z M20.18,42.497c-0.702,0-1.27-0.567-1.27-1.268c0-0.705,0.568-1.27,1.27-1.27 c0.704,0,1.27,0.564,1.27,1.27C21.45,41.93,20.884,42.497,20.18,42.497z M20.18,35.669c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.269,1.27-1.269c0.704,0,1.27,0.565,1.27,1.269S20.884,35.669,20.18,35.669z M20.18,28.84c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.271,1.27-1.271c0.704,0,1.27,0.567,1.27,1.271S20.884,28.84,20.18,28.84z M25.234,42.752c-0.842,0-1.523-0.681-1.523-1.522 c0-0.845,0.682-1.523,1.523-1.523c0.84,0,1.522,0.679,1.522,1.523C26.756,42.071,26.074,42.752,25.234,42.752z M25.234,35.922 c-0.842,0-1.523-0.684-1.523-1.524c0-0.842,0.682-1.523,1.523-1.523c0.84,0,1.522,0.682,1.522,1.523 C26.756,35.238,26.074,35.922,25.234,35.922z M25.234,29.093c-0.842,0-1.523-0.683-1.523-1.524s0.682-1.525,1.523-1.525 c0.84,0,1.522,0.684,1.522,1.525S26.074,29.093,25.234,29.093z M30.523,43.005c-0.983,0-1.778-0.792-1.778-1.775 c0-0.982,0.795-1.78,1.778-1.78c0.985,0,1.779,0.798,1.779,1.78C32.302,42.213,31.508,43.005,30.523,43.005z M30.523,36.176 c-0.983,0-1.778-0.796-1.778-1.778s0.795-1.776,1.778-1.776c0.985,0,1.779,0.794,1.779,1.776S31.508,36.176,30.523,36.176z M30.523,29.346c-0.983,0-1.778-0.796-1.778-1.777s0.795-1.776,1.778-1.776c0.985,0,1.779,0.795,1.779,1.776 S31.508,29.346,30.523,29.346z M36.812,56.922c-1.121,0-2.027-0.911-2.027-2.034c0-1.119,0.906-2.027,2.027-2.027 c1.125,0,2.035,0.908,2.035,2.027C38.847,56.011,37.938,56.922,36.812,56.922z M36.812,50.091c-1.121,0-2.027-0.91-2.027-2.03 c0-1.122,0.906-2.036,2.027-2.036c1.125,0,2.035,0.914,2.035,2.036C38.847,49.181,37.938,50.091,36.812,50.091z M36.812,43.26 c-1.121,0-2.027-0.909-2.027-2.03c0-1.123,0.906-2.033,2.027-2.033c1.125,0,2.035,0.91,2.035,2.033 C38.847,42.351,37.938,43.26,36.812,43.26z M36.812,36.43c-1.121,0-2.027-0.91-2.027-2.032c0-1.124,0.906-2.03,2.027-2.03 c1.125,0,2.035,0.906,2.035,2.03C38.847,35.52,37.938,36.43,36.812,36.43z M36.812,29.6c-1.121,0-2.027-0.908-2.027-2.031 c0-1.122,0.906-2.031,2.027-2.031c1.125,0,2.035,0.909,2.035,2.031C38.847,28.691,37.938,29.6,36.812,29.6z M36.812,22.77 c-1.121,0-2.027-0.912-2.027-2.032c0-1.123,0.906-2.03,2.027-2.03c1.125,0,2.035,0.907,2.035,2.03 C38.847,21.857,37.938,22.77,36.812,22.77z M36.812,15.938c-1.121,0-2.027-0.91-2.027-2.029c0-1.123,0.906-2.033,2.027-2.033 c1.125,0,2.035,0.91,2.035,2.033C38.847,15.027,37.938,15.938,36.812,15.938z M43.342,50.3c-1.233,0-2.238-1.002-2.238-2.239 c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242C45.585,49.298,44.582,50.3,43.342,50.3z M43.342,43.469 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,42.466,44.582,43.469,43.342,43.469z M43.342,36.64c-1.233,0-2.238-1.004-2.238-2.242c0-1.237,1.004-2.238,2.238-2.238 c1.24,0,2.243,1.001,2.243,2.238C45.585,35.636,44.582,36.64,43.342,36.64z M43.342,29.807c-1.233,0-2.238-1.002-2.238-2.238 c0-1.238,1.004-2.24,2.238-2.24c1.24,0,2.243,1.002,2.243,2.24C45.585,28.805,44.582,29.807,43.342,29.807z M43.342,22.977 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,21.974,44.582,22.977,43.342,22.977z M50.351,43.765c-1.393,0-2.517-1.126-2.517-2.517c0-1.389,1.124-2.516,2.517-2.516 c1.391,0,2.513,1.127,2.513,2.516C52.863,42.639,51.742,43.765,50.351,43.765z M50.351,36.933c-1.393,0-2.517-1.123-2.517-2.515 c0-1.386,1.124-2.517,2.517-2.517c1.391,0,2.513,1.131,2.513,2.517C52.863,35.81,51.742,36.933,50.351,36.933z M50.351,30.104 c-1.393,0-2.517-1.125-2.517-2.515c0-1.393,1.124-2.517,2.517-2.517c1.391,0,2.513,1.124,2.513,2.517 C52.863,28.979,51.742,30.104,50.351,30.104z M57.49,37.219c-1.519,0-2.756-1.234-2.756-2.754c0-1.523,1.238-2.757,2.756-2.757 c1.521,0,2.754,1.233,2.754,2.757C60.244,35.984,59.012,37.219,57.49,37.219z"
             />
           </svg>
         </div>
         <a
-          class="logoLink"
+          class="Header__logoLink"
           data-analytics="header:jobs"
           href="/"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             SEEK
           </span>
         </a>
       </h1>
       <span
-        class="logoNote screen"
+        class="Header__logoNote Hidden__screen"
       >
         Australia’s #1 job site
       </span>
       <span
-        class="userWrapper print"
+        class="Header__userWrapper Hidden__print"
       >
         <div
-          class="user user_isUnauthenticated user_isReady"
+          class="Header__user Header__user_isUnauthenticated Header__user_isReady"
         >
           <div
-            class="userAccountWrapper"
+            class="Header__userAccountWrapper"
           >
             <nav
               aria-labelledby="UserMenu"
-              class="root"
+              class="UserAccount__root"
               data-automation="user-account"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="UserMenu"
@@ -3654,32 +3654,32 @@ exports[`Header: should render when unauthenticated 1`] = `
               </span>
               <input
                 autocomplete="off"
-                class="toggle"
+                class="UserAccount__toggle"
                 id="user-account-menu-toggle"
                 type="checkbox"
               />
               <div
-                class="menuBackdrop"
+                class="UserAccount__menuBackdrop"
               >
                 <label
-                  class="menuBackdropLabel"
+                  class="UserAccount__menuBackdropLabel"
                   data-automation="user-account-menu-backdrop"
                   for="user-account-menu-toggle"
                 >
                   <span
-                    class="root"
+                    class="ScreenReaderOnly__root"
                   >
                     Show user menu
                   </span>
                 </label>
               </div>
               <label
-                class="toggleLabel"
+                class="UserAccount__toggleLabel"
                 data-automation="user-account-menu-toggle"
                 for="user-account-menu-toggle"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   Show user menu
                 </span>
@@ -3687,32 +3687,32 @@ exports[`Header: should render when unauthenticated 1`] = `
                   data-hj-masked="true"
                 >
                   <span
-                    class="mobileMenuLabel"
+                    class="UserAccount__mobileMenuLabel"
                   >
                     Menu
                   </span>
                   <span
-                    class="desktopMenuLabel"
+                    class="UserAccount__desktopMenuLabel"
                     data-automation="user-account-name"
                   />
                 </span>
                 <span
-                  class="root root chevron"
+                  class="Icon__root ChevronIcon__root UserAccount__chevron"
                 >
                   mock svg
                 </span>
               </label>
               <div
-                class="toggleContainer"
+                class="UserAccount__toggleContainer"
               >
                 <ul
-                  class="root"
+                  class="UserAccountMenu__root"
                 >
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:jobs"
                       href="/"
                     >
@@ -3720,7 +3720,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                         Job Search
                       </span>
                       <span
-                        class="root icon jobSearch"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__jobSearch"
                       >
                         mock svg
                       </span>
@@ -3730,7 +3730,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:profile"
                       href="/profile/"
                     >
@@ -3738,17 +3738,17 @@ exports[`Header: should render when unauthenticated 1`] = `
                         Profile
                       </span>
                       <span
-                        class="root icon profile"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__profile"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+searches"
                       href="/myactivity"
                     >
@@ -3756,7 +3756,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                         Saved Searches
                       </span>
                       <span
-                        class="root icon saveSearches"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveSearches"
                       >
                         mock svg
                       </span>
@@ -3766,45 +3766,45 @@ exports[`Header: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
                         Saved 
                         <span
-                          class="desktop"
+                          class="Hidden__desktop"
                         >
                           & Applied 
                         </span>
                         Jobs
                       </span>
                       <span
-                        class="root icon saveJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
                       Applied Jobs
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -3812,48 +3812,48 @@ exports[`Header: should render when unauthenticated 1`] = `
                         Recommended Jobs
                       </span>
                       <span
-                        class="root icon recommendedJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__recommendedJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
                       Company Reviews
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:settings"
                       href="/settings/"
                     >
                       Settings
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <span
-                      class="item"
+                      class="UserAccountMenu__item"
                     >
                       <a
-                        class="itemLink"
+                        class="UserAccountMenu__itemLink"
                         data-analytics="header:sign-in"
                         href="/sign-in"
                         title="Sign in"
@@ -3861,12 +3861,12 @@ exports[`Header: should render when unauthenticated 1`] = `
                         Sign in
                       </a>
                       <span
-                        class="secondaryItemText"
+                        class="UserAccountMenu__secondaryItemText"
                       >
                          or 
                       </span>
                       <a
-                        class="itemLink"
+                        class="UserAccountMenu__itemLink"
                         data-analytics="header:register"
                         href="/sign-up"
                         title="Register"
@@ -3874,35 +3874,35 @@ exports[`Header: should render when unauthenticated 1`] = `
                         Register
                       </a>
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </span>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:advice"
                       href="/career-advice/"
                     >
                       Career Advice
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
@@ -3911,15 +3911,15 @@ exports[`Header: should render when unauthenticated 1`] = `
             </nav>
           </div>
           <div
-            class="signInRegisterWrapper"
+            class="Header__signInRegisterWrapper"
           >
             <nav
               aria-labelledby="SignInOrRegister"
-              class="root"
+              class="SignInRegister__root"
               data-automation="sign-in-register"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="SignInOrRegister"
@@ -3928,7 +3928,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                 </h1>
               </span>
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:sign-in"
                 href="/sign-in"
                 rel="nofollow"
@@ -3938,7 +3938,7 @@ exports[`Header: should render when unauthenticated 1`] = `
               </a>
                or 
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:register"
                 href="/sign-up"
                 rel="nofollow"
@@ -3949,14 +3949,14 @@ exports[`Header: should render when unauthenticated 1`] = `
             </nav>
           </div>
           <span
-            class="divider"
+            class="Header__divider"
           />
         </div>
         <div
-          class="employerSite"
+          class="Header__employerSite"
         >
           <a
-            class="employerLink"
+            class="Header__employerLink"
             data-analytics="header:employer+site"
             href="https://talent.seek.com.au/"
           >
@@ -3966,15 +3966,15 @@ exports[`Header: should render when unauthenticated 1`] = `
       </span>
     </div>
     <span
-      class="navigation print"
+      class="Header__navigation Hidden__print"
     >
       <nav
         aria-labelledby="MainNavigation"
-        class="root divider"
+        class="Navigation__root Navigation__divider"
         role="navigation"
       >
         <span
-          class="root"
+          class="ScreenReaderOnly__root"
         >
           <h1
             id="MainNavigation"
@@ -3983,14 +3983,14 @@ exports[`Header: should render when unauthenticated 1`] = `
           </h1>
         </span>
         <ul
-          class="list"
+          class="Navigation__list"
           data-automation="nav-tabs"
         >
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:jobs"
               href="/"
             >
@@ -3998,11 +3998,11 @@ exports[`Header: should render when unauthenticated 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
               aria-label="One fifty K jobs"
-              class="link"
+              class="Navigation__link"
               data-analytics="header:high+salary"
               href="/150kjobs"
             >
@@ -4010,10 +4010,10 @@ exports[`Header: should render when unauthenticated 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:profile"
               href="/profile/"
             >
@@ -4021,10 +4021,10 @@ exports[`Header: should render when unauthenticated 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:companies"
               href="/companies/"
             >
@@ -4032,10 +4032,10 @@ exports[`Header: should render when unauthenticated 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:advice"
               href="/career-advice/"
             >
@@ -4046,23 +4046,23 @@ exports[`Header: should render when unauthenticated 1`] = `
       </nav>
     </span>
     <div
-      class="topBanner"
+      class="Header__topBanner"
     >
       <div
-        class="root mobile print"
+        class="PartnerSites__root Hidden__mobile Hidden__print"
       >
         <div
-          class="content"
+          class="PageBlock__content"
         >
           <div
-            class="content"
+            class="PartnerSites__content"
           >
             <nav
               aria-labelledby="Sites"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="Sites"
@@ -4071,11 +4071,11 @@ exports[`Header: should render when unauthenticated 1`] = `
                 </h1>
               </span>
               <ul
-                class="list"
+                class="Sites__list"
               >
                 <li>
                   <span
-                    class="link link_isActive"
+                    class="Sites__link Sites__link_isActive"
                     title="SEEK Jobs"
                   >
                     Jobs
@@ -4083,7 +4083,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isLearning"
+                    class="Sites__link Sites__link_isLearning"
                     data-analytics="header:courses"
                     href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     title="SEEK Learning"
@@ -4093,7 +4093,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isBusiness"
+                    class="Sites__link Sites__link_isBusiness"
                     data-analytics="header:business+for+sale"
                     href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     title="SEEK Business"
@@ -4103,7 +4103,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isVolunteering"
+                    class="Sites__link Sites__link_isVolunteering"
                     data-analytics="header:volunteering"
                     href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     title="SEEK Volunteer"
@@ -4114,14 +4114,14 @@ exports[`Header: should render when unauthenticated 1`] = `
               </ul>
             </nav>
             <div
-              class="locale"
+              class="PartnerSites__locale"
             >
               <nav
                 aria-labelledby="Locales"
                 role="navigation"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   <h1
                     id="Locales"
@@ -4130,18 +4130,18 @@ exports[`Header: should render when unauthenticated 1`] = `
                   </h1>
                 </span>
                 <ul
-                  class="list"
+                  class="Locales__list"
                 >
                   <li>
                     <span
-                      class="locale_isActive"
+                      class="Locales__locale_isActive"
                     >
                       AU
                     </span>
                   </li>
                   <li>
                     <a
-                      class="localeLink"
+                      class="Locales__localeLink"
                       data-analytics="header:nz+homepage"
                       href="https://www.seek.co.nz"
                       title="SEEK New Zealand"
@@ -4163,56 +4163,56 @@ exports[`Header: should render when unauthenticated 1`] = `
 exports[`Header: should render with a custom logo 1`] = `
 <header
   aria-label="Primary navigation"
-  class="root"
+  class="Header__root"
   role="banner"
 >
   <section
-    class="content"
+    class="Header__content"
   >
     <div
-      class="banner"
+      class="Header__banner"
     >
       <h1
-        class="logo"
+        class="Header__logo"
         data-automation="logo"
       >
         <div>
           Custom Logo
         </div>
         <a
-          class="logoLink"
+          class="Header__logoLink"
           data-analytics="header:jobs"
           href="/"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             SEEK
           </span>
         </a>
       </h1>
       <span
-        class="logoNote screen"
+        class="Header__logoNote Hidden__screen"
       >
         Australia’s #1 job site
       </span>
       <span
-        class="userWrapper print"
+        class="Header__userWrapper Hidden__print"
       >
         <div
-          class="user"
+          class="Header__user"
         >
           <div
-            class="userAccountWrapper"
+            class="Header__userAccountWrapper"
           >
             <nav
               aria-labelledby="UserMenu"
-              class="root"
+              class="UserAccount__root"
               data-automation="user-account"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="UserMenu"
@@ -4222,32 +4222,32 @@ exports[`Header: should render with a custom logo 1`] = `
               </span>
               <input
                 autocomplete="off"
-                class="toggle"
+                class="UserAccount__toggle"
                 id="user-account-menu-toggle"
                 type="checkbox"
               />
               <div
-                class="menuBackdrop"
+                class="UserAccount__menuBackdrop"
               >
                 <label
-                  class="menuBackdropLabel"
+                  class="UserAccount__menuBackdropLabel"
                   data-automation="user-account-menu-backdrop"
                   for="user-account-menu-toggle"
                 >
                   <span
-                    class="root"
+                    class="ScreenReaderOnly__root"
                   >
                     Show user menu
                   </span>
                 </label>
               </div>
               <label
-                class="toggleLabel"
+                class="UserAccount__toggleLabel"
                 data-automation="user-account-menu-toggle"
                 for="user-account-menu-toggle"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   Show user menu
                 </span>
@@ -4255,30 +4255,30 @@ exports[`Header: should render with a custom logo 1`] = `
                   data-hj-masked="true"
                 >
                   <span
-                    class="mobileMenuLabel"
+                    class="UserAccount__mobileMenuLabel"
                   />
                   <span
-                    class="desktopMenuLabel"
+                    class="UserAccount__desktopMenuLabel"
                     data-automation="user-account-name"
                   />
                 </span>
                 <span
-                  class="root root chevron"
+                  class="Icon__root ChevronIcon__root UserAccount__chevron"
                 >
                   mock svg
                 </span>
               </label>
               <div
-                class="toggleContainer"
+                class="UserAccount__toggleContainer"
               >
                 <ul
-                  class="root"
+                  class="UserAccountMenu__root"
                 >
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:jobs"
                       href="/"
                     >
@@ -4286,7 +4286,7 @@ exports[`Header: should render with a custom logo 1`] = `
                         Job Search
                       </span>
                       <span
-                        class="root icon jobSearch"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__jobSearch"
                       >
                         mock svg
                       </span>
@@ -4296,7 +4296,7 @@ exports[`Header: should render with a custom logo 1`] = `
                     class=""
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:profile"
                       href="/profile/"
                     >
@@ -4304,17 +4304,17 @@ exports[`Header: should render with a custom logo 1`] = `
                         Profile
                       </span>
                       <span
-                        class="root icon profile"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__profile"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+searches"
                       href="/myactivity"
                     >
@@ -4322,7 +4322,7 @@ exports[`Header: should render with a custom logo 1`] = `
                         Saved Searches
                       </span>
                       <span
-                        class="root icon saveSearches"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveSearches"
                       >
                         mock svg
                       </span>
@@ -4332,45 +4332,45 @@ exports[`Header: should render with a custom logo 1`] = `
                     class=""
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
                         Saved 
                         <span
-                          class="desktop"
+                          class="Hidden__desktop"
                         >
                           & Applied 
                         </span>
                         Jobs
                       </span>
                       <span
-                        class="root icon saveJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
                       Applied Jobs
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -4378,89 +4378,89 @@ exports[`Header: should render with a custom logo 1`] = `
                         Recommended Jobs
                       </span>
                       <span
-                        class="root icon recommendedJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__recommendedJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
                       Company Reviews
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:settings"
                       href="/settings/"
                     >
                       Settings
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <span
-                      class="item pendingAuth"
+                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="root _small"
+                        class="Loader__root Loader___small"
                       >
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                       </div>
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </span>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:advice"
                       href="/career-advice/"
                     >
                       Career Advice
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
@@ -4469,15 +4469,15 @@ exports[`Header: should render with a custom logo 1`] = `
             </nav>
           </div>
           <div
-            class="signInRegisterWrapper"
+            class="Header__signInRegisterWrapper"
           >
             <nav
               aria-labelledby="SignInOrRegister"
-              class="root"
+              class="SignInRegister__root"
               data-automation="sign-in-register"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="SignInOrRegister"
@@ -4486,7 +4486,7 @@ exports[`Header: should render with a custom logo 1`] = `
                 </h1>
               </span>
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:sign-in"
                 href="/sign-in"
                 rel="nofollow"
@@ -4496,7 +4496,7 @@ exports[`Header: should render with a custom logo 1`] = `
               </a>
                or 
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:register"
                 href="/sign-up"
                 rel="nofollow"
@@ -4507,14 +4507,14 @@ exports[`Header: should render with a custom logo 1`] = `
             </nav>
           </div>
           <span
-            class="divider"
+            class="Header__divider"
           />
         </div>
         <div
-          class="employerSite"
+          class="Header__employerSite"
         >
           <a
-            class="employerLink"
+            class="Header__employerLink"
             data-analytics="header:employer+site"
             href="https://talent.seek.com.au/"
           >
@@ -4524,15 +4524,15 @@ exports[`Header: should render with a custom logo 1`] = `
       </span>
     </div>
     <span
-      class="navigation print"
+      class="Header__navigation Hidden__print"
     >
       <nav
         aria-labelledby="MainNavigation"
-        class="root divider"
+        class="Navigation__root Navigation__divider"
         role="navigation"
       >
         <span
-          class="root"
+          class="ScreenReaderOnly__root"
         >
           <h1
             id="MainNavigation"
@@ -4541,14 +4541,14 @@ exports[`Header: should render with a custom logo 1`] = `
           </h1>
         </span>
         <ul
-          class="list"
+          class="Navigation__list"
           data-automation="nav-tabs"
         >
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:jobs"
               href="/"
             >
@@ -4556,11 +4556,11 @@ exports[`Header: should render with a custom logo 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
               aria-label="One fifty K jobs"
-              class="link"
+              class="Navigation__link"
               data-analytics="header:high+salary"
               href="/150kjobs"
             >
@@ -4568,10 +4568,10 @@ exports[`Header: should render with a custom logo 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:profile"
               href="/profile/"
             >
@@ -4579,10 +4579,10 @@ exports[`Header: should render with a custom logo 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:companies"
               href="/companies/"
             >
@@ -4590,10 +4590,10 @@ exports[`Header: should render with a custom logo 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:advice"
               href="/career-advice/"
             >
@@ -4604,23 +4604,23 @@ exports[`Header: should render with a custom logo 1`] = `
       </nav>
     </span>
     <div
-      class="topBanner"
+      class="Header__topBanner"
     >
       <div
-        class="root mobile print"
+        class="PartnerSites__root Hidden__mobile Hidden__print"
       >
         <div
-          class="content"
+          class="PageBlock__content"
         >
           <div
-            class="content"
+            class="PartnerSites__content"
           >
             <nav
               aria-labelledby="Sites"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="Sites"
@@ -4629,11 +4629,11 @@ exports[`Header: should render with a custom logo 1`] = `
                 </h1>
               </span>
               <ul
-                class="list"
+                class="Sites__list"
               >
                 <li>
                   <span
-                    class="link link_isActive"
+                    class="Sites__link Sites__link_isActive"
                     title="SEEK Jobs"
                   >
                     Jobs
@@ -4641,7 +4641,7 @@ exports[`Header: should render with a custom logo 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isLearning"
+                    class="Sites__link Sites__link_isLearning"
                     data-analytics="header:courses"
                     href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     title="SEEK Learning"
@@ -4651,7 +4651,7 @@ exports[`Header: should render with a custom logo 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isBusiness"
+                    class="Sites__link Sites__link_isBusiness"
                     data-analytics="header:business+for+sale"
                     href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     title="SEEK Business"
@@ -4661,7 +4661,7 @@ exports[`Header: should render with a custom logo 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isVolunteering"
+                    class="Sites__link Sites__link_isVolunteering"
                     data-analytics="header:volunteering"
                     href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     title="SEEK Volunteer"
@@ -4672,14 +4672,14 @@ exports[`Header: should render with a custom logo 1`] = `
               </ul>
             </nav>
             <div
-              class="locale"
+              class="PartnerSites__locale"
             >
               <nav
                 aria-labelledby="Locales"
                 role="navigation"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   <h1
                     id="Locales"
@@ -4688,18 +4688,18 @@ exports[`Header: should render with a custom logo 1`] = `
                   </h1>
                 </span>
                 <ul
-                  class="list"
+                  class="Locales__list"
                 >
                   <li>
                     <span
-                      class="locale_isActive"
+                      class="Locales__locale_isActive"
                     >
                       AU
                     </span>
                   </li>
                   <li>
                     <a
-                      class="localeLink"
+                      class="Locales__localeLink"
                       data-analytics="header:nz+homepage"
                       href="https://www.seek.co.nz"
                       title="SEEK New Zealand"
@@ -4721,24 +4721,24 @@ exports[`Header: should render with a custom logo 1`] = `
 exports[`Header: should render with locale of AU 1`] = `
 <header
   aria-label="Primary navigation"
-  class="root"
+  class="Header__root"
   role="banner"
 >
   <section
-    class="content"
+    class="Header__content"
   >
     <div
-      class="banner"
+      class="Header__banner"
     >
       <h1
-        class="logo"
+        class="Header__logo"
         data-automation="logo"
       >
         <div
           class=""
         >
           <svg
-            class="logoSvg root"
+            class="Header__logoSvg Logo__root"
             height="68.031"
             id="sk-logo-pos"
             viewBox="0 0 170.079 68.031"
@@ -4748,7 +4748,7 @@ exports[`Header: should render with locale of AU 1`] = `
             y="0px"
           >
             <g
-              class="logoText"
+              class="Logo__logoText"
             >
               <path
                 d="M86.641,45.601c-3.697,0-7.037-0.408-10.012-3.385l3.834-3.833c1.942,1.938,4.467,2.208,6.269,2.208 c2.031,0,4.148-0.675,4.148-2.434c0-1.174-0.629-1.985-2.479-2.167l-3.699-0.36c-4.24-0.404-6.854-2.253-6.854-6.586 c0-4.869,4.282-7.485,9.064-7.485c3.653,0,6.72,0.632,8.976,2.75l-3.607,3.653c-1.354-1.217-3.43-1.576-5.459-1.576 c-2.344,0-3.336,1.082-3.336,2.254c0,0.857,0.361,1.85,2.436,2.03l3.7,0.361c4.643,0.45,6.992,2.932,6.992,6.9 C96.612,43.118,92.19,45.601,86.641,45.601z"
@@ -4764,45 +4764,45 @@ exports[`Header: should render with locale of AU 1`] = `
               />
             </g>
             <path
-              class="logoIcon"
+              class="Logo__logoIcon"
               d="M34.015,1.51c-17.952,0-32.506,14.552-32.506,32.507c0,17.952,14.554,32.505,32.506,32.505 c17.958,0,32.508-14.553,32.508-32.505C66.523,16.062,51.972,1.51,34.015,1.51z M8.262,41.733c-0.281,0-0.511-0.226-0.511-0.504 c0-0.281,0.229-0.511,0.511-0.511c0.278,0,0.504,0.229,0.504,0.511C8.766,41.508,8.541,41.733,8.262,41.733z M8.262,34.907 c-0.281,0-0.511-0.229-0.511-0.51s0.229-0.509,0.511-0.509c0.278,0,0.504,0.228,0.504,0.509S8.541,34.907,8.262,34.907z M8.262,28.077c-0.281,0-0.511-0.229-0.511-0.509c0-0.281,0.229-0.507,0.511-0.507c0.278,0,0.504,0.226,0.504,0.507 C8.766,27.849,8.541,28.077,8.262,28.077z M11.764,41.991c-0.422,0-0.762-0.342-0.762-0.762c0-0.422,0.34-0.765,0.762-0.765 c0.421,0,0.762,0.343,0.762,0.765C12.526,41.649,12.186,41.991,11.764,41.991z M11.764,35.158c-0.422,0-0.762-0.339-0.762-0.761 c0-0.42,0.34-0.761,0.762-0.761c0.421,0,0.762,0.341,0.762,0.761C12.526,34.819,12.186,35.158,11.764,35.158z M11.764,28.33 c-0.422,0-0.762-0.341-0.762-0.762c0-0.422,0.34-0.763,0.762-0.763c0.421,0,0.762,0.341,0.762,0.763 C12.526,27.989,12.186,28.33,11.764,28.33z M15.867,42.246c-0.562,0-1.019-0.455-1.019-1.017c0-0.561,0.457-1.018,1.019-1.018 c0.558,0,1.016,0.457,1.016,1.018C16.882,41.791,16.424,42.246,15.867,42.246z M15.867,35.412c-0.562,0-1.019-0.453-1.019-1.015 c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016C16.882,34.959,16.424,35.412,15.867,35.412z M15.867,28.583 c-0.562,0-1.019-0.451-1.019-1.015c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016 C16.882,28.132,16.424,28.583,15.867,28.583z M20.18,42.497c-0.702,0-1.27-0.567-1.27-1.268c0-0.705,0.568-1.27,1.27-1.27 c0.704,0,1.27,0.564,1.27,1.27C21.45,41.93,20.884,42.497,20.18,42.497z M20.18,35.669c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.269,1.27-1.269c0.704,0,1.27,0.565,1.27,1.269S20.884,35.669,20.18,35.669z M20.18,28.84c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.271,1.27-1.271c0.704,0,1.27,0.567,1.27,1.271S20.884,28.84,20.18,28.84z M25.234,42.752c-0.842,0-1.523-0.681-1.523-1.522 c0-0.845,0.682-1.523,1.523-1.523c0.84,0,1.522,0.679,1.522,1.523C26.756,42.071,26.074,42.752,25.234,42.752z M25.234,35.922 c-0.842,0-1.523-0.684-1.523-1.524c0-0.842,0.682-1.523,1.523-1.523c0.84,0,1.522,0.682,1.522,1.523 C26.756,35.238,26.074,35.922,25.234,35.922z M25.234,29.093c-0.842,0-1.523-0.683-1.523-1.524s0.682-1.525,1.523-1.525 c0.84,0,1.522,0.684,1.522,1.525S26.074,29.093,25.234,29.093z M30.523,43.005c-0.983,0-1.778-0.792-1.778-1.775 c0-0.982,0.795-1.78,1.778-1.78c0.985,0,1.779,0.798,1.779,1.78C32.302,42.213,31.508,43.005,30.523,43.005z M30.523,36.176 c-0.983,0-1.778-0.796-1.778-1.778s0.795-1.776,1.778-1.776c0.985,0,1.779,0.794,1.779,1.776S31.508,36.176,30.523,36.176z M30.523,29.346c-0.983,0-1.778-0.796-1.778-1.777s0.795-1.776,1.778-1.776c0.985,0,1.779,0.795,1.779,1.776 S31.508,29.346,30.523,29.346z M36.812,56.922c-1.121,0-2.027-0.911-2.027-2.034c0-1.119,0.906-2.027,2.027-2.027 c1.125,0,2.035,0.908,2.035,2.027C38.847,56.011,37.938,56.922,36.812,56.922z M36.812,50.091c-1.121,0-2.027-0.91-2.027-2.03 c0-1.122,0.906-2.036,2.027-2.036c1.125,0,2.035,0.914,2.035,2.036C38.847,49.181,37.938,50.091,36.812,50.091z M36.812,43.26 c-1.121,0-2.027-0.909-2.027-2.03c0-1.123,0.906-2.033,2.027-2.033c1.125,0,2.035,0.91,2.035,2.033 C38.847,42.351,37.938,43.26,36.812,43.26z M36.812,36.43c-1.121,0-2.027-0.91-2.027-2.032c0-1.124,0.906-2.03,2.027-2.03 c1.125,0,2.035,0.906,2.035,2.03C38.847,35.52,37.938,36.43,36.812,36.43z M36.812,29.6c-1.121,0-2.027-0.908-2.027-2.031 c0-1.122,0.906-2.031,2.027-2.031c1.125,0,2.035,0.909,2.035,2.031C38.847,28.691,37.938,29.6,36.812,29.6z M36.812,22.77 c-1.121,0-2.027-0.912-2.027-2.032c0-1.123,0.906-2.03,2.027-2.03c1.125,0,2.035,0.907,2.035,2.03 C38.847,21.857,37.938,22.77,36.812,22.77z M36.812,15.938c-1.121,0-2.027-0.91-2.027-2.029c0-1.123,0.906-2.033,2.027-2.033 c1.125,0,2.035,0.91,2.035,2.033C38.847,15.027,37.938,15.938,36.812,15.938z M43.342,50.3c-1.233,0-2.238-1.002-2.238-2.239 c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242C45.585,49.298,44.582,50.3,43.342,50.3z M43.342,43.469 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,42.466,44.582,43.469,43.342,43.469z M43.342,36.64c-1.233,0-2.238-1.004-2.238-2.242c0-1.237,1.004-2.238,2.238-2.238 c1.24,0,2.243,1.001,2.243,2.238C45.585,35.636,44.582,36.64,43.342,36.64z M43.342,29.807c-1.233,0-2.238-1.002-2.238-2.238 c0-1.238,1.004-2.24,2.238-2.24c1.24,0,2.243,1.002,2.243,2.24C45.585,28.805,44.582,29.807,43.342,29.807z M43.342,22.977 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,21.974,44.582,22.977,43.342,22.977z M50.351,43.765c-1.393,0-2.517-1.126-2.517-2.517c0-1.389,1.124-2.516,2.517-2.516 c1.391,0,2.513,1.127,2.513,2.516C52.863,42.639,51.742,43.765,50.351,43.765z M50.351,36.933c-1.393,0-2.517-1.123-2.517-2.515 c0-1.386,1.124-2.517,2.517-2.517c1.391,0,2.513,1.131,2.513,2.517C52.863,35.81,51.742,36.933,50.351,36.933z M50.351,30.104 c-1.393,0-2.517-1.125-2.517-2.515c0-1.393,1.124-2.517,2.517-2.517c1.391,0,2.513,1.124,2.513,2.517 C52.863,28.979,51.742,30.104,50.351,30.104z M57.49,37.219c-1.519,0-2.756-1.234-2.756-2.754c0-1.523,1.238-2.757,2.756-2.757 c1.521,0,2.754,1.233,2.754,2.757C60.244,35.984,59.012,37.219,57.49,37.219z"
             />
           </svg>
         </div>
         <a
-          class="logoLink"
+          class="Header__logoLink"
           data-analytics="header:jobs"
           href="/"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             SEEK
           </span>
         </a>
       </h1>
       <span
-        class="logoNote screen"
+        class="Header__logoNote Hidden__screen"
       >
         Australia’s #1 job site
       </span>
       <span
-        class="userWrapper print"
+        class="Header__userWrapper Hidden__print"
       >
         <div
-          class="user"
+          class="Header__user"
         >
           <div
-            class="userAccountWrapper"
+            class="Header__userAccountWrapper"
           >
             <nav
               aria-labelledby="UserMenu"
-              class="root"
+              class="UserAccount__root"
               data-automation="user-account"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="UserMenu"
@@ -4812,32 +4812,32 @@ exports[`Header: should render with locale of AU 1`] = `
               </span>
               <input
                 autocomplete="off"
-                class="toggle"
+                class="UserAccount__toggle"
                 id="user-account-menu-toggle"
                 type="checkbox"
               />
               <div
-                class="menuBackdrop"
+                class="UserAccount__menuBackdrop"
               >
                 <label
-                  class="menuBackdropLabel"
+                  class="UserAccount__menuBackdropLabel"
                   data-automation="user-account-menu-backdrop"
                   for="user-account-menu-toggle"
                 >
                   <span
-                    class="root"
+                    class="ScreenReaderOnly__root"
                   >
                     Show user menu
                   </span>
                 </label>
               </div>
               <label
-                class="toggleLabel"
+                class="UserAccount__toggleLabel"
                 data-automation="user-account-menu-toggle"
                 for="user-account-menu-toggle"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   Show user menu
                 </span>
@@ -4845,30 +4845,30 @@ exports[`Header: should render with locale of AU 1`] = `
                   data-hj-masked="true"
                 >
                   <span
-                    class="mobileMenuLabel"
+                    class="UserAccount__mobileMenuLabel"
                   />
                   <span
-                    class="desktopMenuLabel"
+                    class="UserAccount__desktopMenuLabel"
                     data-automation="user-account-name"
                   />
                 </span>
                 <span
-                  class="root root chevron"
+                  class="Icon__root ChevronIcon__root UserAccount__chevron"
                 >
                   mock svg
                 </span>
               </label>
               <div
-                class="toggleContainer"
+                class="UserAccount__toggleContainer"
               >
                 <ul
-                  class="root"
+                  class="UserAccountMenu__root"
                 >
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:jobs"
                       href="/"
                     >
@@ -4876,7 +4876,7 @@ exports[`Header: should render with locale of AU 1`] = `
                         Job Search
                       </span>
                       <span
-                        class="root icon jobSearch"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__jobSearch"
                       >
                         mock svg
                       </span>
@@ -4886,7 +4886,7 @@ exports[`Header: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:profile"
                       href="/profile/"
                     >
@@ -4894,17 +4894,17 @@ exports[`Header: should render with locale of AU 1`] = `
                         Profile
                       </span>
                       <span
-                        class="root icon profile"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__profile"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+searches"
                       href="/myactivity"
                     >
@@ -4912,7 +4912,7 @@ exports[`Header: should render with locale of AU 1`] = `
                         Saved Searches
                       </span>
                       <span
-                        class="root icon saveSearches"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveSearches"
                       >
                         mock svg
                       </span>
@@ -4922,45 +4922,45 @@ exports[`Header: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
                         Saved 
                         <span
-                          class="desktop"
+                          class="Hidden__desktop"
                         >
                           & Applied 
                         </span>
                         Jobs
                       </span>
                       <span
-                        class="root icon saveJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
                       Applied Jobs
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -4968,89 +4968,89 @@ exports[`Header: should render with locale of AU 1`] = `
                         Recommended Jobs
                       </span>
                       <span
-                        class="root icon recommendedJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__recommendedJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
                       Company Reviews
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:settings"
                       href="/settings/"
                     >
                       Settings
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <span
-                      class="item pendingAuth"
+                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="root _small"
+                        class="Loader__root Loader___small"
                       >
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                       </div>
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </span>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:advice"
                       href="/career-advice/"
                     >
                       Career Advice
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
@@ -5059,15 +5059,15 @@ exports[`Header: should render with locale of AU 1`] = `
             </nav>
           </div>
           <div
-            class="signInRegisterWrapper"
+            class="Header__signInRegisterWrapper"
           >
             <nav
               aria-labelledby="SignInOrRegister"
-              class="root"
+              class="SignInRegister__root"
               data-automation="sign-in-register"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="SignInOrRegister"
@@ -5076,7 +5076,7 @@ exports[`Header: should render with locale of AU 1`] = `
                 </h1>
               </span>
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:sign-in"
                 href="/sign-in"
                 rel="nofollow"
@@ -5086,7 +5086,7 @@ exports[`Header: should render with locale of AU 1`] = `
               </a>
                or 
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:register"
                 href="/sign-up"
                 rel="nofollow"
@@ -5097,14 +5097,14 @@ exports[`Header: should render with locale of AU 1`] = `
             </nav>
           </div>
           <span
-            class="divider"
+            class="Header__divider"
           />
         </div>
         <div
-          class="employerSite"
+          class="Header__employerSite"
         >
           <a
-            class="employerLink"
+            class="Header__employerLink"
             data-analytics="header:employer+site"
             href="https://talent.seek.com.au/"
           >
@@ -5114,15 +5114,15 @@ exports[`Header: should render with locale of AU 1`] = `
       </span>
     </div>
     <span
-      class="navigation print"
+      class="Header__navigation Hidden__print"
     >
       <nav
         aria-labelledby="MainNavigation"
-        class="root divider"
+        class="Navigation__root Navigation__divider"
         role="navigation"
       >
         <span
-          class="root"
+          class="ScreenReaderOnly__root"
         >
           <h1
             id="MainNavigation"
@@ -5131,14 +5131,14 @@ exports[`Header: should render with locale of AU 1`] = `
           </h1>
         </span>
         <ul
-          class="list"
+          class="Navigation__list"
           data-automation="nav-tabs"
         >
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:jobs"
               href="/"
             >
@@ -5146,11 +5146,11 @@ exports[`Header: should render with locale of AU 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
               aria-label="One fifty K jobs"
-              class="link"
+              class="Navigation__link"
               data-analytics="header:high+salary"
               href="/150kjobs"
             >
@@ -5158,10 +5158,10 @@ exports[`Header: should render with locale of AU 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:profile"
               href="/profile/"
             >
@@ -5169,10 +5169,10 @@ exports[`Header: should render with locale of AU 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:companies"
               href="/companies/"
             >
@@ -5180,10 +5180,10 @@ exports[`Header: should render with locale of AU 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:advice"
               href="/career-advice/"
             >
@@ -5194,23 +5194,23 @@ exports[`Header: should render with locale of AU 1`] = `
       </nav>
     </span>
     <div
-      class="topBanner"
+      class="Header__topBanner"
     >
       <div
-        class="root mobile print"
+        class="PartnerSites__root Hidden__mobile Hidden__print"
       >
         <div
-          class="content"
+          class="PageBlock__content"
         >
           <div
-            class="content"
+            class="PartnerSites__content"
           >
             <nav
               aria-labelledby="Sites"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="Sites"
@@ -5219,11 +5219,11 @@ exports[`Header: should render with locale of AU 1`] = `
                 </h1>
               </span>
               <ul
-                class="list"
+                class="Sites__list"
               >
                 <li>
                   <span
-                    class="link link_isActive"
+                    class="Sites__link Sites__link_isActive"
                     title="SEEK Jobs"
                   >
                     Jobs
@@ -5231,7 +5231,7 @@ exports[`Header: should render with locale of AU 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isLearning"
+                    class="Sites__link Sites__link_isLearning"
                     data-analytics="header:courses"
                     href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     title="SEEK Learning"
@@ -5241,7 +5241,7 @@ exports[`Header: should render with locale of AU 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isBusiness"
+                    class="Sites__link Sites__link_isBusiness"
                     data-analytics="header:business+for+sale"
                     href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     title="SEEK Business"
@@ -5251,7 +5251,7 @@ exports[`Header: should render with locale of AU 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isVolunteering"
+                    class="Sites__link Sites__link_isVolunteering"
                     data-analytics="header:volunteering"
                     href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     title="SEEK Volunteer"
@@ -5262,14 +5262,14 @@ exports[`Header: should render with locale of AU 1`] = `
               </ul>
             </nav>
             <div
-              class="locale"
+              class="PartnerSites__locale"
             >
               <nav
                 aria-labelledby="Locales"
                 role="navigation"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   <h1
                     id="Locales"
@@ -5278,18 +5278,18 @@ exports[`Header: should render with locale of AU 1`] = `
                   </h1>
                 </span>
                 <ul
-                  class="list"
+                  class="Locales__list"
                 >
                   <li>
                     <span
-                      class="locale_isActive"
+                      class="Locales__locale_isActive"
                     >
                       AU
                     </span>
                   </li>
                   <li>
                     <a
-                      class="localeLink"
+                      class="Locales__localeLink"
                       data-analytics="header:nz+homepage"
                       href="https://www.seek.co.nz"
                       title="SEEK New Zealand"
@@ -5311,24 +5311,24 @@ exports[`Header: should render with locale of AU 1`] = `
 exports[`Header: should render with locale of NZ 1`] = `
 <header
   aria-label="Primary navigation"
-  class="root"
+  class="Header__root"
   role="banner"
 >
   <section
-    class="content"
+    class="Header__content"
   >
     <div
-      class="banner"
+      class="Header__banner"
     >
       <h1
-        class="logo"
+        class="Header__logo"
         data-automation="logo"
       >
         <div
           class=""
         >
           <svg
-            class="logoSvg root"
+            class="Header__logoSvg Logo__root"
             height="68.031"
             id="sk-logo-pos"
             viewBox="0 0 170.079 68.031"
@@ -5338,7 +5338,7 @@ exports[`Header: should render with locale of NZ 1`] = `
             y="0px"
           >
             <g
-              class="logoText"
+              class="Logo__logoText"
             >
               <path
                 d="M86.641,45.601c-3.697,0-7.037-0.408-10.012-3.385l3.834-3.833c1.942,1.938,4.467,2.208,6.269,2.208 c2.031,0,4.148-0.675,4.148-2.434c0-1.174-0.629-1.985-2.479-2.167l-3.699-0.36c-4.24-0.404-6.854-2.253-6.854-6.586 c0-4.869,4.282-7.485,9.064-7.485c3.653,0,6.72,0.632,8.976,2.75l-3.607,3.653c-1.354-1.217-3.43-1.576-5.459-1.576 c-2.344,0-3.336,1.082-3.336,2.254c0,0.857,0.361,1.85,2.436,2.03l3.7,0.361c4.643,0.45,6.992,2.932,6.992,6.9 C96.612,43.118,92.19,45.601,86.641,45.601z"
@@ -5354,45 +5354,45 @@ exports[`Header: should render with locale of NZ 1`] = `
               />
             </g>
             <path
-              class="logoIcon"
+              class="Logo__logoIcon"
               d="M34.015,1.51c-17.952,0-32.506,14.552-32.506,32.507c0,17.952,14.554,32.505,32.506,32.505 c17.958,0,32.508-14.553,32.508-32.505C66.523,16.062,51.972,1.51,34.015,1.51z M8.262,41.733c-0.281,0-0.511-0.226-0.511-0.504 c0-0.281,0.229-0.511,0.511-0.511c0.278,0,0.504,0.229,0.504,0.511C8.766,41.508,8.541,41.733,8.262,41.733z M8.262,34.907 c-0.281,0-0.511-0.229-0.511-0.51s0.229-0.509,0.511-0.509c0.278,0,0.504,0.228,0.504,0.509S8.541,34.907,8.262,34.907z M8.262,28.077c-0.281,0-0.511-0.229-0.511-0.509c0-0.281,0.229-0.507,0.511-0.507c0.278,0,0.504,0.226,0.504,0.507 C8.766,27.849,8.541,28.077,8.262,28.077z M11.764,41.991c-0.422,0-0.762-0.342-0.762-0.762c0-0.422,0.34-0.765,0.762-0.765 c0.421,0,0.762,0.343,0.762,0.765C12.526,41.649,12.186,41.991,11.764,41.991z M11.764,35.158c-0.422,0-0.762-0.339-0.762-0.761 c0-0.42,0.34-0.761,0.762-0.761c0.421,0,0.762,0.341,0.762,0.761C12.526,34.819,12.186,35.158,11.764,35.158z M11.764,28.33 c-0.422,0-0.762-0.341-0.762-0.762c0-0.422,0.34-0.763,0.762-0.763c0.421,0,0.762,0.341,0.762,0.763 C12.526,27.989,12.186,28.33,11.764,28.33z M15.867,42.246c-0.562,0-1.019-0.455-1.019-1.017c0-0.561,0.457-1.018,1.019-1.018 c0.558,0,1.016,0.457,1.016,1.018C16.882,41.791,16.424,42.246,15.867,42.246z M15.867,35.412c-0.562,0-1.019-0.453-1.019-1.015 c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016C16.882,34.959,16.424,35.412,15.867,35.412z M15.867,28.583 c-0.562,0-1.019-0.451-1.019-1.015c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016 C16.882,28.132,16.424,28.583,15.867,28.583z M20.18,42.497c-0.702,0-1.27-0.567-1.27-1.268c0-0.705,0.568-1.27,1.27-1.27 c0.704,0,1.27,0.564,1.27,1.27C21.45,41.93,20.884,42.497,20.18,42.497z M20.18,35.669c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.269,1.27-1.269c0.704,0,1.27,0.565,1.27,1.269S20.884,35.669,20.18,35.669z M20.18,28.84c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.271,1.27-1.271c0.704,0,1.27,0.567,1.27,1.271S20.884,28.84,20.18,28.84z M25.234,42.752c-0.842,0-1.523-0.681-1.523-1.522 c0-0.845,0.682-1.523,1.523-1.523c0.84,0,1.522,0.679,1.522,1.523C26.756,42.071,26.074,42.752,25.234,42.752z M25.234,35.922 c-0.842,0-1.523-0.684-1.523-1.524c0-0.842,0.682-1.523,1.523-1.523c0.84,0,1.522,0.682,1.522,1.523 C26.756,35.238,26.074,35.922,25.234,35.922z M25.234,29.093c-0.842,0-1.523-0.683-1.523-1.524s0.682-1.525,1.523-1.525 c0.84,0,1.522,0.684,1.522,1.525S26.074,29.093,25.234,29.093z M30.523,43.005c-0.983,0-1.778-0.792-1.778-1.775 c0-0.982,0.795-1.78,1.778-1.78c0.985,0,1.779,0.798,1.779,1.78C32.302,42.213,31.508,43.005,30.523,43.005z M30.523,36.176 c-0.983,0-1.778-0.796-1.778-1.778s0.795-1.776,1.778-1.776c0.985,0,1.779,0.794,1.779,1.776S31.508,36.176,30.523,36.176z M30.523,29.346c-0.983,0-1.778-0.796-1.778-1.777s0.795-1.776,1.778-1.776c0.985,0,1.779,0.795,1.779,1.776 S31.508,29.346,30.523,29.346z M36.812,56.922c-1.121,0-2.027-0.911-2.027-2.034c0-1.119,0.906-2.027,2.027-2.027 c1.125,0,2.035,0.908,2.035,2.027C38.847,56.011,37.938,56.922,36.812,56.922z M36.812,50.091c-1.121,0-2.027-0.91-2.027-2.03 c0-1.122,0.906-2.036,2.027-2.036c1.125,0,2.035,0.914,2.035,2.036C38.847,49.181,37.938,50.091,36.812,50.091z M36.812,43.26 c-1.121,0-2.027-0.909-2.027-2.03c0-1.123,0.906-2.033,2.027-2.033c1.125,0,2.035,0.91,2.035,2.033 C38.847,42.351,37.938,43.26,36.812,43.26z M36.812,36.43c-1.121,0-2.027-0.91-2.027-2.032c0-1.124,0.906-2.03,2.027-2.03 c1.125,0,2.035,0.906,2.035,2.03C38.847,35.52,37.938,36.43,36.812,36.43z M36.812,29.6c-1.121,0-2.027-0.908-2.027-2.031 c0-1.122,0.906-2.031,2.027-2.031c1.125,0,2.035,0.909,2.035,2.031C38.847,28.691,37.938,29.6,36.812,29.6z M36.812,22.77 c-1.121,0-2.027-0.912-2.027-2.032c0-1.123,0.906-2.03,2.027-2.03c1.125,0,2.035,0.907,2.035,2.03 C38.847,21.857,37.938,22.77,36.812,22.77z M36.812,15.938c-1.121,0-2.027-0.91-2.027-2.029c0-1.123,0.906-2.033,2.027-2.033 c1.125,0,2.035,0.91,2.035,2.033C38.847,15.027,37.938,15.938,36.812,15.938z M43.342,50.3c-1.233,0-2.238-1.002-2.238-2.239 c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242C45.585,49.298,44.582,50.3,43.342,50.3z M43.342,43.469 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,42.466,44.582,43.469,43.342,43.469z M43.342,36.64c-1.233,0-2.238-1.004-2.238-2.242c0-1.237,1.004-2.238,2.238-2.238 c1.24,0,2.243,1.001,2.243,2.238C45.585,35.636,44.582,36.64,43.342,36.64z M43.342,29.807c-1.233,0-2.238-1.002-2.238-2.238 c0-1.238,1.004-2.24,2.238-2.24c1.24,0,2.243,1.002,2.243,2.24C45.585,28.805,44.582,29.807,43.342,29.807z M43.342,22.977 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,21.974,44.582,22.977,43.342,22.977z M50.351,43.765c-1.393,0-2.517-1.126-2.517-2.517c0-1.389,1.124-2.516,2.517-2.516 c1.391,0,2.513,1.127,2.513,2.516C52.863,42.639,51.742,43.765,50.351,43.765z M50.351,36.933c-1.393,0-2.517-1.123-2.517-2.515 c0-1.386,1.124-2.517,2.517-2.517c1.391,0,2.513,1.131,2.513,2.517C52.863,35.81,51.742,36.933,50.351,36.933z M50.351,30.104 c-1.393,0-2.517-1.125-2.517-2.515c0-1.393,1.124-2.517,2.517-2.517c1.391,0,2.513,1.124,2.513,2.517 C52.863,28.979,51.742,30.104,50.351,30.104z M57.49,37.219c-1.519,0-2.756-1.234-2.756-2.754c0-1.523,1.238-2.757,2.756-2.757 c1.521,0,2.754,1.233,2.754,2.757C60.244,35.984,59.012,37.219,57.49,37.219z"
             />
           </svg>
         </div>
         <a
-          class="logoLink"
+          class="Header__logoLink"
           data-analytics="header:jobs"
           href="/"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             SEEK
           </span>
         </a>
       </h1>
       <span
-        class="logoNote screen"
+        class="Header__logoNote Hidden__screen"
       >
         Australia’s #1 job site
       </span>
       <span
-        class="userWrapper print"
+        class="Header__userWrapper Hidden__print"
       >
         <div
-          class="user"
+          class="Header__user"
         >
           <div
-            class="userAccountWrapper"
+            class="Header__userAccountWrapper"
           >
             <nav
               aria-labelledby="UserMenu"
-              class="root"
+              class="UserAccount__root"
               data-automation="user-account"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="UserMenu"
@@ -5402,32 +5402,32 @@ exports[`Header: should render with locale of NZ 1`] = `
               </span>
               <input
                 autocomplete="off"
-                class="toggle"
+                class="UserAccount__toggle"
                 id="user-account-menu-toggle"
                 type="checkbox"
               />
               <div
-                class="menuBackdrop"
+                class="UserAccount__menuBackdrop"
               >
                 <label
-                  class="menuBackdropLabel"
+                  class="UserAccount__menuBackdropLabel"
                   data-automation="user-account-menu-backdrop"
                   for="user-account-menu-toggle"
                 >
                   <span
-                    class="root"
+                    class="ScreenReaderOnly__root"
                   >
                     Show user menu
                   </span>
                 </label>
               </div>
               <label
-                class="toggleLabel"
+                class="UserAccount__toggleLabel"
                 data-automation="user-account-menu-toggle"
                 for="user-account-menu-toggle"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   Show user menu
                 </span>
@@ -5435,30 +5435,30 @@ exports[`Header: should render with locale of NZ 1`] = `
                   data-hj-masked="true"
                 >
                   <span
-                    class="mobileMenuLabel"
+                    class="UserAccount__mobileMenuLabel"
                   />
                   <span
-                    class="desktopMenuLabel"
+                    class="UserAccount__desktopMenuLabel"
                     data-automation="user-account-name"
                   />
                 </span>
                 <span
-                  class="root root chevron"
+                  class="Icon__root ChevronIcon__root UserAccount__chevron"
                 >
                   mock svg
                 </span>
               </label>
               <div
-                class="toggleContainer"
+                class="UserAccount__toggleContainer"
               >
                 <ul
-                  class="root"
+                  class="UserAccountMenu__root"
                 >
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:jobs"
                       href="/"
                     >
@@ -5466,7 +5466,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                         Job Search
                       </span>
                       <span
-                        class="root icon jobSearch"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__jobSearch"
                       >
                         mock svg
                       </span>
@@ -5476,7 +5476,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:profile"
                       href="/profile/"
                     >
@@ -5484,17 +5484,17 @@ exports[`Header: should render with locale of NZ 1`] = `
                         Profile
                       </span>
                       <span
-                        class="root icon profile"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__profile"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+searches"
                       href="/myactivity"
                     >
@@ -5502,7 +5502,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                         Saved Searches
                       </span>
                       <span
-                        class="root icon saveSearches"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveSearches"
                       >
                         mock svg
                       </span>
@@ -5512,45 +5512,45 @@ exports[`Header: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
                         Saved 
                         <span
-                          class="desktop"
+                          class="Hidden__desktop"
                         >
                           & Applied 
                         </span>
                         Jobs
                       </span>
                       <span
-                        class="root icon saveJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
                       Applied Jobs
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -5558,61 +5558,61 @@ exports[`Header: should render with locale of NZ 1`] = `
                         Recommended Jobs
                       </span>
                       <span
-                        class="root icon recommendedJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__recommendedJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:settings"
                       href="/settings/"
                     >
                       Settings
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <span
-                      class="item pendingAuth"
+                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="root _small"
+                        class="Loader__root Loader___small"
                       >
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                       </div>
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </span>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.co.nz/"
                     >
                       Employer Site
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
@@ -5621,15 +5621,15 @@ exports[`Header: should render with locale of NZ 1`] = `
             </nav>
           </div>
           <div
-            class="signInRegisterWrapper"
+            class="Header__signInRegisterWrapper"
           >
             <nav
               aria-labelledby="SignInOrRegister"
-              class="root"
+              class="SignInRegister__root"
               data-automation="sign-in-register"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="SignInOrRegister"
@@ -5638,7 +5638,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                 </h1>
               </span>
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:sign-in"
                 href="/sign-in"
                 rel="nofollow"
@@ -5648,7 +5648,7 @@ exports[`Header: should render with locale of NZ 1`] = `
               </a>
                or 
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:register"
                 href="/sign-up"
                 rel="nofollow"
@@ -5659,14 +5659,14 @@ exports[`Header: should render with locale of NZ 1`] = `
             </nav>
           </div>
           <span
-            class="divider"
+            class="Header__divider"
           />
         </div>
         <div
-          class="employerSite"
+          class="Header__employerSite"
         >
           <a
-            class="employerLink"
+            class="Header__employerLink"
             data-analytics="header:employer+site"
             href="https://talent.seek.co.nz/"
           >
@@ -5676,15 +5676,15 @@ exports[`Header: should render with locale of NZ 1`] = `
       </span>
     </div>
     <span
-      class="navigation print"
+      class="Header__navigation Hidden__print"
     >
       <nav
         aria-labelledby="MainNavigation"
-        class="root divider"
+        class="Navigation__root Navigation__divider"
         role="navigation"
       >
         <span
-          class="root"
+          class="ScreenReaderOnly__root"
         >
           <h1
             id="MainNavigation"
@@ -5693,14 +5693,14 @@ exports[`Header: should render with locale of NZ 1`] = `
           </h1>
         </span>
         <ul
-          class="list"
+          class="Navigation__list"
           data-automation="nav-tabs"
         >
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:jobs"
               href="/"
             >
@@ -5708,10 +5708,10 @@ exports[`Header: should render with locale of NZ 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:profile"
               href="/profile/"
             >
@@ -5719,10 +5719,10 @@ exports[`Header: should render with locale of NZ 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:advice"
               href="/career-advice/"
             >
@@ -5733,23 +5733,23 @@ exports[`Header: should render with locale of NZ 1`] = `
       </nav>
     </span>
     <div
-      class="topBanner"
+      class="Header__topBanner"
     >
       <div
-        class="root mobile print"
+        class="PartnerSites__root Hidden__mobile Hidden__print"
       >
         <div
-          class="content"
+          class="PageBlock__content"
         >
           <div
-            class="content"
+            class="PartnerSites__content"
           >
             <nav
               aria-labelledby="Sites"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="Sites"
@@ -5758,11 +5758,11 @@ exports[`Header: should render with locale of NZ 1`] = `
                 </h1>
               </span>
               <ul
-                class="list"
+                class="Sites__list"
               >
                 <li>
                   <span
-                    class="link link_isActive"
+                    class="Sites__link Sites__link_isActive"
                     title="SEEK Jobs"
                   >
                     Jobs
@@ -5770,7 +5770,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isLearning"
+                    class="Sites__link Sites__link_isLearning"
                     data-analytics="header:courses"
                     href="https://www.seeklearning.co.nz/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     title="SEEK Learning"
@@ -5780,7 +5780,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isBusiness"
+                    class="Sites__link Sites__link_isBusiness"
                     data-analytics="header:business+for+sale"
                     href="https://www.seekbusiness.com.au/?site=nz&tracking=sk:main:nz:nav:bus"
                     title="SEEK Business"
@@ -5790,7 +5790,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isVolunteering"
+                    class="Sites__link Sites__link_isVolunteering"
                     data-analytics="header:volunteering"
                     href="https://seekvolunteer.co.nz/?tracking=SKMNZ:main+header"
                     title="SEEK Volunteer"
@@ -5801,14 +5801,14 @@ exports[`Header: should render with locale of NZ 1`] = `
               </ul>
             </nav>
             <div
-              class="locale"
+              class="PartnerSites__locale"
             >
               <nav
                 aria-labelledby="Locales"
                 role="navigation"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   <h1
                     id="Locales"
@@ -5817,11 +5817,11 @@ exports[`Header: should render with locale of NZ 1`] = `
                   </h1>
                 </span>
                 <ul
-                  class="list list_isNZ"
+                  class="Locales__list Locales__list_isNZ"
                 >
                   <li>
                     <a
-                      class="localeLink"
+                      class="Locales__localeLink"
                       data-analytics="header:au+homepage"
                       href="https://www.seek.com.au"
                       title="SEEK Australia"
@@ -5831,7 +5831,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                   </li>
                   <li>
                     <span
-                      class="locale_isActive"
+                      class="Locales__locale_isActive"
                     >
                       NZ
                     </span>
@@ -5850,24 +5850,24 @@ exports[`Header: should render with locale of NZ 1`] = `
 exports[`Header: should render with no divider 1`] = `
 <header
   aria-label="Primary navigation"
-  class="root"
+  class="Header__root"
   role="banner"
 >
   <section
-    class="content"
+    class="Header__content"
   >
     <div
-      class="banner"
+      class="Header__banner"
     >
       <h1
-        class="logo"
+        class="Header__logo"
         data-automation="logo"
       >
         <div
           class=""
         >
           <svg
-            class="logoSvg root"
+            class="Header__logoSvg Logo__root"
             height="68.031"
             id="sk-logo-pos"
             viewBox="0 0 170.079 68.031"
@@ -5877,7 +5877,7 @@ exports[`Header: should render with no divider 1`] = `
             y="0px"
           >
             <g
-              class="logoText"
+              class="Logo__logoText"
             >
               <path
                 d="M86.641,45.601c-3.697,0-7.037-0.408-10.012-3.385l3.834-3.833c1.942,1.938,4.467,2.208,6.269,2.208 c2.031,0,4.148-0.675,4.148-2.434c0-1.174-0.629-1.985-2.479-2.167l-3.699-0.36c-4.24-0.404-6.854-2.253-6.854-6.586 c0-4.869,4.282-7.485,9.064-7.485c3.653,0,6.72,0.632,8.976,2.75l-3.607,3.653c-1.354-1.217-3.43-1.576-5.459-1.576 c-2.344,0-3.336,1.082-3.336,2.254c0,0.857,0.361,1.85,2.436,2.03l3.7,0.361c4.643,0.45,6.992,2.932,6.992,6.9 C96.612,43.118,92.19,45.601,86.641,45.601z"
@@ -5893,45 +5893,45 @@ exports[`Header: should render with no divider 1`] = `
               />
             </g>
             <path
-              class="logoIcon"
+              class="Logo__logoIcon"
               d="M34.015,1.51c-17.952,0-32.506,14.552-32.506,32.507c0,17.952,14.554,32.505,32.506,32.505 c17.958,0,32.508-14.553,32.508-32.505C66.523,16.062,51.972,1.51,34.015,1.51z M8.262,41.733c-0.281,0-0.511-0.226-0.511-0.504 c0-0.281,0.229-0.511,0.511-0.511c0.278,0,0.504,0.229,0.504,0.511C8.766,41.508,8.541,41.733,8.262,41.733z M8.262,34.907 c-0.281,0-0.511-0.229-0.511-0.51s0.229-0.509,0.511-0.509c0.278,0,0.504,0.228,0.504,0.509S8.541,34.907,8.262,34.907z M8.262,28.077c-0.281,0-0.511-0.229-0.511-0.509c0-0.281,0.229-0.507,0.511-0.507c0.278,0,0.504,0.226,0.504,0.507 C8.766,27.849,8.541,28.077,8.262,28.077z M11.764,41.991c-0.422,0-0.762-0.342-0.762-0.762c0-0.422,0.34-0.765,0.762-0.765 c0.421,0,0.762,0.343,0.762,0.765C12.526,41.649,12.186,41.991,11.764,41.991z M11.764,35.158c-0.422,0-0.762-0.339-0.762-0.761 c0-0.42,0.34-0.761,0.762-0.761c0.421,0,0.762,0.341,0.762,0.761C12.526,34.819,12.186,35.158,11.764,35.158z M11.764,28.33 c-0.422,0-0.762-0.341-0.762-0.762c0-0.422,0.34-0.763,0.762-0.763c0.421,0,0.762,0.341,0.762,0.763 C12.526,27.989,12.186,28.33,11.764,28.33z M15.867,42.246c-0.562,0-1.019-0.455-1.019-1.017c0-0.561,0.457-1.018,1.019-1.018 c0.558,0,1.016,0.457,1.016,1.018C16.882,41.791,16.424,42.246,15.867,42.246z M15.867,35.412c-0.562,0-1.019-0.453-1.019-1.015 c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016C16.882,34.959,16.424,35.412,15.867,35.412z M15.867,28.583 c-0.562,0-1.019-0.451-1.019-1.015c0-0.562,0.457-1.016,1.019-1.016c0.558,0,1.016,0.453,1.016,1.016 C16.882,28.132,16.424,28.583,15.867,28.583z M20.18,42.497c-0.702,0-1.27-0.567-1.27-1.268c0-0.705,0.568-1.27,1.27-1.27 c0.704,0,1.27,0.564,1.27,1.27C21.45,41.93,20.884,42.497,20.18,42.497z M20.18,35.669c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.269,1.27-1.269c0.704,0,1.27,0.565,1.27,1.269S20.884,35.669,20.18,35.669z M20.18,28.84c-0.702,0-1.27-0.568-1.27-1.271 s0.568-1.271,1.27-1.271c0.704,0,1.27,0.567,1.27,1.271S20.884,28.84,20.18,28.84z M25.234,42.752c-0.842,0-1.523-0.681-1.523-1.522 c0-0.845,0.682-1.523,1.523-1.523c0.84,0,1.522,0.679,1.522,1.523C26.756,42.071,26.074,42.752,25.234,42.752z M25.234,35.922 c-0.842,0-1.523-0.684-1.523-1.524c0-0.842,0.682-1.523,1.523-1.523c0.84,0,1.522,0.682,1.522,1.523 C26.756,35.238,26.074,35.922,25.234,35.922z M25.234,29.093c-0.842,0-1.523-0.683-1.523-1.524s0.682-1.525,1.523-1.525 c0.84,0,1.522,0.684,1.522,1.525S26.074,29.093,25.234,29.093z M30.523,43.005c-0.983,0-1.778-0.792-1.778-1.775 c0-0.982,0.795-1.78,1.778-1.78c0.985,0,1.779,0.798,1.779,1.78C32.302,42.213,31.508,43.005,30.523,43.005z M30.523,36.176 c-0.983,0-1.778-0.796-1.778-1.778s0.795-1.776,1.778-1.776c0.985,0,1.779,0.794,1.779,1.776S31.508,36.176,30.523,36.176z M30.523,29.346c-0.983,0-1.778-0.796-1.778-1.777s0.795-1.776,1.778-1.776c0.985,0,1.779,0.795,1.779,1.776 S31.508,29.346,30.523,29.346z M36.812,56.922c-1.121,0-2.027-0.911-2.027-2.034c0-1.119,0.906-2.027,2.027-2.027 c1.125,0,2.035,0.908,2.035,2.027C38.847,56.011,37.938,56.922,36.812,56.922z M36.812,50.091c-1.121,0-2.027-0.91-2.027-2.03 c0-1.122,0.906-2.036,2.027-2.036c1.125,0,2.035,0.914,2.035,2.036C38.847,49.181,37.938,50.091,36.812,50.091z M36.812,43.26 c-1.121,0-2.027-0.909-2.027-2.03c0-1.123,0.906-2.033,2.027-2.033c1.125,0,2.035,0.91,2.035,2.033 C38.847,42.351,37.938,43.26,36.812,43.26z M36.812,36.43c-1.121,0-2.027-0.91-2.027-2.032c0-1.124,0.906-2.03,2.027-2.03 c1.125,0,2.035,0.906,2.035,2.03C38.847,35.52,37.938,36.43,36.812,36.43z M36.812,29.6c-1.121,0-2.027-0.908-2.027-2.031 c0-1.122,0.906-2.031,2.027-2.031c1.125,0,2.035,0.909,2.035,2.031C38.847,28.691,37.938,29.6,36.812,29.6z M36.812,22.77 c-1.121,0-2.027-0.912-2.027-2.032c0-1.123,0.906-2.03,2.027-2.03c1.125,0,2.035,0.907,2.035,2.03 C38.847,21.857,37.938,22.77,36.812,22.77z M36.812,15.938c-1.121,0-2.027-0.91-2.027-2.029c0-1.123,0.906-2.033,2.027-2.033 c1.125,0,2.035,0.91,2.035,2.033C38.847,15.027,37.938,15.938,36.812,15.938z M43.342,50.3c-1.233,0-2.238-1.002-2.238-2.239 c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242C45.585,49.298,44.582,50.3,43.342,50.3z M43.342,43.469 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,42.466,44.582,43.469,43.342,43.469z M43.342,36.64c-1.233,0-2.238-1.004-2.238-2.242c0-1.237,1.004-2.238,2.238-2.238 c1.24,0,2.243,1.001,2.243,2.238C45.585,35.636,44.582,36.64,43.342,36.64z M43.342,29.807c-1.233,0-2.238-1.002-2.238-2.238 c0-1.238,1.004-2.24,2.238-2.24c1.24,0,2.243,1.002,2.243,2.24C45.585,28.805,44.582,29.807,43.342,29.807z M43.342,22.977 c-1.233,0-2.238-1.003-2.238-2.239c0-1.239,1.004-2.242,2.238-2.242c1.24,0,2.243,1.003,2.243,2.242 C45.585,21.974,44.582,22.977,43.342,22.977z M50.351,43.765c-1.393,0-2.517-1.126-2.517-2.517c0-1.389,1.124-2.516,2.517-2.516 c1.391,0,2.513,1.127,2.513,2.516C52.863,42.639,51.742,43.765,50.351,43.765z M50.351,36.933c-1.393,0-2.517-1.123-2.517-2.515 c0-1.386,1.124-2.517,2.517-2.517c1.391,0,2.513,1.131,2.513,2.517C52.863,35.81,51.742,36.933,50.351,36.933z M50.351,30.104 c-1.393,0-2.517-1.125-2.517-2.515c0-1.393,1.124-2.517,2.517-2.517c1.391,0,2.513,1.124,2.513,2.517 C52.863,28.979,51.742,30.104,50.351,30.104z M57.49,37.219c-1.519,0-2.756-1.234-2.756-2.754c0-1.523,1.238-2.757,2.756-2.757 c1.521,0,2.754,1.233,2.754,2.757C60.244,35.984,59.012,37.219,57.49,37.219z"
             />
           </svg>
         </div>
         <a
-          class="logoLink"
+          class="Header__logoLink"
           data-analytics="header:jobs"
           href="/"
         >
           <span
-            class="root"
+            class="ScreenReaderOnly__root"
           >
             SEEK
           </span>
         </a>
       </h1>
       <span
-        class="logoNote screen"
+        class="Header__logoNote Hidden__screen"
       >
         Australia’s #1 job site
       </span>
       <span
-        class="userWrapper print"
+        class="Header__userWrapper Hidden__print"
       >
         <div
-          class="user"
+          class="Header__user"
         >
           <div
-            class="userAccountWrapper"
+            class="Header__userAccountWrapper"
           >
             <nav
               aria-labelledby="UserMenu"
-              class="root"
+              class="UserAccount__root"
               data-automation="user-account"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="UserMenu"
@@ -5941,32 +5941,32 @@ exports[`Header: should render with no divider 1`] = `
               </span>
               <input
                 autocomplete="off"
-                class="toggle"
+                class="UserAccount__toggle"
                 id="user-account-menu-toggle"
                 type="checkbox"
               />
               <div
-                class="menuBackdrop"
+                class="UserAccount__menuBackdrop"
               >
                 <label
-                  class="menuBackdropLabel"
+                  class="UserAccount__menuBackdropLabel"
                   data-automation="user-account-menu-backdrop"
                   for="user-account-menu-toggle"
                 >
                   <span
-                    class="root"
+                    class="ScreenReaderOnly__root"
                   >
                     Show user menu
                   </span>
                 </label>
               </div>
               <label
-                class="toggleLabel"
+                class="UserAccount__toggleLabel"
                 data-automation="user-account-menu-toggle"
                 for="user-account-menu-toggle"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   Show user menu
                 </span>
@@ -5974,30 +5974,30 @@ exports[`Header: should render with no divider 1`] = `
                   data-hj-masked="true"
                 >
                   <span
-                    class="mobileMenuLabel"
+                    class="UserAccount__mobileMenuLabel"
                   />
                   <span
-                    class="desktopMenuLabel"
+                    class="UserAccount__desktopMenuLabel"
                     data-automation="user-account-name"
                   />
                 </span>
                 <span
-                  class="root root chevron"
+                  class="Icon__root ChevronIcon__root UserAccount__chevron"
                 >
                   mock svg
                 </span>
               </label>
               <div
-                class="toggleContainer"
+                class="UserAccount__toggleContainer"
               >
                 <ul
-                  class="root"
+                  class="UserAccountMenu__root"
                 >
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:jobs"
                       href="/"
                     >
@@ -6005,7 +6005,7 @@ exports[`Header: should render with no divider 1`] = `
                         Job Search
                       </span>
                       <span
-                        class="root icon jobSearch"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__jobSearch"
                       >
                         mock svg
                       </span>
@@ -6015,7 +6015,7 @@ exports[`Header: should render with no divider 1`] = `
                     class=""
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:profile"
                       href="/profile/"
                     >
@@ -6023,17 +6023,17 @@ exports[`Header: should render with no divider 1`] = `
                         Profile
                       </span>
                       <span
-                        class="root icon profile"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__profile"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+searches"
                       href="/myactivity"
                     >
@@ -6041,7 +6041,7 @@ exports[`Header: should render with no divider 1`] = `
                         Saved Searches
                       </span>
                       <span
-                        class="root icon saveSearches"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveSearches"
                       >
                         mock svg
                       </span>
@@ -6051,45 +6051,45 @@ exports[`Header: should render with no divider 1`] = `
                     class=""
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
                         Saved 
                         <span
-                          class="desktop"
+                          class="Hidden__desktop"
                         >
                           & Applied 
                         </span>
                         Jobs
                       </span>
                       <span
-                        class="root icon saveJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
                       Applied Jobs
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -6097,89 +6097,89 @@ exports[`Header: should render with no divider 1`] = `
                         Recommended Jobs
                       </span>
                       <span
-                        class="root icon recommendedJobs"
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__recommendedJobs"
                       >
                         mock svg
                       </span>
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item subItem"
+                      class="UserAccountMenu__item UserAccountMenu__subItem"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
                       Company Reviews
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="mobile"
+                    class="Hidden__mobile"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:settings"
                       href="/settings/"
                     >
                       Settings
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <span
-                      class="item pendingAuth"
+                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="root _small"
+                        class="Loader__root Loader___small"
                       >
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                         <div
-                          class="ball"
+                          class="Loader__ball"
                         />
                       </div>
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </span>
                   </li>
                   <li
-                    class="firstItemInGroup desktop"
+                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:advice"
                       href="/career-advice/"
                     >
                       Career Advice
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
                   <li
-                    class="desktop"
+                    class="Hidden__desktop"
                   >
                     <a
-                      class="item"
+                      class="UserAccountMenu__item"
                       data-analytics="header:employer+site"
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
                       <div
-                        class="iconSpacer"
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
@@ -6188,15 +6188,15 @@ exports[`Header: should render with no divider 1`] = `
             </nav>
           </div>
           <div
-            class="signInRegisterWrapper"
+            class="Header__signInRegisterWrapper"
           >
             <nav
               aria-labelledby="SignInOrRegister"
-              class="root"
+              class="SignInRegister__root"
               data-automation="sign-in-register"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="SignInOrRegister"
@@ -6205,7 +6205,7 @@ exports[`Header: should render with no divider 1`] = `
                 </h1>
               </span>
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:sign-in"
                 href="/sign-in"
                 rel="nofollow"
@@ -6215,7 +6215,7 @@ exports[`Header: should render with no divider 1`] = `
               </a>
                or 
               <a
-                class="link"
+                class="SignInRegister__link"
                 data-analytics="header:register"
                 href="/sign-up"
                 rel="nofollow"
@@ -6226,14 +6226,14 @@ exports[`Header: should render with no divider 1`] = `
             </nav>
           </div>
           <span
-            class="divider"
+            class="Header__divider"
           />
         </div>
         <div
-          class="employerSite"
+          class="Header__employerSite"
         >
           <a
-            class="employerLink"
+            class="Header__employerLink"
             data-analytics="header:employer+site"
             href="https://talent.seek.com.au/"
           >
@@ -6243,15 +6243,15 @@ exports[`Header: should render with no divider 1`] = `
       </span>
     </div>
     <span
-      class="navigation print"
+      class="Header__navigation Hidden__print"
     >
       <nav
         aria-labelledby="MainNavigation"
-        class="root"
+        class="Navigation__root"
         role="navigation"
       >
         <span
-          class="root"
+          class="ScreenReaderOnly__root"
         >
           <h1
             id="MainNavigation"
@@ -6260,14 +6260,14 @@ exports[`Header: should render with no divider 1`] = `
           </h1>
         </span>
         <ul
-          class="list"
+          class="Navigation__list"
           data-automation="nav-tabs"
         >
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:jobs"
               href="/"
             >
@@ -6275,11 +6275,11 @@ exports[`Header: should render with no divider 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
               aria-label="One fifty K jobs"
-              class="link"
+              class="Navigation__link"
               data-analytics="header:high+salary"
               href="/150kjobs"
             >
@@ -6287,10 +6287,10 @@ exports[`Header: should render with no divider 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:profile"
               href="/profile/"
             >
@@ -6298,10 +6298,10 @@ exports[`Header: should render with no divider 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:companies"
               href="/companies/"
             >
@@ -6309,10 +6309,10 @@ exports[`Header: should render with no divider 1`] = `
             </a>
           </li>
           <li
-            class="item"
+            class="Navigation__item"
           >
             <a
-              class="link"
+              class="Navigation__link"
               data-analytics="header:advice"
               href="/career-advice/"
             >
@@ -6323,23 +6323,23 @@ exports[`Header: should render with no divider 1`] = `
       </nav>
     </span>
     <div
-      class="topBanner"
+      class="Header__topBanner"
     >
       <div
-        class="root mobile print"
+        class="PartnerSites__root Hidden__mobile Hidden__print"
       >
         <div
-          class="content"
+          class="PageBlock__content"
         >
           <div
-            class="content"
+            class="PartnerSites__content"
           >
             <nav
               aria-labelledby="Sites"
               role="navigation"
             >
               <span
-                class="root"
+                class="ScreenReaderOnly__root"
               >
                 <h1
                   id="Sites"
@@ -6348,11 +6348,11 @@ exports[`Header: should render with no divider 1`] = `
                 </h1>
               </span>
               <ul
-                class="list"
+                class="Sites__list"
               >
                 <li>
                   <span
-                    class="link link_isActive"
+                    class="Sites__link Sites__link_isActive"
                     title="SEEK Jobs"
                   >
                     Jobs
@@ -6360,7 +6360,7 @@ exports[`Header: should render with no divider 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isLearning"
+                    class="Sites__link Sites__link_isLearning"
                     data-analytics="header:courses"
                     href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
                     title="SEEK Learning"
@@ -6370,7 +6370,7 @@ exports[`Header: should render with no divider 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isBusiness"
+                    class="Sites__link Sites__link_isBusiness"
                     data-analytics="header:business+for+sale"
                     href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
                     title="SEEK Business"
@@ -6380,7 +6380,7 @@ exports[`Header: should render with no divider 1`] = `
                 </li>
                 <li>
                   <a
-                    class="link link_isVolunteering"
+                    class="Sites__link Sites__link_isVolunteering"
                     data-analytics="header:volunteering"
                     href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
                     title="SEEK Volunteer"
@@ -6391,14 +6391,14 @@ exports[`Header: should render with no divider 1`] = `
               </ul>
             </nav>
             <div
-              class="locale"
+              class="PartnerSites__locale"
             >
               <nav
                 aria-labelledby="Locales"
                 role="navigation"
               >
                 <span
-                  class="root"
+                  class="ScreenReaderOnly__root"
                 >
                   <h1
                     id="Locales"
@@ -6407,18 +6407,18 @@ exports[`Header: should render with no divider 1`] = `
                   </h1>
                 </span>
                 <ul
-                  class="list"
+                  class="Locales__list"
                 >
                   <li>
                     <span
-                      class="locale_isActive"
+                      class="Locales__locale_isActive"
                     >
                       AU
                     </span>
                   </li>
                   <li>
                     <a
-                      class="localeLink"
+                      class="Locales__localeLink"
                       data-analytics="header:nz+homepage"
                       href="https://www.seek.co.nz"
                       title="SEEK New Zealand"

--- a/react/Hidden/__snapshots__/Hidden.test.js.snap
+++ b/react/Hidden/__snapshots__/Hidden.test.js.snap
@@ -26,7 +26,7 @@ exports[`components/grid/hidden should render with component 1`] = `
 
 exports[`components/grid/hidden should render with desktop 1`] = `
 <span
-  className="desktop"
+  className="Hidden__desktop"
 >
   Text
 </span>
@@ -34,7 +34,7 @@ exports[`components/grid/hidden should render with desktop 1`] = `
 
 exports[`components/grid/hidden should render with mobile 1`] = `
 <span
-  className="mobile"
+  className="Hidden__mobile"
 >
   Text
 </span>
@@ -42,7 +42,7 @@ exports[`components/grid/hidden should render with mobile 1`] = `
 
 exports[`components/grid/hidden should render with print 1`] = `
 <span
-  className="print"
+  className="Hidden__print"
 >
   Text
 </span>
@@ -59,7 +59,7 @@ exports[`components/grid/hidden should render with props 1`] = `
 
 exports[`components/grid/hidden should render with screen 1`] = `
 <span
-  className="screen"
+  className="Hidden__screen"
 >
   Text
 </span>

--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.test.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.test.js
@@ -34,8 +34,8 @@ describe('CustomMonthPicker', () => {
   function render(jsx) {
     element = jsx;
     monthPicker = renderer.render(element);
-    monthDropdown = findAllWithClass(monthPicker, 'dropdown')[0] || null;
-    yearDropdown = findAllWithClass(monthPicker, 'dropdown')[1] || null;
+    monthDropdown = findAllWithClass(monthPicker, 'CustomMonthPicker__dropdown')[0] || null;
+    yearDropdown = findAllWithClass(monthPicker, 'CustomMonthPicker__dropdown')[1] || null;
   }
 
   function renderToDom(jsx) {

--- a/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.test.js
+++ b/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.test.js
@@ -33,14 +33,14 @@ describe('NativeMonthPicker', () => {
   function render(jsx) {
     element = jsx;
     monthPicker = renderer.render(element);
-    rootElement = findAllWithClass(monthPicker, 'root')[0] || null;
-    input = findAllWithClass(monthPicker, 'input')[0] || null;
+    rootElement = findAllWithClass(monthPicker, 'NativeMonthPicker__root')[0] || null;
+    input = findAllWithClass(monthPicker, 'NativeMonthPicker__input')[0] || null;
   }
 
   function renderToDom(jsx) {
     element = jsx;
     monthPicker = renderIntoDocument(element);
-    input = findRenderedDOMComponentWithClass(monthPicker, 'input');
+    input = findRenderedDOMComponentWithClass(monthPicker, 'NativeMonthPicker__input');
   }
 
   it('should have a displayName', () => {

--- a/react/PartnerSites/Locales/__snapshots__/Locales.test.js.snap
+++ b/react/PartnerSites/Locales/__snapshots__/Locales.test.js.snap
@@ -6,7 +6,7 @@ exports[`Locales: should render with locale of AU first and active 1`] = `
   role="navigation"
 >
   <span
-    class="root"
+    class="ScreenReaderOnly__root"
   >
     <h1
       id="Locales"
@@ -15,18 +15,18 @@ exports[`Locales: should render with locale of AU first and active 1`] = `
     </h1>
   </span>
   <ul
-    class="list"
+    class="Locales__list"
   >
     <li>
       <span
-        class="locale_isActive"
+        class="Locales__locale_isActive"
       >
         AU
       </span>
     </li>
     <li>
       <a
-        class="localeLink"
+        class="Locales__localeLink"
         data-analytics="header:nz+homepage"
         href="https://www.seek.co.nz"
         title="SEEK New Zealand"
@@ -44,7 +44,7 @@ exports[`Locales: should render with locale of NZ first and active 1`] = `
   role="navigation"
 >
   <span
-    class="root"
+    class="ScreenReaderOnly__root"
   >
     <h1
       id="Locales"
@@ -53,11 +53,11 @@ exports[`Locales: should render with locale of NZ first and active 1`] = `
     </h1>
   </span>
   <ul
-    class="list list_isNZ"
+    class="Locales__list Locales__list_isNZ"
   >
     <li>
       <a
-        class="localeLink"
+        class="Locales__localeLink"
         data-analytics="header:au+homepage"
         href="https://www.seek.com.au"
         title="SEEK Australia"
@@ -67,7 +67,7 @@ exports[`Locales: should render with locale of NZ first and active 1`] = `
     </li>
     <li>
       <span
-        class="locale_isActive"
+        class="Locales__locale_isActive"
       >
         NZ
       </span>

--- a/react/PartnerSites/Sites/__snapshots__/Sites.test.js.snap
+++ b/react/PartnerSites/Sites/__snapshots__/Sites.test.js.snap
@@ -6,7 +6,7 @@ exports[`Sites: active product states: should render with businesses link as act
   role="navigation"
 >
   <span
-    class="root"
+    class="ScreenReaderOnly__root"
   >
     <h1
       id="Sites"
@@ -15,11 +15,11 @@ exports[`Sites: active product states: should render with businesses link as act
     </h1>
   </span>
   <ul
-    class="list"
+    class="Sites__list"
   >
     <li>
       <a
-        class="link link_isJobs"
+        class="Sites__link Sites__link_isJobs"
         data-analytics="header:jobs"
         href="https://www.seek.com.au"
         title="SEEK Jobs"
@@ -29,7 +29,7 @@ exports[`Sites: active product states: should render with businesses link as act
     </li>
     <li>
       <a
-        class="link link_isLearning"
+        class="Sites__link Sites__link_isLearning"
         data-analytics="header:courses"
         href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
         title="SEEK Learning"
@@ -39,7 +39,7 @@ exports[`Sites: active product states: should render with businesses link as act
     </li>
     <li>
       <a
-        class="link link_isBusiness"
+        class="Sites__link Sites__link_isBusiness"
         data-analytics="header:business+for+sale"
         href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
         title="SEEK Business"
@@ -49,7 +49,7 @@ exports[`Sites: active product states: should render with businesses link as act
     </li>
     <li>
       <a
-        class="link link_isVolunteering"
+        class="Sites__link Sites__link_isVolunteering"
         data-analytics="header:volunteering"
         href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
         title="SEEK Volunteer"
@@ -67,7 +67,7 @@ exports[`Sites: active product states: should render with courses link as active
   role="navigation"
 >
   <span
-    class="root"
+    class="ScreenReaderOnly__root"
   >
     <h1
       id="Sites"
@@ -76,11 +76,11 @@ exports[`Sites: active product states: should render with courses link as active
     </h1>
   </span>
   <ul
-    class="list"
+    class="Sites__list"
   >
     <li>
       <a
-        class="link link_isJobs"
+        class="Sites__link Sites__link_isJobs"
         data-analytics="header:jobs"
         href="https://www.seek.com.au"
         title="SEEK Jobs"
@@ -90,7 +90,7 @@ exports[`Sites: active product states: should render with courses link as active
     </li>
     <li>
       <a
-        class="link link_isLearning"
+        class="Sites__link Sites__link_isLearning"
         data-analytics="header:courses"
         href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
         title="SEEK Learning"
@@ -100,7 +100,7 @@ exports[`Sites: active product states: should render with courses link as active
     </li>
     <li>
       <a
-        class="link link_isBusiness"
+        class="Sites__link Sites__link_isBusiness"
         data-analytics="header:business+for+sale"
         href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
         title="SEEK Business"
@@ -110,7 +110,7 @@ exports[`Sites: active product states: should render with courses link as active
     </li>
     <li>
       <a
-        class="link link_isVolunteering"
+        class="Sites__link Sites__link_isVolunteering"
         data-analytics="header:volunteering"
         href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
         title="SEEK Volunteer"
@@ -128,7 +128,7 @@ exports[`Sites: active product states: should render with jobs link as active 1`
   role="navigation"
 >
   <span
-    class="root"
+    class="ScreenReaderOnly__root"
   >
     <h1
       id="Sites"
@@ -137,11 +137,11 @@ exports[`Sites: active product states: should render with jobs link as active 1`
     </h1>
   </span>
   <ul
-    class="list"
+    class="Sites__list"
   >
     <li>
       <a
-        class="link link_isJobs"
+        class="Sites__link Sites__link_isJobs"
         data-analytics="header:jobs"
         href="https://www.seek.com.au"
         title="SEEK Jobs"
@@ -151,7 +151,7 @@ exports[`Sites: active product states: should render with jobs link as active 1`
     </li>
     <li>
       <a
-        class="link link_isLearning"
+        class="Sites__link Sites__link_isLearning"
         data-analytics="header:courses"
         href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
         title="SEEK Learning"
@@ -161,7 +161,7 @@ exports[`Sites: active product states: should render with jobs link as active 1`
     </li>
     <li>
       <a
-        class="link link_isBusiness"
+        class="Sites__link Sites__link_isBusiness"
         data-analytics="header:business+for+sale"
         href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
         title="SEEK Business"
@@ -171,7 +171,7 @@ exports[`Sites: active product states: should render with jobs link as active 1`
     </li>
     <li>
       <a
-        class="link link_isVolunteering"
+        class="Sites__link Sites__link_isVolunteering"
         data-analytics="header:volunteering"
         href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
         title="SEEK Volunteer"
@@ -189,7 +189,7 @@ exports[`Sites: active product states: should render with no link as active by d
   role="navigation"
 >
   <span
-    class="root"
+    class="ScreenReaderOnly__root"
   >
     <h1
       id="Sites"
@@ -198,11 +198,11 @@ exports[`Sites: active product states: should render with no link as active by d
     </h1>
   </span>
   <ul
-    class="list"
+    class="Sites__list"
   >
     <li>
       <a
-        class="link link_isJobs"
+        class="Sites__link Sites__link_isJobs"
         data-analytics="header:jobs"
         href="https://www.seek.com.au"
         title="SEEK Jobs"
@@ -212,7 +212,7 @@ exports[`Sites: active product states: should render with no link as active by d
     </li>
     <li>
       <a
-        class="link link_isLearning"
+        class="Sites__link Sites__link_isLearning"
         data-analytics="header:courses"
         href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
         title="SEEK Learning"
@@ -222,7 +222,7 @@ exports[`Sites: active product states: should render with no link as active by d
     </li>
     <li>
       <a
-        class="link link_isBusiness"
+        class="Sites__link Sites__link_isBusiness"
         data-analytics="header:business+for+sale"
         href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
         title="SEEK Business"
@@ -232,7 +232,7 @@ exports[`Sites: active product states: should render with no link as active by d
     </li>
     <li>
       <a
-        class="link link_isVolunteering"
+        class="Sites__link Sites__link_isVolunteering"
         data-analytics="header:volunteering"
         href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
         title="SEEK Volunteer"
@@ -250,7 +250,7 @@ exports[`Sites: active product states: should render with volunteering link as a
   role="navigation"
 >
   <span
-    class="root"
+    class="ScreenReaderOnly__root"
   >
     <h1
       id="Sites"
@@ -259,11 +259,11 @@ exports[`Sites: active product states: should render with volunteering link as a
     </h1>
   </span>
   <ul
-    class="list"
+    class="Sites__list"
   >
     <li>
       <a
-        class="link link_isJobs"
+        class="Sites__link Sites__link_isJobs"
         data-analytics="header:jobs"
         href="https://www.seek.com.au"
         title="SEEK Jobs"
@@ -273,7 +273,7 @@ exports[`Sites: active product states: should render with volunteering link as a
     </li>
     <li>
       <a
-        class="link link_isLearning"
+        class="Sites__link Sites__link_isLearning"
         data-analytics="header:courses"
         href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
         title="SEEK Learning"
@@ -283,7 +283,7 @@ exports[`Sites: active product states: should render with volunteering link as a
     </li>
     <li>
       <a
-        class="link link_isBusiness"
+        class="Sites__link Sites__link_isBusiness"
         data-analytics="header:business+for+sale"
         href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
         title="SEEK Business"
@@ -293,7 +293,7 @@ exports[`Sites: active product states: should render with volunteering link as a
     </li>
     <li>
       <a
-        class="link link_isVolunteering"
+        class="Sites__link Sites__link_isVolunteering"
         data-analytics="header:volunteering"
         href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
         title="SEEK Volunteer"
@@ -311,7 +311,7 @@ exports[`Sites: locale states: should render with locale of AU 1`] = `
   role="navigation"
 >
   <span
-    class="root"
+    class="ScreenReaderOnly__root"
   >
     <h1
       id="Sites"
@@ -320,11 +320,11 @@ exports[`Sites: locale states: should render with locale of AU 1`] = `
     </h1>
   </span>
   <ul
-    class="list"
+    class="Sites__list"
   >
     <li>
       <a
-        class="link link_isJobs"
+        class="Sites__link Sites__link_isJobs"
         data-analytics="header:jobs"
         href="https://www.seek.com.au"
         title="SEEK Jobs"
@@ -334,7 +334,7 @@ exports[`Sites: locale states: should render with locale of AU 1`] = `
     </li>
     <li>
       <a
-        class="link link_isLearning"
+        class="Sites__link Sites__link_isLearning"
         data-analytics="header:courses"
         href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
         title="SEEK Learning"
@@ -344,7 +344,7 @@ exports[`Sites: locale states: should render with locale of AU 1`] = `
     </li>
     <li>
       <a
-        class="link link_isBusiness"
+        class="Sites__link Sites__link_isBusiness"
         data-analytics="header:business+for+sale"
         href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
         title="SEEK Business"
@@ -354,7 +354,7 @@ exports[`Sites: locale states: should render with locale of AU 1`] = `
     </li>
     <li>
       <a
-        class="link link_isVolunteering"
+        class="Sites__link Sites__link_isVolunteering"
         data-analytics="header:volunteering"
         href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
         title="SEEK Volunteer"
@@ -372,7 +372,7 @@ exports[`Sites: locale states: should render with locale of NZ 1`] = `
   role="navigation"
 >
   <span
-    class="root"
+    class="ScreenReaderOnly__root"
   >
     <h1
       id="Sites"
@@ -381,11 +381,11 @@ exports[`Sites: locale states: should render with locale of NZ 1`] = `
     </h1>
   </span>
   <ul
-    class="list"
+    class="Sites__list"
   >
     <li>
       <a
-        class="link link_isJobs"
+        class="Sites__link Sites__link_isJobs"
         data-analytics="header:jobs"
         href="https://www.seek.co.nz"
         title="SEEK Jobs"
@@ -395,7 +395,7 @@ exports[`Sites: locale states: should render with locale of NZ 1`] = `
     </li>
     <li>
       <a
-        class="link link_isLearning"
+        class="Sites__link Sites__link_isLearning"
         data-analytics="header:courses"
         href="https://www.seeklearning.co.nz/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
         title="SEEK Learning"
@@ -405,7 +405,7 @@ exports[`Sites: locale states: should render with locale of NZ 1`] = `
     </li>
     <li>
       <a
-        class="link link_isBusiness"
+        class="Sites__link Sites__link_isBusiness"
         data-analytics="header:business+for+sale"
         href="https://www.seekbusiness.com.au/?site=nz&tracking=sk:main:nz:nav:bus"
         title="SEEK Business"
@@ -415,7 +415,7 @@ exports[`Sites: locale states: should render with locale of NZ 1`] = `
     </li>
     <li>
       <a
-        class="link link_isVolunteering"
+        class="Sites__link Sites__link_isVolunteering"
         data-analytics="header:volunteering"
         href="https://seekvolunteer.co.nz/?tracking=SKMNZ:main+header"
         title="SEEK Volunteer"

--- a/react/Pill/__snapshots__/Pill.test.js.snap
+++ b/react/Pill/__snapshots__/Pill.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Pill: should pass through additional props 1`] = `
 <span
-  className="staticPill"
+  className="Pill__staticPill"
   custom-prop={true}
 >
   <Text
@@ -16,7 +16,7 @@ exports[`Pill: should pass through additional props 1`] = `
 
 exports[`Pill: should render a child component 1`] = `
 <span
-  className="staticPill"
+  className="Pill__staticPill"
 >
   <Text
     baseline={false}
@@ -29,7 +29,7 @@ exports[`Pill: should render a child component 1`] = `
 
 exports[`Pill: should render a static pill 1`] = `
 <span
-  className="staticPill"
+  className="Pill__staticPill"
 >
   <Text
     baseline={false}
@@ -42,7 +42,7 @@ exports[`Pill: should render a static pill 1`] = `
 
 exports[`Pill: should render an additional class for the interactive pill 1`] = `
 <span
-  className="test-class interactivePill"
+  className="test-class Pill__interactivePill"
 >
   <Text
     baseline={false}
@@ -51,7 +51,7 @@ exports[`Pill: should render an additional class for the interactive pill 1`] = 
     I am a pill
   </Text>
   <button
-    className="removeButton"
+    className="Pill__removeButton"
     onClick={[Function]}
   >
     <ScreenReaderOnly
@@ -61,11 +61,11 @@ exports[`Pill: should render an additional class for the interactive pill 1`] = 
       I am a pill
     </ScreenReaderOnly>
     <div
-      className="removeCircle"
+      className="Pill__removeCircle"
     >
       <CrossIcon
-        className="removeIcon"
-        svgClassName="removeSvg"
+        className="Pill__removeIcon"
+        svgClassName="Pill__removeSvg"
       />
     </div>
   </button>
@@ -74,7 +74,7 @@ exports[`Pill: should render an additional class for the interactive pill 1`] = 
 
 exports[`Pill: should render an additional class for the static pill 1`] = `
 <span
-  className="test-class staticPill"
+  className="test-class Pill__staticPill"
 >
   <Text
     baseline={false}
@@ -87,7 +87,7 @@ exports[`Pill: should render an additional class for the static pill 1`] = `
 
 exports[`Pill: should render an interactive pill 1`] = `
 <span
-  className="interactivePill"
+  className="Pill__interactivePill"
 >
   <Text
     baseline={false}
@@ -96,7 +96,7 @@ exports[`Pill: should render an interactive pill 1`] = `
     I am a pill
   </Text>
   <button
-    className="removeButton"
+    className="Pill__removeButton"
     onClick={[Function]}
   >
     <ScreenReaderOnly
@@ -106,11 +106,11 @@ exports[`Pill: should render an interactive pill 1`] = `
       I am a pill
     </ScreenReaderOnly>
     <div
-      className="removeCircle"
+      className="Pill__removeCircle"
     >
       <CrossIcon
-        className="removeIcon"
-        svgClassName="removeSvg"
+        className="Pill__removeIcon"
+        svgClassName="Pill__removeSvg"
       />
     </div>
   </button>
@@ -119,7 +119,7 @@ exports[`Pill: should render an interactive pill 1`] = `
 
 exports[`Pill: should render an interactive pill with the legacy "text" prop 1`] = `
 <span
-  className="interactivePill"
+  className="Pill__interactivePill"
 >
   <Text
     baseline={false}
@@ -128,7 +128,7 @@ exports[`Pill: should render an interactive pill with the legacy "text" prop 1`]
     I am a pill
   </Text>
   <button
-    className="removeButton"
+    className="Pill__removeButton"
     onClick={[Function]}
   >
     <ScreenReaderOnly
@@ -138,11 +138,11 @@ exports[`Pill: should render an interactive pill with the legacy "text" prop 1`]
       I am a pill
     </ScreenReaderOnly>
     <div
-      className="removeCircle"
+      className="Pill__removeCircle"
     >
       <CrossIcon
-        className="removeIcon"
-        svgClassName="removeSvg"
+        className="Pill__removeIcon"
+        svgClassName="Pill__removeSvg"
       />
     </div>
   </button>
@@ -151,7 +151,7 @@ exports[`Pill: should render an interactive pill with the legacy "text" prop 1`]
 
 exports[`Pill: should support the legacy "text" prop 1`] = `
 <span
-  className="staticPill"
+  className="Pill__staticPill"
 >
   <Text
     baseline={false}

--- a/react/Radio/__snapshots__/Radio.test.js.snap
+++ b/react/Radio/__snapshots__/Radio.test.js.snap
@@ -2,34 +2,34 @@
 
 exports[`Radio inputProps should pass through other props to the input 1`] = `
 <div
-  className="root"
+  className="Radio__root"
 >
   <input
     checked={true}
-    className="input"
+    className="Radio__input"
     data-automation="first-name-field"
     id="testRadio"
     onChange={[Function]}
     type="radio"
   />
   <label
-    className="label"
+    className="Radio__label"
     htmlFor="testRadio"
   >
     <svg
-      className="svg"
+      className="Radio__svg"
       focusable="false"
       viewBox="0 0 200 200"
       xmlns="http://www.w3.org/2000/svg"
     >
       <circle
-        className="circle circle_isHover"
+        className="Radio__circle Radio__circle_isHover"
         cx="100"
         cy="100"
         r="100"
       />
       <circle
-        className="circle circle_isSelected"
+        className="Radio__circle Radio__circle_isSelected"
         cx="100"
         cy="100"
         r="100"
@@ -37,7 +37,7 @@ exports[`Radio inputProps should pass through other props to the input 1`] = `
     </svg>
     <Text
       baseline={false}
-      className="labelText"
+      className="Radio__labelText"
       raw={true}
     >
       Still in role
@@ -48,33 +48,33 @@ exports[`Radio inputProps should pass through other props to the input 1`] = `
 
 exports[`Radio should render with className 1`] = `
 <div
-  className="root testClassname"
+  className="Radio__root testClassname"
 >
   <input
     checked={false}
-    className="input"
+    className="Radio__input"
     id="testRadio"
     onChange={[Function]}
     type="radio"
   />
   <label
-    className="label"
+    className="Radio__label"
     htmlFor="testRadio"
   >
     <svg
-      className="svg"
+      className="Radio__svg"
       focusable="false"
       viewBox="0 0 200 200"
       xmlns="http://www.w3.org/2000/svg"
     >
       <circle
-        className="circle circle_isHover"
+        className="Radio__circle Radio__circle_isHover"
         cx="100"
         cy="100"
         r="100"
       />
       <circle
-        className="circle circle_isSelected"
+        className="Radio__circle Radio__circle_isSelected"
         cx="100"
         cy="100"
         r="100"
@@ -82,7 +82,7 @@ exports[`Radio should render with className 1`] = `
     </svg>
     <Text
       baseline={false}
-      className="labelText"
+      className="Radio__labelText"
       raw={true}
     >
       Still in role
@@ -93,33 +93,33 @@ exports[`Radio should render with className 1`] = `
 
 exports[`Radio should render with simple props 1`] = `
 <div
-  className="root"
+  className="Radio__root"
 >
   <input
     checked={false}
-    className="input"
+    className="Radio__input"
     id="testRadio"
     onChange={[Function]}
     type="radio"
   />
   <label
-    className="label"
+    className="Radio__label"
     htmlFor="testRadio"
   >
     <svg
-      className="svg"
+      className="Radio__svg"
       focusable="false"
       viewBox="0 0 200 200"
       xmlns="http://www.w3.org/2000/svg"
     >
       <circle
-        className="circle circle_isHover"
+        className="Radio__circle Radio__circle_isHover"
         cx="100"
         cy="100"
         r="100"
       />
       <circle
-        className="circle circle_isSelected"
+        className="Radio__circle Radio__circle_isSelected"
         cx="100"
         cy="100"
         r="100"
@@ -127,7 +127,7 @@ exports[`Radio should render with simple props 1`] = `
     </svg>
     <Text
       baseline={false}
-      className="labelText"
+      className="Radio__labelText"
       raw={true}
     >
       Still in role

--- a/react/Rating/__snapshots__/Rating.test.js.snap
+++ b/react/Rating/__snapshots__/Rating.test.js.snap
@@ -2,41 +2,41 @@
 
 exports[`Rating should render correct size when size is: heading 1`] = `
 <span
-  class="root heading raw baseline"
+  class="Text__root Text__heading Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       3.5 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled heading star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__heading Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled heading star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__heading Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled heading star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__heading Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large heading star"
+        class="Icon__root StarIcon___large StarIcon__heading Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large heading star"
+        class="Icon__root StarIcon___large StarIcon__heading Rating__star"
       >
         mock svg
       </span>
@@ -47,46 +47,46 @@ exports[`Rating should render correct size when size is: heading 1`] = `
 
 exports[`Rating should render correct size when size is: heading and rating text is shown 1`] = `
 <span
-  class="root heading raw baseline"
+  class="Text__root Text__heading Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       4 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled heading star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__heading Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled heading star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__heading Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled heading star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__heading Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled heading star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__heading Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large heading star"
+        class="Icon__root StarIcon___large StarIcon__heading Rating__star"
       >
         mock svg
       </span>
       <span
-        class="textRating"
+        class="Rating__textRating"
       >
         4.0
       </span>
@@ -97,41 +97,41 @@ exports[`Rating should render correct size when size is: heading and rating text
 
 exports[`Rating should render correct size when size is: headline 1`] = `
 <span
-  class="root headline raw baseline"
+  class="Text__root Text__headline Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       3.5 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled headline star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__headline Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled headline star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__headline Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled headline star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__headline Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large headline star"
+        class="Icon__root StarIcon___large StarIcon__headline Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large headline star"
+        class="Icon__root StarIcon___large StarIcon__headline Rating__star"
       >
         mock svg
       </span>
@@ -142,46 +142,46 @@ exports[`Rating should render correct size when size is: headline 1`] = `
 
 exports[`Rating should render correct size when size is: headline and rating text is shown 1`] = `
 <span
-  class="root headline raw baseline"
+  class="Text__root Text__headline Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       4 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled headline star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__headline Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled headline star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__headline Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled headline star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__headline Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled headline star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__headline Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large headline star"
+        class="Icon__root StarIcon___large StarIcon__headline Rating__star"
       >
         mock svg
       </span>
       <span
-        class="textRating"
+        class="Rating__textRating"
       >
         4.0
       </span>
@@ -192,41 +192,41 @@ exports[`Rating should render correct size when size is: headline and rating tex
 
 exports[`Rating should render correct size when size is: hero 1`] = `
 <span
-  class="root hero raw baseline"
+  class="Text__root Text__hero Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       3.5 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled hero star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__hero Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled hero star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__hero Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled hero star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__hero Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large hero star"
+        class="Icon__root StarIcon___large StarIcon__hero Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large hero star"
+        class="Icon__root StarIcon___large StarIcon__hero Rating__star"
       >
         mock svg
       </span>
@@ -237,46 +237,46 @@ exports[`Rating should render correct size when size is: hero 1`] = `
 
 exports[`Rating should render correct size when size is: hero and rating text is shown 1`] = `
 <span
-  class="root hero raw baseline"
+  class="Text__root Text__hero Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       4 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled hero star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__hero Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled hero star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__hero Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled hero star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__hero Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled hero star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__hero Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large hero star"
+        class="Icon__root StarIcon___large StarIcon__hero Rating__star"
       >
         mock svg
       </span>
       <span
-        class="textRating"
+        class="Rating__textRating"
       >
         4.0
       </span>
@@ -287,41 +287,41 @@ exports[`Rating should render correct size when size is: hero and rating text is
 
 exports[`Rating should render correct star rating when rating is: 0 1`] = `
 <span
-  class="root standard raw baseline"
+  class="Text__root Text__standard Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       0 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
@@ -332,41 +332,41 @@ exports[`Rating should render correct star rating when rating is: 0 1`] = `
 
 exports[`Rating should render correct star rating when rating is: 2.74 1`] = `
 <span
-  class="root standard raw baseline"
+  class="Text__root Text__standard Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       2.74 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
@@ -377,41 +377,41 @@ exports[`Rating should render correct star rating when rating is: 2.74 1`] = `
 
 exports[`Rating should render correct star rating when rating is: 2.75 1`] = `
 <span
-  class="root standard raw baseline"
+  class="Text__root Text__standard Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       2.75 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
@@ -422,41 +422,41 @@ exports[`Rating should render correct star rating when rating is: 2.75 1`] = `
 
 exports[`Rating should render correct star rating when rating is: 3.74 1`] = `
 <span
-  class="root standard raw baseline"
+  class="Text__root Text__standard Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       3.74 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
@@ -467,41 +467,41 @@ exports[`Rating should render correct star rating when rating is: 3.74 1`] = `
 
 exports[`Rating should render correct star rating when rating is: 3.75 1`] = `
 <span
-  class="root standard raw baseline"
+  class="Text__root Text__standard Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       3.75 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large standard star"
+        class="Icon__root StarIcon___large StarIcon__standard Rating__star"
       >
         mock svg
       </span>
@@ -512,41 +512,41 @@ exports[`Rating should render correct star rating when rating is: 3.75 1`] = `
 
 exports[`Rating should render correct star rating when rating is: 5 1`] = `
 <span
-  class="root standard raw baseline"
+  class="Text__root Text__standard Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       5 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
@@ -557,41 +557,41 @@ exports[`Rating should render correct star rating when rating is: 5 1`] = `
 
 exports[`Rating should render with className 1`] = `
 <span
-  class="root root-class-name standard raw baseline"
+  class="Text__root root-class-name Text__standard Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       5 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
@@ -602,46 +602,46 @@ exports[`Rating should render with className 1`] = `
 
 exports[`Rating should render with description 1`] = `
 <span
-  class="root standard raw baseline"
+  class="Text__root Text__standard Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       5 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="textRating"
+        class="Rating__textRating"
       >
         5.0 overall rating from...
       </span>
@@ -652,46 +652,46 @@ exports[`Rating should render with description 1`] = `
 
 exports[`Rating should render with description as a component 1`] = `
 <span
-  class="root standard raw baseline"
+  class="Text__root Text__standard Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       5 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="textRating"
+        class="Rating__textRating"
       >
         5.0 
         <span>
@@ -705,41 +705,41 @@ exports[`Rating should render with description as a component 1`] = `
 
 exports[`Rating should render with starClassName 1`] = `
 <span
-  class="root standard raw baseline"
+  class="Text__root Text__standard Text__raw Text__baseline"
 >
   <span
-    class="root"
+    class="Regular__root"
   >
     <span
-      class="root"
+      class="ScreenReaderOnly__root"
     >
       5 out of 5
     </span>
     <span
-      class="rating"
+      class="Rating__rating"
     >
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>
       <span
-        class="root _large filled standard star"
+        class="Icon__root StarIcon___large StarIcon__filled StarIcon__standard Rating__star"
       >
         mock svg
       </span>

--- a/react/Section/__snapshots__/Section.test.js.snap
+++ b/react/Section/__snapshots__/Section.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Section: levels: should render primary sections 1`] = `
 <div
-  className="root primary"
+  className="Section__root Section__primary"
 >
   Test content
 </div>
@@ -10,7 +10,7 @@ exports[`Section: levels: should render primary sections 1`] = `
 
 exports[`Section: levels: should render secondary sections 1`] = `
 <div
-  className="root secondary"
+  className="Section__root Section__secondary"
 >
   Test content
 </div>
@@ -18,7 +18,7 @@ exports[`Section: levels: should render secondary sections 1`] = `
 
 exports[`Section: should accept additional classnames and place them on the root 1`] = `
 <div
-  className="testClass root secondary"
+  className="testClass Section__root Section__secondary"
 >
   Test content
 </div>
@@ -26,7 +26,7 @@ exports[`Section: should accept additional classnames and place them on the root
 
 exports[`Section: should accept additional props 1`] = `
 <div
-  className="root"
+  className="Section__root"
   testProp={true}
 >
   Test content
@@ -35,7 +35,7 @@ exports[`Section: should accept additional props 1`] = `
 
 exports[`Section: should render multiple classes together 1`] = `
 <div
-  className="root slim info secondary"
+  className="Section__root Section__slim Section__info Section__secondary"
 >
   Test content
 </div>
@@ -43,7 +43,7 @@ exports[`Section: should render multiple classes together 1`] = `
 
 exports[`Section: should render the header style 1`] = `
 <div
-  className="root header"
+  className="Section__root Section__header"
 >
   Test content
 </div>
@@ -51,7 +51,7 @@ exports[`Section: should render the header style 1`] = `
 
 exports[`Section: should render the pullout style 1`] = `
 <div
-  className="root pullout"
+  className="Section__root Section__pullout"
 >
   Test content
 </div>
@@ -59,7 +59,7 @@ exports[`Section: should render the pullout style 1`] = `
 
 exports[`Section: should render the slim style 1`] = `
 <div
-  className="root slim"
+  className="Section__root Section__slim"
 >
   Test content
 </div>
@@ -67,7 +67,7 @@ exports[`Section: should render the slim style 1`] = `
 
 exports[`Section: types: should render critical sections 1`] = `
 <div
-  className="root critical"
+  className="Section__root Section__critical"
 >
   Test content
 </div>
@@ -75,7 +75,7 @@ exports[`Section: types: should render critical sections 1`] = `
 
 exports[`Section: types: should render help sections 1`] = `
 <div
-  className="root help"
+  className="Section__root Section__help"
 >
   Test content
 </div>
@@ -83,7 +83,7 @@ exports[`Section: types: should render help sections 1`] = `
 
 exports[`Section: types: should render info sections 1`] = `
 <div
-  className="root info"
+  className="Section__root Section__info"
 >
   Test content
 </div>
@@ -91,7 +91,7 @@ exports[`Section: types: should render info sections 1`] = `
 
 exports[`Section: types: should render positive sections 1`] = `
 <div
-  className="root positive"
+  className="Section__root Section__positive"
 >
   Test content
 </div>

--- a/react/SlideToggle/__snapshots__/SlideToggle.test.js.snap
+++ b/react/SlideToggle/__snapshots__/SlideToggle.test.js.snap
@@ -2,32 +2,32 @@
 
 exports[`Slide toggle: should render a checked state 1`] = `
 <div
-  className="root"
+  className="SlideToggle__root"
 >
   <input
     aria-label="Test toggle"
     checked={true}
-    className="input"
+    className="SlideToggle__input"
     id="testSlideToggle"
     type="checkbox"
   />
   <label
-    className="switch"
+    className="SlideToggle__switch"
     htmlFor="testSlideToggle"
   >
     <div
-      className="slideContainer"
+      className="SlideToggle__slideContainer"
     >
       <div
-        className="slider"
+        className="SlideToggle__slider"
       />
       <TickIcon
-        className="slideButton"
-        svgClassName="svg"
+        className="SlideToggle__slideButton"
+        svgClassName="SlideToggle__svg"
       />
     </div>
     <span
-      className="labelText labelRight"
+      className="SlideToggle__labelText SlideToggle__labelRight"
     >
       Test toggle
     </span>
@@ -37,31 +37,31 @@ exports[`Slide toggle: should render a checked state 1`] = `
 
 exports[`Slide toggle: should render with default props 1`] = `
 <div
-  className="root"
+  className="SlideToggle__root"
 >
   <input
     aria-label="Test toggle"
-    className="input"
+    className="SlideToggle__input"
     id="testSlideToggle"
     type="checkbox"
   />
   <label
-    className="switch"
+    className="SlideToggle__switch"
     htmlFor="testSlideToggle"
   >
     <div
-      className="slideContainer"
+      className="SlideToggle__slideContainer"
     >
       <div
-        className="slider"
+        className="SlideToggle__slider"
       />
       <TickIcon
-        className="slideButton"
-        svgClassName="svg"
+        className="SlideToggle__slideButton"
+        svgClassName="SlideToggle__svg"
       />
     </div>
     <span
-      className="labelText labelRight"
+      className="SlideToggle__labelText SlideToggle__labelRight"
     >
       Test toggle
     </span>
@@ -71,27 +71,27 @@ exports[`Slide toggle: should render with default props 1`] = `
 
 exports[`Slide toggle: should render with the label hidden 1`] = `
 <div
-  className="root"
+  className="SlideToggle__root"
 >
   <input
     aria-label="Test toggle"
-    className="input"
+    className="SlideToggle__input"
     id="testSlideToggle"
     type="checkbox"
   />
   <label
-    className="switch"
+    className="SlideToggle__switch"
     htmlFor="testSlideToggle"
   >
     <div
-      className="slideContainer"
+      className="SlideToggle__slideContainer"
     >
       <div
-        className="slider"
+        className="SlideToggle__slider"
       />
       <TickIcon
-        className="slideButton"
-        svgClassName="svg"
+        className="SlideToggle__slideButton"
+        svgClassName="SlideToggle__svg"
       />
     </div>
   </label>
@@ -100,32 +100,32 @@ exports[`Slide toggle: should render with the label hidden 1`] = `
 
 exports[`Slide toggle: should render with the label on the left 1`] = `
 <div
-  className="root"
+  className="SlideToggle__root"
 >
   <input
     aria-label="Test toggle"
-    className="input inputLeft"
+    className="SlideToggle__input SlideToggle__inputLeft"
     id="testSlideToggle"
     type="checkbox"
   />
   <label
-    className="switch"
+    className="SlideToggle__switch"
     htmlFor="testSlideToggle"
   >
     <span
-      className="labelText labelLeft"
+      className="SlideToggle__labelText SlideToggle__labelLeft"
     >
       Test toggle
     </span>
     <div
-      className="slideContainer"
+      className="SlideToggle__slideContainer"
     >
       <div
-        className="slider"
+        className="SlideToggle__slider"
       />
       <TickIcon
-        className="slideButton"
-        svgClassName="svg"
+        className="SlideToggle__slideButton"
+        svgClassName="SlideToggle__svg"
       />
     </div>
   </label>

--- a/react/Text/__snapshots__/Text.test.js.snap
+++ b/react/Text/__snapshots__/Text.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Text should render a bullet point 1`] = `
 <li
-  class="root standard bullet baseline"
+  class="Text__root Text__standard Text__bullet Text__baseline"
 >
   <span
     class=""
@@ -14,7 +14,7 @@ exports[`Text should render a bullet point 1`] = `
 
 exports[`Text should render with a custom component 1`] = `
 <div
-  class="root standard baseline"
+  class="Text__root Text__standard Text__baseline"
 >
   <span
     class=""
@@ -26,7 +26,7 @@ exports[`Text should render with a custom component 1`] = `
 
 exports[`Text should render with defaults 1`] = `
 <span
-  class="root standard baseline"
+  class="Text__root Text__standard Text__baseline"
 >
   <span
     class=""
@@ -38,7 +38,7 @@ exports[`Text should render with defaults 1`] = `
 
 exports[`Text sizes should render as heading 1`] = `
 <span
-  class="root heading baseline"
+  class="Text__root Text__heading Text__baseline"
 >
   <span
     class=""
@@ -50,7 +50,7 @@ exports[`Text sizes should render as heading 1`] = `
 
 exports[`Text sizes should render as heading 2`] = `
 <span
-  class="root heading baseline"
+  class="Text__root Text__heading Text__baseline"
 >
   <span
     class=""
@@ -62,7 +62,7 @@ exports[`Text sizes should render as heading 2`] = `
 
 exports[`Text sizes should render as headline 1`] = `
 <span
-  class="root headline baseline"
+  class="Text__root Text__headline Text__baseline"
 >
   <span
     class=""
@@ -74,7 +74,7 @@ exports[`Text sizes should render as headline 1`] = `
 
 exports[`Text sizes should render as headline 2`] = `
 <span
-  class="root headline baseline"
+  class="Text__root Text__headline Text__baseline"
 >
   <span
     class=""
@@ -86,7 +86,7 @@ exports[`Text sizes should render as headline 2`] = `
 
 exports[`Text sizes should render as hero 1`] = `
 <span
-  class="root hero baseline"
+  class="Text__root Text__hero Text__baseline"
 >
   <span
     class=""
@@ -98,7 +98,7 @@ exports[`Text sizes should render as hero 1`] = `
 
 exports[`Text sizes should render as hero 2`] = `
 <span
-  class="root hero baseline"
+  class="Text__root Text__hero Text__baseline"
 >
   <span
     class=""
@@ -110,7 +110,7 @@ exports[`Text sizes should render as hero 2`] = `
 
 exports[`Text sizes should render as large 1`] = `
 <span
-  class="root large baseline"
+  class="Text__root Text__large Text__baseline"
 >
   <span
     class=""
@@ -122,7 +122,7 @@ exports[`Text sizes should render as large 1`] = `
 
 exports[`Text sizes should render as large 2`] = `
 <span
-  class="root large baseline"
+  class="Text__root Text__large Text__baseline"
 >
   <span
     class=""
@@ -134,7 +134,7 @@ exports[`Text sizes should render as large 2`] = `
 
 exports[`Text sizes should render as small 1`] = `
 <span
-  class="root small baseline"
+  class="Text__root Text__small Text__baseline"
 >
   <span
     class=""
@@ -146,7 +146,7 @@ exports[`Text sizes should render as small 1`] = `
 
 exports[`Text sizes should render as small 2`] = `
 <span
-  class="root small baseline"
+  class="Text__root Text__small Text__baseline"
 >
   <span
     class=""
@@ -158,7 +158,7 @@ exports[`Text sizes should render as small 2`] = `
 
 exports[`Text sizes should render as standard 1`] = `
 <span
-  class="root standard baseline"
+  class="Text__root Text__standard Text__baseline"
 >
   <span
     class=""
@@ -170,7 +170,7 @@ exports[`Text sizes should render as standard 1`] = `
 
 exports[`Text sizes should render as standard 2`] = `
 <span
-  class="root standard baseline"
+  class="Text__root Text__standard Text__baseline"
 >
   <span
     class=""
@@ -182,7 +182,7 @@ exports[`Text sizes should render as standard 2`] = `
 
 exports[`Text sizes should render as subheading 1`] = `
 <span
-  class="root subheading baseline"
+  class="Text__root Text__subheading Text__baseline"
 >
   <span
     class=""
@@ -194,7 +194,7 @@ exports[`Text sizes should render as subheading 1`] = `
 
 exports[`Text sizes should render as subheading 2`] = `
 <span
-  class="root subheading baseline"
+  class="Text__root Text__subheading Text__baseline"
 >
   <span
     class=""

--- a/react/TextField/TextField.test.js
+++ b/react/TextField/TextField.test.js
@@ -95,7 +95,7 @@ describe('TextField', () => {
 
       const wrapper = mount(<TextField {...requiredProps} onClear={clickHandlerSpy} />);
       const input = wrapper.find('input').html();
-      const clearButton = wrapper.find('.clearField');
+      const clearButton = wrapper.find('.TextField__clearField');
 
       clearButton.simulate('mouseDown');
       expect(clickHandlerSpy).toBeCalled();

--- a/react/TextField/__snapshots__/TextField.test.js.snap
+++ b/react/TextField/__snapshots__/TextField.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TextField clear button inputProps should be visible when value has white spaces only 1`] = `
 <div
-  className="root canClear"
+  className="TextField__root TextField__canClear"
 >
   <FieldLabel
     id="testTextField"
@@ -13,13 +13,13 @@ exports[`TextField clear button inputProps should be visible when value has whit
   />
   <input
     aria-describedby="testTextField-message"
-    className="input"
+    className="TextField__input"
     id="testTextField"
     onChange={[Function]}
     value="  "
   />
   <span
-    className="clearField"
+    className="TextField__clearField"
     onMouseDown={[Function]}
   >
     <ClearField />
@@ -40,7 +40,7 @@ exports[`TextField clear button inputProps should be visible when value has whit
 
 exports[`TextField clear button inputProps should be visible when value is provided 1`] = `
 <div
-  className="root canClear"
+  className="TextField__root TextField__canClear"
 >
   <FieldLabel
     id="testTextField"
@@ -51,13 +51,13 @@ exports[`TextField clear button inputProps should be visible when value is provi
   />
   <input
     aria-describedby="testTextField-message"
-    className="input"
+    className="TextField__input"
     id="testTextField"
     onChange={[Function]}
     value="abc"
   />
   <span
-    className="clearField"
+    className="TextField__clearField"
     onMouseDown={[Function]}
   >
     <ClearField />
@@ -78,7 +78,7 @@ exports[`TextField clear button inputProps should be visible when value is provi
 
 exports[`TextField clear button inputProps should not be visible when value is empty 1`] = `
 <div
-  className="root"
+  className="TextField__root"
 >
   <FieldLabel
     id="testTextField"
@@ -89,13 +89,13 @@ exports[`TextField clear button inputProps should not be visible when value is e
   />
   <input
     aria-describedby="testTextField-message"
-    className="input"
+    className="TextField__input"
     id="testTextField"
     onChange={[Function]}
     value=""
   />
   <span
-    className="clearField"
+    className="TextField__clearField"
     onMouseDown={[Function]}
   >
     <ClearField />
@@ -116,7 +116,7 @@ exports[`TextField clear button inputProps should not be visible when value is e
 
 exports[`TextField clear button inputProps should not be visible when value is provided but no clear handler 1`] = `
 <div
-  className="root"
+  className="TextField__root"
 >
   <FieldLabel
     id="testTextField"
@@ -127,13 +127,13 @@ exports[`TextField clear button inputProps should not be visible when value is p
   />
   <input
     aria-describedby="testTextField-message"
-    className="input"
+    className="TextField__input"
     id="testTextField"
     onChange={[Function]}
     value="abc"
   />
   <span
-    className="clearField"
+    className="TextField__clearField"
     onMouseDown={[Function]}
   >
     <ClearField />
@@ -154,7 +154,7 @@ exports[`TextField clear button inputProps should not be visible when value is p
 
 exports[`TextField clear button should be visible when value has white spaces only 1`] = `
 <div
-  className="root canClear"
+  className="TextField__root TextField__canClear"
 >
   <FieldLabel
     id="testTextField"
@@ -165,13 +165,13 @@ exports[`TextField clear button should be visible when value has white spaces on
   />
   <input
     aria-describedby="testTextField-message"
-    className="input"
+    className="TextField__input"
     id="testTextField"
     onChange={[Function]}
     value="  "
   />
   <span
-    className="clearField"
+    className="TextField__clearField"
     onMouseDown={[Function]}
   >
     <ClearField />
@@ -192,7 +192,7 @@ exports[`TextField clear button should be visible when value has white spaces on
 
 exports[`TextField clear button should be visible when value is provided 1`] = `
 <div
-  className="root canClear"
+  className="TextField__root TextField__canClear"
 >
   <FieldLabel
     id="testTextField"
@@ -203,13 +203,13 @@ exports[`TextField clear button should be visible when value is provided 1`] = `
   />
   <input
     aria-describedby="testTextField-message"
-    className="input"
+    className="TextField__input"
     id="testTextField"
     onChange={[Function]}
     value="abc"
   />
   <span
-    className="clearField"
+    className="TextField__clearField"
     onMouseDown={[Function]}
   >
     <ClearField />
@@ -230,7 +230,7 @@ exports[`TextField clear button should be visible when value is provided 1`] = `
 
 exports[`TextField clear button should not be visible when value is empty 1`] = `
 <div
-  className="root"
+  className="TextField__root"
 >
   <FieldLabel
     id="testTextField"
@@ -241,13 +241,13 @@ exports[`TextField clear button should not be visible when value is empty 1`] = 
   />
   <input
     aria-describedby="testTextField-message"
-    className="input"
+    className="TextField__input"
     id="testTextField"
     onChange={[Function]}
     value=""
   />
   <span
-    className="clearField"
+    className="TextField__clearField"
     onMouseDown={[Function]}
   >
     <ClearField />
@@ -268,7 +268,7 @@ exports[`TextField clear button should not be visible when value is empty 1`] = 
 
 exports[`TextField clear button should not be visible when value is provided but no clear handler 1`] = `
 <div
-  className="root"
+  className="TextField__root"
 >
   <FieldLabel
     id="testTextField"
@@ -279,13 +279,13 @@ exports[`TextField clear button should not be visible when value is provided but
   />
   <input
     aria-describedby="testTextField-message"
-    className="input"
+    className="TextField__input"
     id="testTextField"
     onChange={[Function]}
     value="abc"
   />
   <span
-    className="clearField"
+    className="TextField__clearField"
     onMouseDown={[Function]}
   >
     <ClearField />
@@ -306,7 +306,7 @@ exports[`TextField clear button should not be visible when value is provided but
 
 exports[`TextField should render with defaults 1`] = `
 <div
-  className="root"
+  className="TextField__root"
 >
   <FieldLabel
     id="testTextField"
@@ -317,13 +317,13 @@ exports[`TextField should render with defaults 1`] = `
   />
   <input
     aria-describedby="testTextField-message"
-    className="input"
+    className="TextField__input"
     id="testTextField"
     onChange={[Function]}
     value=""
   />
   <span
-    className="clearField"
+    className="TextField__clearField"
     onMouseDown={[Function]}
   >
     <ClearField />
@@ -344,7 +344,7 @@ exports[`TextField should render with defaults 1`] = `
 
 exports[`TextField should render with input props 1`] = `
 <div
-  className="root"
+  className="TextField__root"
 >
   <FieldLabel
     id="testTextField"
@@ -355,14 +355,14 @@ exports[`TextField should render with input props 1`] = `
   />
   <input
     aria-describedby="testTextField-message"
-    className="input first-name-field"
+    className="TextField__input first-name-field"
     data-automation="first-name-field"
     id="testTextField"
     onChange={[Function]}
     value="value"
   />
   <span
-    className="clearField"
+    className="TextField__clearField"
     onMouseDown={[Function]}
   >
     <ClearField />
@@ -383,7 +383,7 @@ exports[`TextField should render with input props 1`] = `
 
 exports[`TextField should render with valid false 1`] = `
 <div
-  className="root invalid"
+  className="TextField__root TextField__invalid"
 >
   <FieldLabel
     id="testTextField"
@@ -394,13 +394,13 @@ exports[`TextField should render with valid false 1`] = `
   />
   <input
     aria-describedby="testTextField-message"
-    className="input"
+    className="TextField__input"
     id="testTextField"
     onChange={[Function]}
     value=""
   />
   <span
-    className="clearField"
+    className="TextField__clearField"
     onMouseDown={[Function]}
   >
     <ClearField />

--- a/react/TextLink/__snapshots__/TextLink.test.js.snap
+++ b/react/TextLink/__snapshots__/TextLink.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`TextLink should render with chevron props 1`] = `
 <a
-  className="link"
+  className="TextLink__link"
 >
   Google
   <ChevronIcon
-    className="chevronRightSide"
+    className="TextLink__chevronRightSide"
     direction="up"
     size="hero"
   />
@@ -15,7 +15,7 @@ exports[`TextLink should render with chevron props 1`] = `
 
 exports[`TextLink should render with children 1`] = `
 <a
-  className="link"
+  className="TextLink__link"
 >
   Google
 </a>
@@ -23,23 +23,23 @@ exports[`TextLink should render with children 1`] = `
 
 exports[`TextLink should render with className 1`] = `
 <a
-  className="link foo"
+  className="TextLink__link foo"
 />
 `;
 
 exports[`TextLink should render with defaults 1`] = `
 <a
-  className="link"
+  className="TextLink__link"
 />
 `;
 
 exports[`TextLink should render with down chevron 1`] = `
 <a
-  className="link"
+  className="TextLink__link"
 >
   Google
   <ChevronIcon
-    className="chevronRightSide"
+    className="TextLink__chevronRightSide"
     direction="down"
     size="standard"
   />
@@ -48,10 +48,10 @@ exports[`TextLink should render with down chevron 1`] = `
 
 exports[`TextLink should render with left chevron 1`] = `
 <a
-  className="link"
+  className="TextLink__link"
 >
   <ChevronIcon
-    className="chevronLeftSide"
+    className="TextLink__chevronLeftSide"
     direction="left"
     size="standard"
   />
@@ -61,11 +61,11 @@ exports[`TextLink should render with left chevron 1`] = `
 
 exports[`TextLink should render with right chevron 1`] = `
 <a
-  className="link"
+  className="TextLink__link"
 >
   Google
   <ChevronIcon
-    className="chevronRightSide"
+    className="TextLink__chevronRightSide"
     direction="right"
     size="standard"
   />
@@ -74,11 +74,11 @@ exports[`TextLink should render with right chevron 1`] = `
 
 exports[`TextLink should render with up chevron 1`] = `
 <a
-  className="link"
+  className="TextLink__link"
 >
   Google
   <ChevronIcon
-    className="chevronRightSide"
+    className="TextLink__chevronRightSide"
     direction="up"
     size="standard"
   />

--- a/react/Textarea/Textarea.test.js
+++ b/react/Textarea/Textarea.test.js
@@ -29,8 +29,8 @@ describe('Textarea', () => {
   function render(jsx) {
     element = jsx;
     textarea = renderer.render(element);
-    input = findAllWithClass(textarea, 'textarea')[0] || null;
-    characterCount = findAllWithClass(textarea, 'characterCount')[0] || null;
+    input = findAllWithClass(textarea, 'Textarea__textarea')[0] || null;
+    characterCount = findAllWithClass(textarea, 'Textarea__characterCount')[0] || null;
   }
 
   it('should have a displayName', () => {

--- a/test/cssModules.transform.js
+++ b/test/cssModules.transform.js
@@ -1,7 +1,8 @@
-// Really naive, regex-based class name extractor
+const path = require('path');
 
 module.exports = {
-  process: src => {
+  process: (src, srcPath) => {
+    const fileName = path.parse(srcPath).name;
     const classNames = [];
 
     const classNameRegEx = /\.([-_a-zA-Z0-9]+)(?=[\.:\[\s{])/gm;
@@ -13,7 +14,7 @@ module.exports = {
 
     const cssModule = {};
     classNames.forEach(className => {
-      cssModule[className] = className;
+      cssModule[className] = `${fileName}__${className}`;
     });
 
     return `module.exports = ${JSON.stringify(cssModule)}`;


### PR DESCRIPTION
This issue was discovered when trying to write tests for `Text.js` where it imported a `secondary` class from two different CSS modules.

As a bonus, I feel like this actually makes the snapshots easier to read since it makes it explicit where each class name is coming from.