### PR TITLE
feat(Loader): Add small loader, change _small to inline

### DIFF
--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -206,7 +206,7 @@ export default function UserAccountMenu({ locale, authenticationStatus, linkRend
             });
             default: return (
               <span className={classnames(styles.item, styles.pendingAuth)}>
-                <Loader _small />
+                <Loader inline />
                 <div key="iconSpacer" className={styles.iconSpacer} />
               </span>
             );

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -291,7 +291,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                       class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="Loader__root Loader___small"
+                        class="Loader__root Loader__inline"
                       >
                         <div
                           class="Loader__ball"
@@ -1479,7 +1479,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                       class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="Loader__root Loader___small"
+                        class="Loader__root Loader__inline"
                       >
                         <div
                           class="Loader__ball"
@@ -3261,7 +3261,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                       class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="Loader__root Loader___small"
+                        class="Loader__root Loader__inline"
                       >
                         <div
                           class="Loader__ball"
@@ -4419,7 +4419,7 @@ exports[`Header: should render with a custom logo 1`] = `
                       class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="Loader__root Loader___small"
+                        class="Loader__root Loader__inline"
                       >
                         <div
                           class="Loader__ball"
@@ -5009,7 +5009,7 @@ exports[`Header: should render with locale of AU 1`] = `
                       class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="Loader__root Loader___small"
+                        class="Loader__root Loader__inline"
                       >
                         <div
                           class="Loader__ball"
@@ -5585,7 +5585,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                       class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="Loader__root Loader___small"
+                        class="Loader__root Loader__inline"
                       >
                         <div
                           class="Loader__ball"
@@ -6138,7 +6138,7 @@ exports[`Header: should render with no divider 1`] = `
                       class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                     >
                       <div
-                        class="Loader__root Loader___small"
+                        class="Loader__root Loader__inline"
                       >
                         <div
                           class="Loader__ball"

--- a/react/Loader/Loader.demo.js
+++ b/react/Loader/Loader.demo.js
@@ -5,5 +5,35 @@ export default {
   title: 'Loader',
   component: Loader,
   initialProps: {},
-  options: []
+  options: [
+    {
+      label: 'Size',
+      type: 'radio',
+      states: [
+        {
+          label: 'Default'
+        },
+        {
+          label: 'Small',
+          transformProps: props => ({
+            ...props,
+            small: true
+          })
+        }
+      ]
+    },
+    {
+      label: 'States',
+      type: 'checklist',
+      states: [
+        {
+          label: 'Inline',
+          transformProps: ({ className, ...props }) => ({
+            ...props,
+            inline: true
+          })
+        }
+      ]
+    }
+  ]
 };

--- a/react/Loader/Loader.js
+++ b/react/Loader/Loader.js
@@ -1,11 +1,16 @@
+// @flow
+
 import React from 'react';
-import PropTypes from 'prop-types';
 import styles from './Loader.less';
 import classnames from 'classnames';
 
-export default function Loader({ _small }) {
+export default function Loader({ inline, small }: { inline?: boolean, small?: boolean }) {
   return (
-    <div className={classnames(styles.root, { [styles._small]: _small })}>
+    <div
+      className={classnames(styles.root, {
+        [styles.inline]: inline,
+        [styles.small]: small
+      })}>
       <div className={styles.ball} />
       <div className={styles.ball} />
       <div className={styles.ball} />
@@ -13,10 +18,3 @@ export default function Loader({ _small }) {
   );
 }
 
-Loader.propTypes = {
-  _small: PropTypes.bool
-};
-
-Loader.defaultProps = {
-  _small: false
-};

--- a/react/Loader/Loader.less
+++ b/react/Loader/Loader.less
@@ -47,7 +47,11 @@
   }
 }
 
-.root._small {
+.root.inline {
   ._coreLoader(4px, 0, currentColor);
   display: inline;
+}
+
+.root.small {
+  ._coreLoader(@row-height * 1.5, 0, @sk-mid-gray-light);
 }


### PR DESCRIPTION
Previously _small api was meant to just be an internal property, however it started being used as inline loader across SEEK repos.

https://github.com/search?p=1&q=org%3ASEEK-Jobs+%3CLoader+_small&type=Code

So changing `_small` to `inline` and adding proper `small` which is just a reduced size of the loader.

+ Demo update, flow types

BREAKING CHANGE: _small is deprecated in favour of inline

Migration guide
```diff
- <Loader _small>
+ <Loader inline>
```

