### PR TITLE
fix(ReadMore): Make backgroundComponentName prop required

### DIFF
--- a/react/ReadMore/ReadMore.js
+++ b/react/ReadMore/ReadMore.js
@@ -29,7 +29,7 @@ type Props = {|
   maxRows?: number,
   moreLabel: string,
   lessLabel: string,
-  backgroundComponentName?: 'card' | 'body',
+  backgroundComponentName: 'card' | 'body',
   onShowMore?: Function
 |};
 type State = {|
@@ -111,7 +111,7 @@ class ReadMore extends PureComponent<Props, State> {
 
     const truncate = mounted ? !showMore && tooLong : true;
     const showFade = truncate && mounted;
-    const fadeColor = backgroundComponentName === 'body' ? styles.body : styles.card;
+    const fadeColor = styles[backgroundComponentName];
     const showMoreLessButton = tooLong && mounted;
 
     const contentStyle = truncate ? {

--- a/react/ReadMore/ReadMore.js
+++ b/react/ReadMore/ReadMore.js
@@ -111,7 +111,7 @@ class ReadMore extends PureComponent<Props, State> {
 
     const truncate = mounted ? !showMore && tooLong : true;
     const showFade = truncate && mounted;
-    const fadeColor = styles[backgroundComponentName];
+    const fadeColor = backgroundComponentName === 'body' ? styles.body : styles.card;
     const showMoreLessButton = tooLong && mounted;
 
     const contentStyle = truncate ? {


### PR DESCRIPTION
The change in #525 added a new prop to ReadMore and all flow checks passed in the styleguide. I'm using the ReadMore component in my app and my build of the latest styleguide version failed with the below error. I've adjusted the type to make `backgroundComponentName` a required prop. There's a default prop in place so there's no need to pass that prop when using the component

![screen shot 2018-08-07 at 11 20 45 am](https://user-images.githubusercontent.com/1896277/43748713-65a7f59e-9a34-11e8-88c2-5663b48e99b8.png)
