### PR TITLE
fix(Badge): Update accent colour

### DIFF
--- a/react/Badge/Badge.less
+++ b/react/Badge/Badge.less
@@ -33,18 +33,18 @@
 }
 
 .accent {
-  background-color: fade(@sk-focus, 10%);
-  color: @sk-focus;
+  background-color: fade(@sk-blue-lighter, 10%);
+  color: @sk-blue-lighter;
   &.strong {
-    .__strong(@sk-focus);
+    .__strong(@sk-blue-lighter);
   }
 }
 
 .critical {
-  background-color: fade(@sk-pink, 10%);
+  background-color: fade(@sk-critical, 10%);
   color: @sk-critical-dark;
   &.strong {
-    .__strong(@sk-pink);
+    .__strong(@sk-critical);
   }
 }
 


### PR DESCRIPTION
Updating the `accent` colour to better align with our blue palette. The spec we built the `Badge` from was slightly outdated.