### PR TITLE
fix(Button): Prevent font-size being increased on mobile

### DIFF
--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -153,9 +153,8 @@
   .activeState({
     transform: none;
   });
-  @media @desktop {
-    .touchableText(@standard-type-scale);
-  }
+
+  .touchableText(@standard-type-scale);
 }
 
 .loading {


### PR DESCRIPTION
Transparent buttons are supposed to follow our standard text typography.

Currently it increases the font-size to 18px due to the historical reasons when we had it baked into our responsive approach, which we've stopped doing.

Change has been introduced in the PR https://github.com/seek-oss/seek-style-guide/pull/158 and the potential risk (current bug) has been identified.