### PR TITLE
fix(Button): Remove passing ref to child component

### DIFF
--- a/react/Button/Button.js
+++ b/react/Button/Button.js
@@ -29,12 +29,6 @@ export default class Button extends Component<Props> {
   button: ?HTMLElement;
   props: Props;
 
-  storeButtonReference = (button: ?HTMLElement) => {
-    if (button !== null) {
-      this.button = button;
-    }
-  };
-
   render() {
     const {
       color,
@@ -55,7 +49,6 @@ export default class Button extends Component<Props> {
         [styles[`root_is${capitalize(color)}`]]: color
       }),
       disabled: loading,
-      ref: this.storeButtonReference,
       ...restProps
     };
 


### PR DESCRIPTION
The Button component currently passes a [ref](https://reactjs.org/docs/refs-and-the-dom.html) to it's child.
This ref is not used or accessible via typical use.

The ref was added as part of an attempt to [address border problems in Firefox](https://github.com/seek-oss/seek-style-guide/pull/30)

This no-longer appears to be necessary, see screenshot from Firefox with this change.

<img width="305" alt="screen shot 2018-09-20 at 9 24 04 am" src="https://user-images.githubusercontent.com/13903378/45787109-f6791400-bcb6-11e8-9f3e-b83e01037f97.png">
