### PR TITLE
fix(Textarea): Update invalid text highlighting logic

### DIFF
--- a/react/Textarea/textAreaUtils.js
+++ b/react/Textarea/textAreaUtils.js
@@ -10,8 +10,8 @@ type Range = {
 
 type InvalidText = string | Range | Array<Range>;
 
-const formatText = (text: string, style: string) =>
-  <Highlight tone="critical" className={style}>{text}</Highlight>;
+const formatText = (text: string, style: string, key: number) =>
+  <Highlight tone="critical" className={style} key={key}>{text}</Highlight>;
 
 export const formatInvalidText = (value: string, invalidText: InvalidText, style: string): [Node | string] => {
   if (invalidText && value) {
@@ -44,11 +44,11 @@ export const formatInvalidText = (value: string, invalidText: InvalidText, style
       if (i !== splitText.length - 1) {
         if (typeof invalidText !== 'string') {
           if (textToHighlight[i]) {
-            return [text, formatText(textToHighlight[i], style)];
+            return [text, formatText(textToHighlight[i], style, i)];
           }
-          return null;
+          return [text];
         }
-        return [text, formatText(textToHighlight[0], style)];
+        return [text, formatText(textToHighlight[0], style, i)];
       }
       return text;
     })).filter(item => item !== null && item !== '');

--- a/react/Textarea/textAreaUtils.spec.js
+++ b/react/Textarea/textAreaUtils.spec.js
@@ -25,7 +25,7 @@ describe('contentEditableUtils', () => {
         const invalidText = 'bad text';
         expect(formatInvalidText(value, invalidText, style)).toEqual([
           'my ',
-          <Highlight className="my-class-name" tone="critical">bad text</Highlight>
+          <Highlight className="my-class-name" tone="critical" key="0">bad text</Highlight>
         ]);
       });
 
@@ -33,29 +33,37 @@ describe('contentEditableUtils', () => {
         const value = 'very very very bad text';
         const invalidText = 'very';
         expect(formatInvalidText(value, invalidText, style)).toEqual([
-          <Highlight className="my-class-name" tone="critical">very</Highlight>,
+          <Highlight className="my-class-name" tone="critical" key="0">very</Highlight>,
           ' ',
-          <Highlight className="my-class-name" tone="critical">very</Highlight>,
+          <Highlight className="my-class-name" tone="critical" key="1">very</Highlight>,
           ' ',
-          <Highlight className="my-class-name" tone="critical">very</Highlight>,
+          <Highlight className="my-class-name" tone="critical" key="2">very</Highlight>,
           ' bad text'
         ]);
       });
     });
 
     describe('invalidText is an object / range', () => {
-      it('should do nothing if there is no invalid text', () => {
+      it('should return the unformatted text if no highlighting is required', () => {
+        const value = 'aaaaaaaaa bbbbbbbbbb';
+        const invalidText = { start: 30 };
+        expect(formatInvalidText(value, invalidText, style)).toEqual([
+          'aaaaaaaaa bbbbbbbbbb'
+        ]);
+      });
+
+      it('should highlight from a start point to the end of a string', () => {
         const value = 'my string of text';
         const invalidText = {
           start: 6
         };
         expect(formatInvalidText(value, invalidText, style)).toEqual([
           'my str',
-          <Highlight className="my-class-name" tone="critical">ing of text</Highlight>
+          <Highlight className="my-class-name" tone="critical" key="0">ing of text</Highlight>
         ]);
       });
 
-      it('should do nothing if there is no invalid text', () => {
+      it('should highlight a range', () => {
         const value = 'my longer text';
         const invalidText = {
           start: 3,
@@ -63,7 +71,7 @@ describe('contentEditableUtils', () => {
         };
         expect(formatInvalidText(value, invalidText, style)).toEqual([
           'my ',
-          <Highlight className="my-class-name" tone="critical">longer</Highlight>,
+          <Highlight className="my-class-name" tone="critical" key="0">longer</Highlight>,
           ' text'
         ]);
       });
@@ -87,11 +95,11 @@ describe('contentEditableUtils', () => {
           ];
           expect(formatInvalidText(value, invalidText, style)).toEqual([
             'my ',
-            <Highlight className="my-class-name" tone="critical">lon</Highlight>,
+            <Highlight className="my-class-name" tone="critical" key="0">lon</Highlight>,
             'g',
-            <Highlight className="my-class-name" tone="critical">e</Highlight>,
+            <Highlight className="my-class-name" tone="critical" key="1">e</Highlight>,
             'r te',
-            <Highlight className="my-class-name" tone="critical">x</Highlight>,
+            <Highlight className="my-class-name" tone="critical" key="2">x</Highlight>,
             't'
           ]);
         });
@@ -110,7 +118,7 @@ describe('contentEditableUtils', () => {
           ];
           expect(formatInvalidText(value, invalidText, style)).toEqual([
             'aaaaaaaaaa',
-            <Highlight className="my-class-name" tone="critical">bbb</Highlight>
+            <Highlight className="my-class-name" tone="critical" key="0">bbb</Highlight>
           ]);
         });
       });


### PR DESCRIPTION
This PR has two bug fixes in relation to this PR that was merged yesterday https://github.com/seek-oss/seek-style-guide/pull/533.

1. No key prop was set on the Highlight component.

2. Previously, the `formatInvalidText` function didn't return anything when highlighting a range with no end value AND when the text was shorter than the beginning of the range. In layman's terms, text highlighting is not appearing until a textarea is scrolled in cases where the start index requires scrolling to be seen.
