### PR TITLE
fix(webpack): Find an open port on start, if port busy

### DIFF
--- a/docs/server.js
+++ b/docs/server.js
@@ -1,19 +1,27 @@
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
-const config = require('./webpack.dev.config');
+const createConfigWithPort = require('./webpack.dev.config');
 const opn = require('opn');
-const port = 3000;
+const portfinder = require('portfinder');
+portfinder.basePort = 3000;
 
-new WebpackDevServer(webpack(config), {
-  publicPath: config.output.publicPath,
-  contentBase: __dirname,
-  hot: true,
-  historyApiFallback: true,
-  disableHostCheck: true
-}).listen(port, '0.0.0.0', error => {
-  if (error) {
-    console.log(error); // eslint-disable-line no-console
-  } else {
-    opn(`http://localhost:${port}`);
-  }
-});
+const startServer = (port) => {
+  const config = createConfigWithPort(port);
+
+  new WebpackDevServer(webpack(config), {
+    publicPath: config.output.publicPath,
+    contentBase: __dirname,
+    hot: true,
+    historyApiFallback: true,
+    disableHostCheck: true
+  }).listen(port, '0.0.0.0', error => {
+    if (error) {
+      console.log(error); // eslint-disable-line no-console
+    } else {
+      opn(`http://localhost:${port}`);
+    }
+  });
+}
+
+portfinder.getPortPromise()
+  .then(startServer)

--- a/docs/webpack.dev.config.js
+++ b/docs/webpack.dev.config.js
@@ -14,113 +14,116 @@ const appPaths = [
   path.resolve(__dirname, 'wip_modules')
 ];
 
-const config = decorateClientConfig({
-  entry: [
-    'core-js/modules/es6.symbol',
-    'react-hot-loader/patch',
-    'webpack-dev-server/client?http://localhost:3000',
-    'webpack/hot/only-dev-server',
-    path.resolve(__dirname, 'src/client-render')
-  ],
+const createConfigWithPort = (port) => {
+  return decorateClientConfig({
+    entry: [
+      'core-js/modules/es6.symbol',
+      'react-hot-loader/patch',
+      `webpack-dev-server/client?http://localhost:${port}`,
+      'webpack/hot/only-dev-server',
+      path.resolve(__dirname, 'src/client-render')
+    ],
 
-  output: {
-    path: path.resolve(__dirname, 'dist'), // Must be an absolute path
-    filename: 'index.js',
-    publicPath: '/dist/'
-  },
+    output: {
+      path: path.resolve(__dirname, 'dist'), // Must be an absolute path
+      filename: 'index.js',
+      publicPath: '/dist/'
+    },
 
-  module: {
-    rules: [
-      {
-        enforce: 'pre',
-        test: /\.js$/,
-        include: appPaths,
-        use: {
-          loader: 'import-glob'
-        }
-      },
-      {
-        test: /\.js$/,
-        include: appPaths,
-        use: {
-          loader: 'babel-loader',
-          options: babelConfig
-        }
-      },
-      {
-        test: /\.js$/,
-        include: /node_modules/,
-        exclude: /canvg-fixed/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            babelrc: false,
-            presets: ['env']
+    module: {
+      rules: [
+        {
+          enforce: 'pre',
+          test: /\.js$/,
+          include: appPaths,
+          use: {
+            loader: 'import-glob'
           }
-        }
-      },
-      {
-        test: /\.less$/,
-        include: appPaths,
-        use: [
-          {
-            loader: 'style-loader'
-          },
-          {
-            loader: 'css-loader',
+        },
+        {
+          test: /\.js$/,
+          include: appPaths,
+          use: {
+            loader: 'babel-loader',
+            options: babelConfig
+          }
+        },
+        {
+          test: /\.js$/,
+          include: /node_modules/,
+          exclude: /canvg-fixed/,
+          use: {
+            loader: 'babel-loader',
             options: {
-              modules: true,
-              localIdentName: '[name]__[local]___[hash:base64:5]'
+              babelrc: false,
+              presets: ['env']
             }
-          },
-          {
-            loader: 'postcss-loader',
-            options: {
-              plugins: [autoprefixer(autoprefixerConfig)]
+          }
+        },
+        {
+          test: /\.less$/,
+          include: appPaths,
+          use: [
+            {
+              loader: 'style-loader'
+            },
+            {
+              loader: 'css-loader',
+              options: {
+                modules: true,
+                localIdentName: '[name]__[local]___[hash:base64:5]'
+              }
+            },
+            {
+              loader: 'postcss-loader',
+              options: {
+                plugins: [autoprefixer(autoprefixerConfig)]
+              }
+            },
+            {
+              loader: 'less-loader'
             }
-          },
-          {
-            loader: 'less-loader'
-          }
-        ]
-      },
-      {
-        test: /\.css$/,
-        include: /node_modules/,
-        use: [
-          {
-            loader: 'style-loader'
-          },
-          {
-            loader: 'css-loader'
-          }
-        ]
-      },
-      {
-        test: /\.svg$/,
-        include: appPaths,
-        use: [
-          {
-            loader: 'raw-loader'
-          },
-          {
-            loader: 'svgo-loader'
-          }
-        ]
-      }
+          ]
+        },
+        {
+          test: /\.css$/,
+          include: /node_modules/,
+          use: [
+            {
+              loader: 'style-loader'
+            },
+            {
+              loader: 'css-loader'
+            }
+          ]
+        },
+        {
+          test: /\.svg$/,
+          include: appPaths,
+          use: [
+            {
+              loader: 'raw-loader'
+            },
+            {
+              loader: 'svgo-loader'
+            }
+          ]
+        }
+      ]
+    },
+
+    resolve: {
+      modules: ['node_modules', 'wip_modules', 'components']
+    },
+
+    plugins: [
+      new webpack.HotModuleReplacementPlugin(),
+      new webpack.DefinePlugin({
+        'process.env.BASE_HREF': JSON.stringify(process.env.BASE_HREF)
+      })
     ]
-  },
+  });
+}
 
-  resolve: {
-    modules: ['node_modules', 'wip_modules', 'components']
-  },
 
-  plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.DefinePlugin({
-      'process.env.BASE_HREF': JSON.stringify(process.env.BASE_HREF)
-    })
-  ]
-});
-
-module.exports = config;
+module.exports = createConfigWithPort;

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "react-shallow-testutils": "^3.0.0",
     "react-test-renderer": "^16.0.0",
     "renovate-config-seek": "^0.4.0",
+    "portfinder": "^1.0.17",
     "scope-eval": "^1.0.0",
     "seek-style-guide-webpack": "^2.2.0",
     "semantic-release": "^8.1.2",


### PR DESCRIPTION
Currently, seek-style-guide is running on port 3000, as is many other projects. Right now, the easiest way to run 2 projects simultaneously is to change the port temporarily on one of them.

This PR updates the style guide to check if port 3000 is open on `npm start`, and then increment to the next available port if it is busy.