### PR TITLE
feat(PartnerSites): Allow overriding links for locale switcher

### DIFF
--- a/react/PartnerSites/Locales/Locales.js
+++ b/react/PartnerSites/Locales/Locales.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import ScreenReaderOnly from '../../ScreenReaderOnly/ScreenReaderOnly';
 
-export default function Locales({ locale, linkRenderer }) {
+export default function Locales({ locale, linkRenderer, localeLinks }) {
   const isAU = locale === 'AU';
   const isNZ = locale === 'NZ';
 
@@ -15,46 +15,41 @@ export default function Locales({ locale, linkRenderer }) {
   });
 
   return (
-    <nav aria-labelledby="Locales" role="navigation" className={styles.root}>
-
+    <nav aria-labelledby='Locales' role='navigation' className={styles.root}>
       <ScreenReaderOnly>
-        <h1 id="Locales">Select your country</h1>
+        <h1 id='Locales'>Select your country</h1>
       </ScreenReaderOnly>
 
       <ul className={listClasses}>
         <li className={styles.listItem}>
-          {
-            isAU ?
-              <span className={styles.locale_isActive}>AU</span> :
-              linkRenderer({
-                'data-analytics': 'header:au+homepage',
-                className: styles.localeLink,
-                href: 'https://www.seek.com.au',
-                title: 'SEEK Australia',
-                children: 'AU'
-              })
-          }
+          {isAU ? (
+            <span className={styles.locale_isActive}>AU</span>
+          ) : (
+            linkRenderer({
+              className: styles.localeLink,
+              children: 'AU',
+              ...localeLinks.AU
+            })
+          )}
         </li>
         <li className={styles.listItem}>
-          {
-            isNZ ?
-              <span className={styles.locale_isActive}>NZ</span> :
-              linkRenderer({
-                'data-analytics': 'header:nz+homepage',
-                className: styles.localeLink,
-                href: 'https://www.seek.co.nz',
-                title: 'SEEK New Zealand',
-                children: 'NZ'
-              })
-          }
+          {isNZ ? (
+            <span className={styles.locale_isActive}>NZ</span>
+          ) : (
+            linkRenderer({
+              className: styles.localeLink,
+              children: 'NZ',
+              ...localeLinks.NZ
+            })
+          )}
         </li>
       </ul>
-
     </nav>
   );
 }
 
 Locales.propTypes = {
   locale: PropTypes.string.isRequired,
-  linkRenderer: PropTypes.func.isRequired
+  linkRenderer: PropTypes.func.isRequired,
+  localeLinks: PropTypes.object.isRequired
 };

--- a/react/PartnerSites/Locales/Locales.js
+++ b/react/PartnerSites/Locales/Locales.js
@@ -15,9 +15,9 @@ export default function Locales({ locale, linkRenderer, localeLinks }) {
   });
 
   return (
-    <nav aria-labelledby='Locales' role='navigation' className={styles.root}>
+    <nav aria-labelledby="Locales" role="navigation" className={styles.root}>
       <ScreenReaderOnly>
-        <h1 id='Locales'>Select your country</h1>
+        <h1 id="Locales">Select your country</h1>
       </ScreenReaderOnly>
 
       <ul className={listClasses}>
@@ -48,8 +48,17 @@ export default function Locales({ locale, linkRenderer, localeLinks }) {
   );
 }
 
+const localeLink = PropTypes.shape({
+  'data-analytics': PropTypes.string,
+  href: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired
+});
+
 Locales.propTypes = {
   locale: PropTypes.string.isRequired,
   linkRenderer: PropTypes.func.isRequired,
-  localeLinks: PropTypes.object.isRequired
+  localeLinks: PropTypes.shape({
+    AU: localeLink.isRequired,
+    NZ: localeLink.isRequired
+  }).isRequired
 };

--- a/react/PartnerSites/Locales/Locales.test.js
+++ b/react/PartnerSites/Locales/Locales.test.js
@@ -5,13 +5,27 @@ import Locales from './Locales';
 
 const renderLocales = props => render(<Locales {...props} />);
 const linkRenderer = props => (<a {...props} />);
