### PR TITLE
build(jest): Add testURL Jest config

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -16,5 +16,6 @@
   "setupFiles": [
     "<rootDir>/test/setupPolyfills.js"
   ],
-  "setupTestFrameworkScriptFile": "<rootDir>/test/setupTestFramework.js"
+  "setupTestFrameworkScriptFile": "<rootDir>/test/setupTestFramework.js",
+  "testURL": "http://localhost"
 }


### PR DESCRIPTION
Travis builds are [failing](https://travis-ci.org/seek-oss/seek-style-guide/builds/408799649) due to [this issue](https://github.com/facebook/jest/issues/6766). The `testURL` config fixes it for me, let's see if it fixes the build!