### PR TITLE
feat(Monthpicker): Add onFocus to custom and native monthpickers

### DIFF
--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
@@ -32,6 +32,7 @@ export default class CustomMonthPicker extends Component {
     id: PropTypes.string.isRequired,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
+    onFocus: PropTypes.func,
     value: PropTypes.shape({
       month: PropTypes.number,
       year: PropTypes.number
@@ -55,6 +56,7 @@ export default class CustomMonthPicker extends Component {
     this.storeMonthReference = this.storeMonthReference.bind(this);
     this.storeYearReference = this.storeYearReference.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
     this.blurIfNotFocussed = this.blurIfNotFocussed.bind(this);
 
     this.yearOptions = getYearOptions(minYear, maxYear, ascendingYears);
@@ -132,6 +134,13 @@ export default class CustomMonthPicker extends Component {
     }
   }
 
+  handleFocus(evt) {
+    const { onFocus } = this.props;
+    if (typeof onFocus === 'function') {
+      onFocus(evt);
+    }
+  }
+
   render() {
     const { id, value, valid, fieldMessageId } = this.props;
     // eslint-disable-next-line react/prop-types
@@ -170,6 +179,7 @@ export default class CustomMonthPicker extends Component {
             placeholder="Month"
             onChange={this.handleMonthChange}
             onBlur={this.handleBlur}
+            onFocus={this.handleFocus}
             value={monthValue}
             inputProps={{
               ref: this.storeMonthReference,
@@ -186,6 +196,7 @@ export default class CustomMonthPicker extends Component {
             placeholder="Year"
             onChange={this.handleYearChange}
             onBlur={this.handleBlur}
+            onFocus={this.handleFocus}
             value={yearValue}
             inputProps={{
               ref: this.storeYearReference,

--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.test.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.test.js
@@ -65,6 +65,15 @@ describe('CustomMonthPicker', () => {
     expect(yearDropdown.props.valid).to.equal(false);
   });
 
+
+  it('should call onFocus when field has the focus', () => {
+    const onFocus = jest.fn();
+    renderToDom(<CustomMonthPicker id="testCustomMonthPicker" onFocus={onFocus} value={{ month: 6, year: 2010 }} fieldMessageId="testCustomMonthPicker-message" />);
+    Simulate.focus(monthDropdown);
+    Simulate.focus(yearDropdown);
+    expect(onFocus.mock.calls.length).equal(2);
+  });
+
   it('should send correct month year format in onChange handler when month is changed', () => {
     const onChange = newValue => {
       value = newValue;

--- a/react/MonthPicker/MonthPicker.js
+++ b/react/MonthPicker/MonthPicker.js
@@ -26,6 +26,7 @@ export default class MonthPicker extends Component {
     native: PropTypes.bool,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
+    onFocus: PropTypes.func,
     minYear: PropTypes.number,
     maxYear: PropTypes.number,
     ascendingYears: PropTypes.bool
@@ -53,6 +54,7 @@ export default class MonthPicker extends Component {
       native,
       valid,
       onBlur,
+      onFocus,
       minYear,
       maxYear,
       ascendingYears
@@ -65,6 +67,7 @@ export default class MonthPicker extends Component {
       value,
       onChange,
       onBlur,
+      onFocus,
       valid,
       minYear,
       maxYear,

--- a/react/MonthPicker/MonthPicker.test.js
+++ b/react/MonthPicker/MonthPicker.test.js
@@ -69,6 +69,14 @@ describe('MonthPicker', () => {
     });
   });
 
+  describe('onFocus', () => {
+    it('should pass onFocus prop through to input', () => {
+      const onFocus = () => {};
+      render(<MonthPicker id="testMonthPicker" onFocus={onFocus} />);
+      expect(monthPicker.props.onFocus).to.equal(onFocus);
+    });
+  });
+
   describe('value', () => {
     it('should pass value prop through to input', () => {
       const value = { month: 1, year: 2000 };

--- a/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.js
+++ b/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.js
@@ -35,6 +35,7 @@ export default class NativeMonthPicker extends Component {
     id: PropTypes.string.isRequired,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
+    onFocus: PropTypes.func,
     value: PropTypes.shape({
       month: PropTypes.number,
       year: PropTypes.number
@@ -52,6 +53,7 @@ export default class NativeMonthPicker extends Component {
 
     this.handleChange = this.handleChange.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
   }
 
   handleChange({ target: { value } }) {
@@ -67,6 +69,14 @@ export default class NativeMonthPicker extends Component {
 
     if (typeof onBlur === 'function') {
       onBlur(getValueFromString(value));
+    }
+  }
+
+  handleFocus(evt) {
+    const { onFocus } = this.props;
+
+    if (typeof onFocus === 'function') {
+      onFocus(evt);
     }
   }
 
@@ -105,6 +115,7 @@ export default class NativeMonthPicker extends Component {
           value={inputValue}
           onChange={this.handleChange}
           onBlur={this.handleBlur}
+          onFocus={this.handleFocus}
           aria-describedby={fieldMessageId}
         />
       </div>

--- a/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.test.js
+++ b/react/MonthPicker/NativeMonthPicker/NativeMonthPicker.test.js
@@ -88,4 +88,11 @@ describe('NativeMonthPicker', () => {
       year: 2012
     });
   });
+
+  it('should call onFocus when field has the focus', () => {
+    const onFocus = jest.fn();
+    renderToDom(<NativeMonthPicker id="testNativeMonthPicker" onFocus={onFocus} value={{ month: 6, year: 2010 }} fieldMessageId="testNativeMonthPicker-message" />);
+    Simulate.focus(input);
+    expect(onFocus.mock.calls.length).equal(1);
+  });
 });


### PR DESCRIPTION
Add onFocus hook to custom and native Monthpickers. 
For custom Monthpickers, focusing on either the month dropdown or the year dropdown will fire the event. 