+const localeLinks = {
+  AU: {
+    'data-analytics': 'header:au+homepage',
+    href: 'https://www.seek.com.au',
+    title: 'SEEK Australia',
+    children: 'AU'
+  },
+  NZ: {
+    'data-analytics': 'header:nz+homepage',
+    href: 'https://www.seek.co.nz',
+    title: 'SEEK New Zealand',
+    children: 'NZ'
+  }
+};
 
 describe('Locales:', () => {
   it('should render with locale of AU first and active', () => {
-    expect(renderLocales({ locale: 'AU', linkRenderer })).toMatchSnapshot();
+    expect(renderLocales({ locale: 'AU', linkRenderer, localeLinks })).toMatchSnapshot();
   });
 
   it('should render with locale of NZ first and active', () => {
-    expect(renderLocales({ locale: 'NZ', linkRenderer })).toMatchSnapshot();
+    expect(renderLocales({ locale: 'NZ', linkRenderer, localeLinks })).toMatchSnapshot();
   });
 });

--- a/react/PartnerSites/PartnerSites.demo.js
+++ b/react/PartnerSites/PartnerSites.demo.js
@@ -68,6 +68,30 @@ export default {
           })
         }
       ]
+    },
+    {
+      label: 'Override Locale Links',
+      type: 'checkbox',
+      states: [
+        {
+          label: 'Override Locale Links',
+          transformProps: props => ({
+            ...props,
+            localeLinks: {
+              AU: {
+                'data-analytics': 'header:au+talent',
+                href: 'https://talent.seek.com.au',
+                title: 'SEEK Employer Australia'
+              },
+              NZ: {
+                'data-analytics': 'header:nz+talent',
+                href: 'https://talent.seek.co.nz',
+                title: 'SEEK Employer New Zealand'
+              }
+            }
+          })
+        }
+      ]
     }
   ]
 };

