### PR TITLE
feat(ReadMore): Add 'onShowMore' event handler prop

### DIFF
--- a/react/ReadMore/ReadMore.js
+++ b/react/ReadMore/ReadMore.js
@@ -29,7 +29,8 @@ type Props = {|
   maxRows?: number,
   moreLabel: string,
   lessLabel: string,
-  backgroundComponentName?: 'card' | 'body'
+  backgroundComponentName?: 'card' | 'body',
+  onShowMore?: Function
 |};
 type State = {|
   showMore: boolean,
@@ -83,9 +84,15 @@ class ReadMore extends PureComponent<Props, State> {
   };
 
   handleShowMore = () => {
+    const { onShowMore } = this.props;
+
     this.setState({
       showMore: !this.state.showMore
     });
+
+    if (onShowMore) {
+      onShowMore();
+    }
   };
 
   render() {

--- a/react/ReadMore/ReadMore.js
+++ b/react/ReadMore/ReadMore.js
@@ -86,13 +86,16 @@ class ReadMore extends PureComponent<Props, State> {
   handleShowMore = () => {
     const { onShowMore } = this.props;
 
-    this.setState({
-      showMore: !this.state.showMore
-    });
-
-    if (onShowMore) {
-      onShowMore();
-    }
+    this.setState(
+      {
+        showMore: !this.state.showMore
+      },
+      () => {
+        if (onShowMore) {
+          onShowMore(this.state.showMore);
+        }
+      }
+    );
   };
 
   render() {


### PR DESCRIPTION
We need to fire a tracking event on jobapply when the candidate expands the job ad. This PR adds a new `onShowMore` prop which takes a function that will be executed as part of the `handleShowMore` handler, if it exists.

The `onShowMore` function is executed as part of `setState`s async callback, to ensure the state changes have been applied when it's called. The component will pass the new value of `this.state.showMore` into `onShowMore`, so that different events can be triggered for expand or collapse, or to make it can only trigger on either expand or collapse. 

EXAMPLE USAGE:

```js
const trackShowMore = detailIsExpanded => {
  this.props.trackLink(detailIsExpanded ? 'job-details-expanded' : 'job-details-collapsed');
}

<ReadMore onShowMore={trackShowMore}>
  <Text>Long piece of text</Text>
</ReadMore>
```
