### PR TITLE
fix(Autosuggest): Add resolutions to fix yarn install for pinned package

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "react-autowhatever": "10.1.1",
     "react-isolated-scroll": "^0.1.1"
   },
+  "resolutions": { 
+    "react-autowhatever": "10.1.1"
+  },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0",


### PR DESCRIPTION
Yarn install was not de-duping the dependency correctly and still installing the incorrect version of react-autowhatever.

This is a non issue with npm and also will be removed when we rebuild Autosuggest.