### PR TITLE
feat(Highlight): Add the concept of tone to the highlight component

### DIFF
--- a/react/Highlight/Highlight.demo.js
+++ b/react/Highlight/Highlight.demo.js
@@ -3,6 +3,8 @@ import Highlight from './Highlight';
 import Text from '../Text/Text';
 import { TONE } from '../Section/Section';
 const NEUTRAL = 'neutral';
+const FOCUS = 'focus';
+const SECONDARY = 'secondary';
 
 const renderChildren = props => ([
   'This text is ',
@@ -24,7 +26,7 @@ export default {
       type: 'checklist',
       states: [
         {
-          label: 'Secondary',
+          label: 'Secondary text',
           transformProps: props => ({
             ...props,
             secondary: true,
@@ -44,6 +46,16 @@ export default {
             children: renderChildren({
               secondary: props.secondary,
               tone: NEUTRAL
+            })
+          })
+        },
+        {
+          label: 'Secondary',
+          transformProps: props => ({
+            ...props,
+            children: renderChildren({
+              secondary: props.secondary,
+              tone: SECONDARY
             })
           })
         },
@@ -74,6 +86,16 @@ export default {
             children: renderChildren({
               secondary: props.secondary,
               tone: TONE.INFO
+            })
+          })
+        },
+        {
+          label: 'Focus',
+          transformProps: props => ({
+            ...props,
+            children: renderChildren({
+              secondary: props.secondary,
+              tone: FOCUS
             })
           })
         }

--- a/react/Highlight/Highlight.demo.js
+++ b/react/Highlight/Highlight.demo.js
@@ -1,6 +1,13 @@
 import React from 'react';
 import Highlight from './Highlight';
 import Text from '../Text/Text';
+import { TONE } from '../Section/Section';
+const NEUTRAL = 'neutral';
+
+const renderChildren = props => ([
+  'This text is ',
+  <Highlight key="highlight" {...props}>highlighted</Highlight>
+]);
 
 export default {
   route: '/highlight',
@@ -9,10 +16,7 @@ export default {
   component: Text,
   initialProps: {
     headline: true,
-    children: [
-      'This text is ',
-      <Highlight key="highlight">highlighted</Highlight>
-    ]
+    children: renderChildren({ tone: NEUTRAL })
   },
   options: [
     {
@@ -24,10 +28,53 @@ export default {
           transformProps: props => ({
             ...props,
             secondary: true,
-            children: [
-              'This text is ',
-              <Highlight key="highlight" secondary>highlighted</Highlight>
-            ]
+            children: renderChildren({ secondary: true })
+          })
+        }
+      ]
+    },
+    {
+      label: 'Tone',
+      type: 'radio',
+      states: [
+        {
+          label: 'Neutral',
+          transformProps: props => ({
+            ...props,
+            children: renderChildren({
+              secondary: props.secondary,
+              tone: NEUTRAL
+            })
+          })
+        },
+        {
+          label: 'Critical',
+          transformProps: props => ({
+            ...props,
+            children: renderChildren({
+              secondary: props.secondary,
+              tone: TONE.CRITICAL
+            })
+          })
+        },
+        {
+          label: 'Positive',
+          transformProps: props => ({
+            ...props,
+            children: renderChildren({
+              secondary: props.secondary,
+              tone: TONE.POSITIVE
+            })
+          })
+        },
+        {
+          label: 'Info',
+          transformProps: props => ({
+            ...props,
+            children: renderChildren({
+              secondary: props.secondary,
+              tone: TONE.INFO
+            })
           })
         }
       ]

--- a/react/Highlight/Highlight.demo.js
+++ b/react/Highlight/Highlight.demo.js
@@ -3,13 +3,13 @@ import Highlight from './Highlight';
 import Text from '../Text/Text';
 import { TONE } from '../Section/Section';
 const NEUTRAL = 'neutral';
-const FOCUS = 'focus';
-const SECONDARY = 'secondary';
 
-const renderChildren = props => ([
+const renderChildren = props => [
   'This text is ',
-  <Highlight key="highlight" {...props}>highlighted</Highlight>
-]);
+  <Highlight key="highlight" {...props}>
+    highlighted
+  </Highlight>
+];
 
 export default {
   route: '/highlight',
@@ -40,24 +40,7 @@ export default {
       type: 'radio',
       states: [
         {
-          label: 'Neutral',
-          transformProps: props => ({
-            ...props,
-            children: renderChildren({
-              secondary: props.secondary,
-              tone: NEUTRAL
-            })
-          })
-        },
-        {
-          label: 'Secondary',
-          transformProps: props => ({
-            ...props,
-            children: renderChildren({
-              secondary: props.secondary,
-              tone: SECONDARY
-            })
-          })
+          label: 'Select tone...'
         },
         {
           label: 'Critical',
@@ -66,36 +49,6 @@ export default {
             children: renderChildren({
               secondary: props.secondary,
               tone: TONE.CRITICAL
-            })
-          })
-        },
-        {
-          label: 'Positive',
-          transformProps: props => ({
-            ...props,
-            children: renderChildren({
-              secondary: props.secondary,
-              tone: TONE.POSITIVE
-            })
-          })
-        },
-        {
-          label: 'Info',
-          transformProps: props => ({
-            ...props,
-            children: renderChildren({
-              secondary: props.secondary,
-              tone: TONE.INFO
-            })
-          })
-        },
-        {
-          label: 'Focus',
-          transformProps: props => ({
-            ...props,
-            children: renderChildren({
-              secondary: props.secondary,
-              tone: FOCUS
             })
           })
         }

--- a/react/Highlight/Highlight.js
+++ b/react/Highlight/Highlight.js
@@ -9,7 +9,7 @@ type Props = {
   children: Node,
   secondary?: boolean,
   className?: string,
-  tone: TONE.POSITIVE | TONE.CRITICAL | TONE.INFO | 'neutral'
+  tone: TONE.POSITIVE | TONE.CRITICAL | TONE.INFO | 'neutral' | 'focus' | 'secondary'
 };
 
 export default function Highlight(props: Props) {
@@ -19,7 +19,7 @@ export default function Highlight(props: Props) {
       {...restProps}
       className={classnames({
         [styles.root]: true,
-        [styles.secondary]: secondary,
+        [styles.secondaryText]: secondary,
         [styles[tone]]: true,
         className
       })}>

--- a/react/Highlight/Highlight.js
+++ b/react/Highlight/Highlight.js
@@ -3,22 +3,24 @@ import styles from './Highlight.less';
 import React from 'react';
 import type { Node } from 'react';
 import classnames from 'classnames';
+import { TONE } from '../Section/Section';
 
 type Props = {
   children: Node,
   secondary?: boolean,
-  className?: string
+  className?: string,
+  tone: TONE.POSITIVE | TONE.CRITICAL | TONE.INFO | 'neutral'
 };
 
 export default function Highlight(props: Props) {
-  const { children, secondary, className, ...restProps } = props;
-
+  const { children, secondary, tone, className, ...restProps } = props;
   return (
     <mark
       {...restProps}
       className={classnames({
         [styles.root]: true,
         [styles.secondary]: secondary,
+        [styles[tone]]: true,
         className
       })}>
       {children}

--- a/react/Highlight/Highlight.js
+++ b/react/Highlight/Highlight.js
@@ -9,7 +9,7 @@ type Props = {
   children: Node,
   secondary?: boolean,
   className?: string,
-  tone: TONE.POSITIVE | TONE.CRITICAL | TONE.INFO | 'neutral' | 'focus' | 'secondary'
+  tone: TONE.CRITICAL | 'neutral'
 };
 
 export default function Highlight(props: Props) {

--- a/react/Highlight/Highlight.less
+++ b/react/Highlight/Highlight.less
@@ -11,8 +11,20 @@
   background-color: fade(@color, 12%);
 }
 
+.secondaryText {
+  color: @sk-charcoal;
+}
+
 .neutral {
-  .highlightBackground(@sk-focus);
+  .highlightBackground(@sk-black);
+}
+
+.secondary {
+  .highlightBackground(@sk-mid-gray-dark);
+}
+
+.info {
+  .highlightBackground(@sk-info);
 }
 
 .critical {
@@ -23,10 +35,6 @@
   .highlightBackground(@sk-positive);
 }
 
-.info {
-  .highlightBackground(@sk-info);
-}
-
-.secondary {
-  color: @sk-charcoal;
+.focus {
+  .highlightBackground(@sk-focus);
 }

--- a/react/Highlight/Highlight.less
+++ b/react/Highlight/Highlight.less
@@ -5,6 +5,7 @@
   display: inline-block;
   margin: -2px;
   padding: 2px;
+  .highlightBackground(@sk-focus);
 }
 
 .highlightBackground(@color) {
@@ -15,26 +16,6 @@
   color: @sk-charcoal;
 }
 
-.neutral {
-  .highlightBackground(@sk-black);
-}
-
-.secondary {
-  .highlightBackground(@sk-mid-gray-dark);
-}
-
-.info {
-  .highlightBackground(@sk-info);
-}
-
 .critical {
   .highlightBackground(@sk-critical);
-}
-
-.positive {
-  .highlightBackground(@sk-positive);
-}
-
-.focus {
-  .highlightBackground(@sk-focus);
 }

--- a/react/Highlight/Highlight.less
+++ b/react/Highlight/Highlight.less
@@ -1,11 +1,30 @@
 @import (reference) "~seek-style-guide/theme";
 
 .root {
-  background-color: fade(@sk-blue-lighter, 12%);
   border-radius: 2px;
   display: inline-block;
   margin: -2px;
   padding: 2px;
+}
+
+.highlightBackground(@color) {
+  background-color: fade(@color, 12%);
+}
+
+.neutral {
+  .highlightBackground(@sk-focus);
+}
+
+.critical {
+  .highlightBackground(@sk-critical);
+}
+
+.positive {
+  .highlightBackground(@sk-positive);
+}
+
+.info {
+  .highlightBackground(@sk-info);
 }
 
 .secondary {


### PR DESCRIPTION
Demo: http://seek-style-guide--47c5bb50b08816738b4e10f5ad9159995d1098be.surge.sh/highlight

This PR https://github.com/seek-oss/seek-style-guide/pull/533 uses the concept of highlighting but doesn't directly use the highlight component because the required colour is not currently available. 

I've added the concept of tone to the highlight component to address the lack of colours currently available.

Neutral tone was added to the styleguide in this (currently un-merged) PR. https://github.com/seek-oss/seek-style-guide/pull/524. I'm planning to go back and do some refactoring here once this has been merged.

Before:

```js
<Highlight>My text</Highlight>
```

After:

```js
<Highlight tone={'neutral'|'positive'|'critical'|'info'}>My text</Highlight>
```