--- a/react/PartnerSites/PartnerSites.demo.js
+++ b/react/PartnerSites/PartnerSites.demo.js
@@ -79,12 +79,12 @@ export default {
             ...props,
             localeLinks: {
               AU: {
-                'data-analytics': 'header:au+talent',
+                'data-analytics': 'header:au+employer',
                 href: 'https://talent.seek.com.au',
                 title: 'SEEK Employer Australia'
               },
               NZ: {
-                'data-analytics': 'header:nz+talent',
+                'data-analytics': 'header:nz+employer',
                 href: 'https://talent.seek.co.nz',
                 title: 'SEEK Employer New Zealand'
               }

--- a/react/PartnerSites/PartnerSites.js
+++ b/react/PartnerSites/PartnerSites.js
@@ -37,6 +37,12 @@ export default function PartnerSites({
 
 PartnerSites.displayName = 'PartnerSites';
 
+const localeLink = PropTypes.shape({
+  'data-analytics': PropTypes.String,
+  href: PropTypes.String,
+  title: PropTypes.String
+});
+
 PartnerSites.propTypes = {
   locale: PropTypes.oneOf(['AU', 'NZ']),
   linkRenderer: PropTypes.func,
@@ -46,7 +52,10 @@ PartnerSites.propTypes = {
     'Businesses for sale',
     'Volunteering'
   ]),
-  localeLinks: PropTypes.object
+  localeLinks: PropTypes.shape({
+    AU: localeLink,
+    NZ: localeLink
+  })
 };
 
 PartnerSites.defaultProps = {

--- a/react/PartnerSites/PartnerSites.js
+++ b/react/PartnerSites/PartnerSites.js
@@ -7,17 +7,32 @@ import PageBlock from '../PageBlock/PageBlock';
 import Locales from './Locales/Locales';
 import Sites from './Sites/Sites';
 
-const defaultLinkRenderer = props => (<a {...props} />);
+const defaultLinkRenderer = props => <a {...props} />;
 
-export default function PartnerSites({ locale, linkRenderer, activeSite }) {
-  return (<Hidden component={PageBlock} print mobile className={styles.root}>
-    <div className={styles.content}>
-      <Sites locale={locale} linkRenderer={linkRenderer} activeSite={activeSite} />
-      <div className={styles.locale}>
-        <Locales locale={locale} linkRenderer={linkRenderer} />
+export default function PartnerSites({
+  locale,
+  linkRenderer,
+  activeSite,
+  localeLinks
+}) {
+  return (
+    <Hidden component={PageBlock} print mobile className={styles.root}>
+      <div className={styles.content}>
+        <Sites
+          locale={locale}
+          linkRenderer={linkRenderer}
+          activeSite={activeSite}
+        />
+        <div className={styles.locale}>
+          <Locales
+            locale={locale}
+            linkRenderer={linkRenderer}
+            localeLinks={localeLinks}
+          />
+        </div>
       </div>
-    </div>
-  </Hidden>);
+    </Hidden>
+  );
 }
 
 PartnerSites.displayName = 'PartnerSites';
@@ -25,11 +40,29 @@ PartnerSites.displayName = 'PartnerSites';
 PartnerSites.propTypes = {
   locale: PropTypes.oneOf(['AU', 'NZ']),
   linkRenderer: PropTypes.func,
-  activeSite: PropTypes.oneOf(['Jobs', 'Courses', 'Businesses for sale', 'Volunteering'])
+  activeSite: PropTypes.oneOf([
+    'Jobs',
+    'Courses',
+    'Businesses for sale',
+    'Volunteering'
+  ]),
+  localeLinks: PropTypes.object
 };
 
 PartnerSites.defaultProps = {
   locale: 'AU',
   linkRenderer: defaultLinkRenderer,
-  activeSite: null
+  activeSite: null,
+  localeLinks: {
+    AU: {
+      'data-analytics': 'header:au+homepage',
+      href: 'https://www.seek.com.au',
+      title: 'SEEK Australia'
+    },
+    NZ: {
+      'data-analytics': 'header:nz+homepage',
+      href: 'https://www.seek.co.nz',
+      title: 'SEEK New Zealand'
+    }
+  }
 };

--- a/react/PartnerSites/PartnerSites.js
+++ b/react/PartnerSites/PartnerSites.js
@@ -38,9 +38,9 @@ export default function PartnerSites({
 PartnerSites.displayName = 'PartnerSites';
 
 const localeLink = PropTypes.shape({
-  'data-analytics': PropTypes.String,
-  href: PropTypes.String,
-  title: PropTypes.String
+  'data-analytics': PropTypes.string,
+  href: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired
 });
 
 PartnerSites.propTypes = {
@@ -53,8 +53,8 @@ PartnerSites.propTypes = {
     'Volunteering'
   ]),
   localeLinks: PropTypes.shape({
-    AU: localeLink,
-    NZ: localeLink
+    AU: localeLink.isRequired,
+    NZ: localeLink.isRequired
   })
 };
 

--- a/react/PartnerSites/PartnerSites.test.js
+++ b/react/PartnerSites/PartnerSites.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render } from 'enzyme';
+
+import PartnerSites from './PartnerSites';
+
+const renderPartnerSites = props => render(<PartnerSites {...props} />);
+
+describe('Header:', () => {
+  const links = {
+    AU: {
+      'data-analytics': 'header:au+employer',
+      href: 'https://talent.seek.com.au',
+      title: 'SEEK Employer Australia',
+      children: 'AU'
+    },
+    NZ: {
+      'data-analytics': 'header:nz+employer',
+      href: 'https://talent.seek.co.nz',
+      title: 'SEEK Employer New Zealand',
+      children: 'NZ'
+    }
+  };
+  it('should render with locale of AU', () => {
+    expect(renderPartnerSites({ locale: 'AU' })).toMatchSnapshot();
+  });
+
+  it('should render with locale of NZ', () => {
+    expect(renderPartnerSites({ locale: 'NZ' })).toMatchSnapshot();
+  });
+
+  it('should render with overridden AU Locale link', () => {
+    expect(renderPartnerSites({ locale: 'NZ', localeLinks: links })).toMatchSnapshot();
+  });
+
+  it('should render with overridden NZ Locale link', () => {
+    expect(renderPartnerSites({ locale: 'AU', localeLinks: links })).toMatchSnapshot();
+  });
+});

--- a/react/PartnerSites/__snapshots__/PartnerSites.test.js.snap
+++ b/react/PartnerSites/__snapshots__/PartnerSites.test.js.snap
@@ -1,0 +1,449 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Header: should render with locale of AU 1`] = `
+<div
+  class="PartnerSites__root Hidden__mobile Hidden__print"
+>
+  <div
+    class="PageBlock__content"
+  >
+    <div
+      class="PartnerSites__content"
+    >
+      <nav
+        aria-labelledby="Sites"
+        role="navigation"
+      >
+        <span
+          class="ScreenReaderOnly__root"
+        >
+          <h1
+            id="Sites"
+          >
+            SEEK Sites
+          </h1>
+        </span>
+        <ul
+          class="Sites__list"
+        >
+          <li>
+            <a
+              class="Sites__link Sites__link_isJobs"
+              data-analytics="header:jobs"
+              href="https://www.seek.com.au"
+              title="SEEK Jobs"
+            >
+              Jobs
+            </a>
+          </li>
+          <li>
+            <a
+              class="Sites__link Sites__link_isLearning"
+              data-analytics="header:courses"
+              href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
+              title="SEEK Learning"
+            >
+              Courses
+            </a>
+          </li>
+          <li>
+            <a
+              class="Sites__link Sites__link_isBusiness"
+              data-analytics="header:business+for+sale"
+              href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
+              title="SEEK Business"
+            >
+              Businesses for sale
+            </a>
+          </li>
+          <li>
+            <a
+              class="Sites__link Sites__link_isVolunteering"
+              data-analytics="header:volunteering"
+              href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
+              title="SEEK Volunteer"
+            >
+              Volunteering
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="PartnerSites__locale"
+      >
+        <nav
+          aria-labelledby="Locales"
+          role="navigation"
+        >
+          <span
+            class="ScreenReaderOnly__root"
+          >
+            <h1
+              id="Locales"
+            >
+              Select your country
+            </h1>
+          </span>
+          <ul
+            class="Locales__list"
+          >
+            <li>
+              <span
+                class="Locales__locale_isActive"
+              >
+                AU
+              </span>
+            </li>
+            <li>
+              <a
+                class="Locales__localeLink"
+                data-analytics="header:nz+homepage"
+                href="https://www.seek.co.nz"
+                title="SEEK New Zealand"
+              >
+                NZ
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Header: should render with locale of NZ 1`] = `
+<div
+  class="PartnerSites__root Hidden__mobile Hidden__print"
+>
+  <div
+    class="PageBlock__content"
+  >
+    <div
+      class="PartnerSites__content"
+    >
+      <nav
+        aria-labelledby="Sites"
+        role="navigation"
+      >
+        <span
+          class="ScreenReaderOnly__root"
+        >
+          <h1
+            id="Sites"
+          >
+            SEEK Sites
+          </h1>
+        </span>
+        <ul
+          class="Sites__list"
+        >
+          <li>
+            <a
+              class="Sites__link Sites__link_isJobs"
+              data-analytics="header:jobs"
+              href="https://www.seek.co.nz"
+              title="SEEK Jobs"
+            >
+              Jobs
+            </a>
+          </li>
+          <li>
+            <a
+              class="Sites__link Sites__link_isLearning"
+              data-analytics="header:courses"
+              href="https://www.seeklearning.co.nz/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
+              title="SEEK Learning"
+            >
+              Courses
+            </a>
+          </li>
+          <li>
+            <a
+              class="Sites__link Sites__link_isBusiness"
+              data-analytics="header:business+for+sale"
+              href="https://www.seekbusiness.com.au/?site=nz&tracking=sk:main:nz:nav:bus"
+              title="SEEK Business"
+            >
+              Businesses for sale
+            </a>
+          </li>
+          <li>
+            <a
+              class="Sites__link Sites__link_isVolunteering"
+              data-analytics="header:volunteering"
+              href="https://seekvolunteer.co.nz/?tracking=SKMNZ:main+header"
+              title="SEEK Volunteer"
+            >
+              Volunteering
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="PartnerSites__locale"
+      >
+        <nav
+          aria-labelledby="Locales"
+          role="navigation"
+        >
+          <span
+            class="ScreenReaderOnly__root"
+          >
+            <h1
+              id="Locales"
+            >
+              Select your country
+            </h1>
+          </span>
+          <ul
+            class="Locales__list Locales__list_isNZ"
+          >
+            <li>
+              <a
+                class="Locales__localeLink"
+                data-analytics="header:au+homepage"
+                href="https://www.seek.com.au"
+                title="SEEK Australia"
+              >
+                AU
+              </a>
+            </li>
+            <li>
+              <span
+                class="Locales__locale_isActive"
+              >
+                NZ
+              </span>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Header: should render with overridden AU Locale link 1`] = `
+<div
+  class="PartnerSites__root Hidden__mobile Hidden__print"
+>
+  <div
+    class="PageBlock__content"
+  >
+    <div
+      class="PartnerSites__content"
+    >
+      <nav
+        aria-labelledby="Sites"
+        role="navigation"
+      >
+        <span
+          class="ScreenReaderOnly__root"
+        >
+          <h1
+            id="Sites"
+          >
+            SEEK Sites
+          </h1>
+        </span>
+        <ul
+          class="Sites__list"
+        >
+          <li>
+            <a
+              class="Sites__link Sites__link_isJobs"
+              data-analytics="header:jobs"
+              href="https://www.seek.co.nz"
+              title="SEEK Jobs"
+            >
+              Jobs
+            </a>
+          </li>
+          <li>
+            <a
+              class="Sites__link Sites__link_isLearning"
+              data-analytics="header:courses"
+              href="https://www.seeklearning.co.nz/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
+              title="SEEK Learning"
+            >
+              Courses
+            </a>
+          </li>
+          <li>
+            <a
+              class="Sites__link Sites__link_isBusiness"
+              data-analytics="header:business+for+sale"
+              href="https://www.seekbusiness.com.au/?site=nz&tracking=sk:main:nz:nav:bus"
+              title="SEEK Business"
+            >
+              Businesses for sale
+            </a>
+          </li>
+          <li>
+            <a
+              class="Sites__link Sites__link_isVolunteering"
+              data-analytics="header:volunteering"
+              href="https://seekvolunteer.co.nz/?tracking=SKMNZ:main+header"
+              title="SEEK Volunteer"
+            >
+              Volunteering
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="PartnerSites__locale"
+      >
+        <nav
+          aria-labelledby="Locales"
+          role="navigation"
+        >
+          <span
+            class="ScreenReaderOnly__root"
+          >
+            <h1
+              id="Locales"
+            >
+              Select your country
+            </h1>
+          </span>
+          <ul
+            class="Locales__list Locales__list_isNZ"
+          >
+            <li>
+              <a
+                class="Locales__localeLink"
+                data-analytics="header:au+employer"
+                href="https://talent.seek.com.au"
+                title="SEEK Employer Australia"
+              >
+                AU
+              </a>
+            </li>
+            <li>
+              <span
+                class="Locales__locale_isActive"
+              >
+                NZ
+              </span>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Header: should render with overridden NZ Locale link 1`] = `
+<div
+  class="PartnerSites__root Hidden__mobile Hidden__print"
+>
+  <div
+    class="PageBlock__content"
+  >
+    <div
+      class="PartnerSites__content"
+    >
+      <nav
+        aria-labelledby="Sites"
+        role="navigation"
+      >
+        <span
+          class="ScreenReaderOnly__root"
+        >
+          <h1
+            id="Sites"
+          >
+            SEEK Sites
+          </h1>
+        </span>
+        <ul
+          class="Sites__list"
+        >
+          <li>
+            <a
+              class="Sites__link Sites__link_isJobs"
+              data-analytics="header:jobs"
+              href="https://www.seek.com.au"
+              title="SEEK Jobs"
+            >
+              Jobs
+            </a>
+          </li>
+          <li>
+            <a
+              class="Sites__link Sites__link_isLearning"
+              data-analytics="header:courses"
+              href="https://www.seek.com.au/learning/?campaigncode=seek_banner_29&sc_trk=skj-courses-link"
+              title="SEEK Learning"
+            >
+              Courses
+            </a>
+          </li>
+          <li>
+            <a
+              class="Sites__link Sites__link_isBusiness"
+              data-analytics="header:business+for+sale"
+              href="https://www.seekbusiness.com.au/?tracking=sk:main:au:nav:bus"
+              title="SEEK Business"
+            >
+              Businesses for sale
+            </a>
+          </li>
+          <li>
+            <a
+              class="Sites__link Sites__link_isVolunteering"
+              data-analytics="header:volunteering"
+              href="https://www.volunteer.com.au/?tracking=SKMAU:main+header"
+              title="SEEK Volunteer"
+            >
+              Volunteering
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="PartnerSites__locale"
+      >
+        <nav
+          aria-labelledby="Locales"
+          role="navigation"
+        >
+          <span
+            class="ScreenReaderOnly__root"
+          >
+            <h1
+              id="Locales"
+            >
+              Select your country
+            </h1>
+          </span>
+          <ul
+            class="Locales__list"
+          >
+            <li>
+              <span
+                class="Locales__locale_isActive"
+              >
+                AU
+              </span>
+            </li>
+            <li>
+              <a
+                class="Locales__localeLink"
+                data-analytics="header:nz+employer"
+                href="https://talent.seek.co.nz"
+                title="SEEK Employer New Zealand"
+              >
+                NZ
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
### Motivation
Hirer acquisition would like to use the Partner Sites header for our shopfront redesign. Currently the Partner Sites component has the SEEK Candidate URLs embedded within the component, with locale changes taking the user back to www.seek.com.au. 

### Proposed solution 
In this PR, an additional, optional prop has been added to the partner sites component be able to specify a custom analytics tag, href link and link title. 

current:
```<PartnerSites locale={locale} />```

proposed:
```
localeLinks: {
    AU: {
      'data-analytics': 'header:au+talent',
      href: 'https://talent.seek.com.au',
      title: 'SEEK Employer Australia'
    },
    NZ: {
      'data-analytics': 'header:nz+talent',
      href: 'https://talent.seek.co.nz',
      title: 'SEEK Employer New Zealand'
    }
  }

<PartnerSites locale={locale} localeLinks={localeLinks} />
```