### PR TITLE
fix(Badge): Prevent className overrides

### DIFF
--- a/react/Badge/Badge.js
+++ b/react/Badge/Badge.js
@@ -2,7 +2,7 @@
 
 import React, { PureComponent } from 'react';
 import classnames from 'classnames';
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 
 import styles from './Badge.less';
 

--- a/react/Badge/Badge.js
+++ b/react/Badge/Badge.js
@@ -17,8 +17,7 @@ type Tone =
 type Props = {
   children: React$Node,
   tone?: Tone,
-  strong?: boolean,
-  className?: string
+  strong?: boolean
 };
 
 export default class Badge extends PureComponent<Props> {

--- a/react/Badge/Badge.js
+++ b/react/Badge/Badge.js
@@ -2,6 +2,7 @@
 
 import React, { PureComponent } from 'react';
 import classnames from 'classnames';
+import { omit } from 'lodash';
 
 import styles from './Badge.less';
 
@@ -26,17 +27,16 @@ export default class Badge extends PureComponent<Props> {
   props: Props;
 
   render() {
-    const { children, tone, strong, className = '', ...restProps } = this.props;
+    const { children, tone, strong, ...restProps } = this.props;
 
     return (
       <div
         className={classnames({
-          [className]: className,
           [styles.root]: true,
           [styles[tone]]: tone,
           [styles.strong]: strong
         })}
-        {...restProps}>
+        {...omit(restProps, 'className')}>
         {children}
       </div>
     );

--- a/react/Badge/Badge.js
+++ b/react/Badge/Badge.js
@@ -16,7 +16,8 @@ type Tone =
 type Props = {
   children: React$Node,
   tone?: Tone,
-  strong?: boolean
+  strong?: boolean,
+  className?: string
 };
 
 export default class Badge extends PureComponent<Props> {
@@ -25,16 +26,17 @@ export default class Badge extends PureComponent<Props> {
   props: Props;
 
   render() {
-    const { children, tone, strong } = this.props;
+    const { children, tone, strong, className = '', ...restProps } = this.props;
 
     return (
       <div
         className={classnames({
+          [className]: className,
           [styles.root]: true,
           [styles[tone]]: tone,
           [styles.strong]: strong
         })}
-        {...this.props}>
+        {...restProps}>
         {children}
       </div>
     );

--- a/react/Badge/Badge.test.js
+++ b/react/Badge/Badge.test.js
@@ -14,6 +14,11 @@ test('should render accent Badge', () => {
   expect(badge).toMatchSnapshot();
 });
 
+test('should render Badge with external className', () => {
+  const badge = renderBadge({ className: 'foo' });
+  expect(badge).toMatchSnapshot();
+});
+
 test('should render critical Badge', () => {
   const badge = renderBadge({ tone: 'critical' });
 

--- a/react/Badge/Badge.test.js
+++ b/react/Badge/Badge.test.js
@@ -14,7 +14,7 @@ test('should render accent Badge', () => {
   expect(badge).toMatchSnapshot();
 });
 
-test('should render Badge with external className', () => {
+test('should ignore external className', () => {
   const badge = renderBadge({ className: 'foo' });
   expect(badge).toMatchSnapshot();
 });

--- a/react/Badge/__snapshots__/Badge.test.js.snap
+++ b/react/Badge/__snapshots__/Badge.test.js.snap
@@ -8,11 +8,17 @@ exports[`should render Badge 1`] = `
 </div>
 `;
 
+exports[`should render Badge with external className 1`] = `
+<div
+  className="foo Badge__root"
+>
+  2 new
+</div>
+`;
+
 exports[`should render a strong positive Badge 1`] = `
 <div
   className="Badge__root Badge__secondary Badge__strong"
-  strong={true}
-  tone="secondary"
 >
   2 new
 </div>
@@ -21,7 +27,6 @@ exports[`should render a strong positive Badge 1`] = `
 exports[`should render accent Badge 1`] = `
 <div
   className="Badge__root Badge__accent"
-  tone="accent"
 >
   2 new
 </div>
@@ -30,7 +35,6 @@ exports[`should render accent Badge 1`] = `
 exports[`should render critical Badge 1`] = `
 <div
   className="Badge__root Badge__critical"
-  tone="critical"
 >
   2 new
 </div>
@@ -39,7 +43,6 @@ exports[`should render critical Badge 1`] = `
 exports[`should render info Badge 1`] = `
 <div
   className="Badge__root Badge__info"
-  tone="info"
 >
   2 new
 </div>
@@ -48,7 +51,6 @@ exports[`should render info Badge 1`] = `
 exports[`should render neutral Badge 1`] = `
 <div
   className="Badge__root Badge__neutral"
-  tone="neutral"
 >
   2 new
 </div>
@@ -57,7 +59,6 @@ exports[`should render neutral Badge 1`] = `
 exports[`should render secondary Badge 1`] = `
 <div
   className="Badge__root Badge__secondary"
-  tone="secondary"
 >
   2 new
 </div>

--- a/react/Badge/__snapshots__/Badge.test.js.snap
+++ b/react/Badge/__snapshots__/Badge.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render Badge 1`] = `
+exports[`should ignore external className 1`] = `
 <div
   className="Badge__root"
 >
@@ -8,9 +8,9 @@ exports[`should render Badge 1`] = `
 </div>
 `;
 
-exports[`should render Badge with external className 1`] = `
+exports[`should render Badge 1`] = `
 <div
-  className="foo Badge__root"
+  className="Badge__root"
 >
   2 new
 </div>


### PR DESCRIPTION
Currently internal classes will be overwritten with a className passed onto the badge.

```diff
<Badge className={styles.foo}>something</Badge> // will overwrite Badge styling
```

Also fixes console warning:

![image](https://user-images.githubusercontent.com/15971854/46840389-743fc380-ce0e-11e8-914d-cb356151cbd5.png)
