### PR TITLE
fix(Textarea): Fix highlighting ranges API

### DIFF
--- a/react/Textarea/Textarea.demo.js
+++ b/react/Textarea/Textarea.demo.js
@@ -139,7 +139,7 @@ export default {
           transformProps: props => ({
             ...props,
             invalidText: {
-              start: 50
+              start: 51
             },
             description: 'No more than 50 characters allowed'
           })

--- a/react/Textarea/textAreaUtils.js
+++ b/react/Textarea/textAreaUtils.js
@@ -10,8 +10,8 @@ type Range = {
 
 type InvalidText = string | Range | Array<Range>;
 
-const formatText = (text: string, style: string) =>
-  <Highlight tone="critical" className={style}>{text}</Highlight>;
+const formatText = (text: string, style: string, key: number) =>
+  <Highlight tone="critical" className={style} key={key}>{text}</Highlight>;
 
 export const formatInvalidText = (value: string, invalidText: InvalidText, style: string): [Node | string] => {
   if (invalidText && value) {
@@ -44,11 +44,11 @@ export const formatInvalidText = (value: string, invalidText: InvalidText, style
       if (i !== splitText.length - 1) {
         if (typeof invalidText !== 'string') {
           if (textToHighlight[i]) {
-            return [text, formatText(textToHighlight[i], style)];
+            return [text, formatText(textToHighlight[i], style, i)];
           }
-          return null;
+          return [text];
         }
-        return [text, formatText(textToHighlight[0], style)];
+        return [text, formatText(textToHighlight[0], style, i)];
       }
       return text;
     })).filter(item => item !== null && item !== '');

--- a/react/Textarea/textAreaUtils.js
+++ b/react/Textarea/textAreaUtils.js
@@ -22,15 +22,15 @@ export const formatInvalidText = (value: string, invalidText: InvalidText, style
       const highlightRanges: Array<Range> = Array.isArray(invalidText) ? invalidText : [invalidText];
       highlightRanges.forEach((range, i) => {
         const { start, end } = range;
-        const highlightedText: string = value.slice(start, end);
+        const highlightedText: string = value.slice(start - 1, end);
         if (highlightedText) {
           textToHighlight.push(highlightedText);
         }
         if (i === 0) {
-          splitText.push(value.slice(0, start));
+          splitText.push(value.slice(0, start - 1));
         }
         if (highlightRanges[i + 1]) {
-          splitText.push(end ? value.slice(end, highlightRanges[i + 1].start) : '');
+          splitText.push(end ? value.slice(end, highlightRanges[i + 1].start - 1) : '');
         } else {
           splitText.push(end ? value.slice(end, value.length) : '');
         }

--- a/react/Textarea/textAreaUtils.spec.js
+++ b/react/Textarea/textAreaUtils.spec.js
@@ -25,7 +25,7 @@ describe('contentEditableUtils', () => {
         const invalidText = 'bad text';
         expect(formatInvalidText(value, invalidText, style)).toEqual([
           'my ',
-          <Highlight className="my-class-name" tone="critical">bad text</Highlight>
+          <Highlight className="my-class-name" tone="critical" key="0">bad text</Highlight>
         ]);
       });
 
@@ -33,29 +33,37 @@ describe('contentEditableUtils', () => {
         const value = 'very very very bad text';
         const invalidText = 'very';
         expect(formatInvalidText(value, invalidText, style)).toEqual([
-          <Highlight className="my-class-name" tone="critical">very</Highlight>,
+          <Highlight className="my-class-name" tone="critical" key="0">very</Highlight>,
           ' ',
-          <Highlight className="my-class-name" tone="critical">very</Highlight>,
+          <Highlight className="my-class-name" tone="critical" key="1">very</Highlight>,
           ' ',
-          <Highlight className="my-class-name" tone="critical">very</Highlight>,
+          <Highlight className="my-class-name" tone="critical" key="2">very</Highlight>,
           ' bad text'
         ]);
       });
     });
 
     describe('invalidText is an object / range', () => {
-      it('should do nothing if there is no invalid text', () => {
+      it('should return the unformatted text if no highlighting is required', () => {
+        const value = 'aaaaaaaaa bbbbbbbbbb';
+        const invalidText = { start: 30 };
+        expect(formatInvalidText(value, invalidText, style)).toEqual([
+          'aaaaaaaaa bbbbbbbbbb'
+        ]);
+      });
+
+      it('should highlight from a start point to the end of a string', () => {
         const value = 'my string of text';
         const invalidText = {
           start: 6
         };
         expect(formatInvalidText(value, invalidText, style)).toEqual([
           'my str',
-          <Highlight className="my-class-name" tone="critical">ing of text</Highlight>
+          <Highlight className="my-class-name" tone="critical" key="0">ing of text</Highlight>
         ]);
       });
 
-      it('should do nothing if there is no invalid text', () => {
+      it('should highlight a range', () => {
         const value = 'my longer text';
         const invalidText = {
           start: 3,
@@ -63,7 +71,7 @@ describe('contentEditableUtils', () => {
         };
         expect(formatInvalidText(value, invalidText, style)).toEqual([
           'my ',
-          <Highlight className="my-class-name" tone="critical">longer</Highlight>,
+          <Highlight className="my-class-name" tone="critical" key="0">longer</Highlight>,
           ' text'
         ]);
       });
@@ -87,11 +95,11 @@ describe('contentEditableUtils', () => {
           ];
           expect(formatInvalidText(value, invalidText, style)).toEqual([
             'my ',
-            <Highlight className="my-class-name" tone="critical">lon</Highlight>,
+            <Highlight className="my-class-name" tone="critical" key="0">lon</Highlight>,
             'g',
-            <Highlight className="my-class-name" tone="critical">e</Highlight>,
+            <Highlight className="my-class-name" tone="critical" key="1">e</Highlight>,
             'r te',
-            <Highlight className="my-class-name" tone="critical">x</Highlight>,
+            <Highlight className="my-class-name" tone="critical" key="2">x</Highlight>,
             't'
           ]);
         });
@@ -110,7 +118,7 @@ describe('contentEditableUtils', () => {
           ];
           expect(formatInvalidText(value, invalidText, style)).toEqual([
             'aaaaaaaaaa',
-            <Highlight className="my-class-name" tone="critical">bbb</Highlight>
+            <Highlight className="my-class-name" tone="critical" key="0">bbb</Highlight>
           ]);
         });
       });

--- a/react/Textarea/textAreaUtils.spec.js
+++ b/react/Textarea/textAreaUtils.spec.js
@@ -58,22 +58,48 @@ describe('contentEditableUtils', () => {
           start: 6
         };
         expect(formatInvalidText(value, invalidText, style)).toEqual([
-          'my str',
-          <Highlight className="my-class-name" tone="critical" key="0">ing of text</Highlight>
+          'my st',
+          <Highlight className="my-class-name" tone="critical" key="0">ring of text</Highlight>
         ]);
       });
 
-      it('should highlight a range', () => {
-        const value = 'my longer text';
+      it('should highlight a single character', () => {
+        const value = 'my string of text';
         const invalidText = {
-          start: 3,
-          end: 9
+          start: 1,
+          end: 1
         };
         expect(formatInvalidText(value, invalidText, style)).toEqual([
-          'my ',
-          <Highlight className="my-class-name" tone="critical" key="0">longer</Highlight>,
-          ' text'
+          <Highlight className="my-class-name" tone="critical" key="0">m</Highlight>,
+          'y string of text'
         ]);
+      });
+
+      describe('should highlight a range', () => {
+        it('should highlight correctly', () => {
+          const value = 'my longer text';
+          const invalidText = {
+            start: 3,
+            end: 10
+          };
+          expect(formatInvalidText(value, invalidText, style)).toEqual([
+            'my',
+            <Highlight className="my-class-name" tone="critical" key="0"> longer </Highlight>,
+            'text'
+          ]);
+        });
+        it('should highlight correctly', () => {
+          const value = 'this is a test string of text';
+          const invalidText = {
+            start: 10,
+            end: 20
+          };
+          expect(formatInvalidText(value, invalidText, style)).toEqual([
+            'this is a',
+            <Highlight className="my-class-name" tone="critical" key="0"> test strin</Highlight>,
+            'g of text'
+          ]);
+        });
       });
 
       describe('highlighting multiple ranges', () => {
@@ -81,15 +107,15 @@ describe('contentEditableUtils', () => {
           const value = 'my longer text';
           const invalidText = [
             {
-              start: 3,
+              start: 4,
               end: 6
             },
             {
-              start: 7,
+              start: 8,
               end: 8
             },
             {
-              start: 12,
+              start: 13,
               end: 13
             }
           ];
@@ -117,8 +143,8 @@ describe('contentEditableUtils', () => {
             }
           ];
           expect(formatInvalidText(value, invalidText, style)).toEqual([
-            'aaaaaaaaaa',
-            <Highlight className="my-class-name" tone="critical" key="0">bbb</Highlight>
+            'aaaaaaaaa',
+            <Highlight className="my-class-name" tone="critical" key="0">abbb</Highlight>
           ]);
         });
       });


### PR DESCRIPTION
The API for setting highlighting ranges was not very intuitive. Updating to make it more human usable rather than machine usable.

Note that this is technically a breaking change but it's not being marked as one given the text highlighting feature was released yesterday