### PR TITLE
feat(ReadMore): Adds backgroundColor prop

### DIFF
--- a/react/ReadMore/ReadMore.demo.js
+++ b/react/ReadMore/ReadMore.demo.js
@@ -7,6 +7,8 @@ import Text from '../Text/Text';
 import Card from '../Card/Card';
 import Section from '../Section/Section';
 
+import styles from './ReadMore.demo.less';
+
 const longText = (
   <Text>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vitae nulla
@@ -37,7 +39,11 @@ const shortText = (
 );
 
 const ReadMoreContainer = ({ component: DemoComponent, componentProps }) => (
-  <Card style={{ width: 500 }}>
+  <Card
+    style={{ width: 500 }}
+    className={
+      componentProps.backgroundColor === 'body' ? styles.grayBackground : ''
+    }>
     <Section>
       <DemoComponent {...componentProps} />
     </Section>
@@ -121,6 +127,32 @@ export default {
           transformProps: props => ({
             ...omit(props, 'maxLines'),
             maxRows: 20
+          })
+        }
+      ]
+    },
+    {
+      label: 'Color',
+      type: 'radio',
+      states: [
+        {
+          label: 'Default Background',
+          transformProps: props => ({
+            ...omit(props, 'backgroundColor')
+          })
+        },
+        {
+          label: 'Card',
+          transformProps: props => ({
+            ...props,
+            backgroundColor: 'card'
+          })
+        },
+        {
+          label: 'Body',
+          transformProps: props => ({
+            ...props,
+            backgroundColor: 'body'
           })
         }
       ]

--- a/react/ReadMore/ReadMore.demo.less
+++ b/react/ReadMore/ReadMore.demo.less
@@ -1,0 +1,5 @@
+@import (reference) '~seek-style-guide/theme';
+
+.grayBackground {
+  background-color: @sk-background;
+}

--- a/react/ReadMore/ReadMore.js
+++ b/react/ReadMore/ReadMore.js
@@ -27,7 +27,8 @@ type Props = {|
   maxLines?: number,
   maxRows?: number,
   moreLabel: string,
-  lessLabel: string
+  lessLabel: string,
+  backgroundColor: 'card' | 'body'
 |};
 type State = {|
   showMore: boolean,
@@ -86,11 +87,19 @@ class ReadMore extends PureComponent<Props, State> {
   };
 
   render() {
-    const { children, maxLines, maxRows, moreLabel, lessLabel } = this.props;
+    const {
+      children,
+      maxLines,
+      maxRows,
+      moreLabel,
+      lessLabel,
+      backgroundColor
+    } = this.props;
     const { tooLong, showMore, mounted } = this.state;
 
     const truncate = mounted ? !showMore && tooLong : true;
     const showFade = truncate && mounted;
+    const fadeColor = styles[backgroundColor || 'card'];
     const showMoreLessButton = tooLong && mounted;
 
     const contentStyle = truncate ? {
@@ -102,7 +111,9 @@ class ReadMore extends PureComponent<Props, State> {
       <div>
         <div className={styles.content} style={contentStyle}>
           <div ref={this.setTextRef}>{children}</div>
-          {showFade ? <div className={styles.fadeOut} /> : null}
+          {showFade ? (
+            <div className={[styles.fadeOut, fadeColor].join(' ')} />
+          ) : null}
         </div>
         {showMoreLessButton ? (
           <Button color="transparent" onClick={this.handleShowMore}>

--- a/react/ReadMore/ReadMore.less
+++ b/react/ReadMore/ReadMore.less
@@ -15,19 +15,21 @@
 }
 
 .card {
-  background: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 0) 0%,
-    @sk-white 100%
-  );
+  background:
+    linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0) 0%,
+      @sk-white 100%
+    );
 }
 
 .body {
-  background: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 0) 0%,
-    @sk-background 100%
-  );
+  background:
+    linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0) 0%,
+      @sk-background 100%
+    );
 }
 
 .chevron {

--- a/react/ReadMore/ReadMore.less
+++ b/react/ReadMore/ReadMore.less
@@ -1,4 +1,4 @@
-@import (reference) "~seek-style-guide/theme";
+@import (reference) '~seek-style-guide/theme';
 
 .content {
   position: relative;
@@ -8,11 +8,26 @@
 }
 
 .fadeOut {
-  background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, white 100%);
   position: absolute;
   height: (@row-height * 4);
   width: 100%;
   bottom: 0;
+}
+
+.card {
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0) 0%,
+    @sk-white 100%
+  );
+}
+
+.body {
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0) 0%,
+    @sk-background 100%
+  );
 }
 
 .chevron {


### PR DESCRIPTION
There is a need to use the ReadMore component on backgrounds that are not white (like a card is). This PR adds a `backgroundColor` prop, which takes a string describing the context the component is used in (currently "card" or "body"), and sets the colour of the fade element to match. Defaults to "card".

EXAMPLE USAGE:

```js
<ReadMore backgroundColor="body" maxLines={3}>
  <Text>Content</Text>
</ReadMore>
```
