### PR TITLE
fix(Radio): Set min-width to stop svg from being squished

### DIFF
--- a/react/Radio/Radio.less
+++ b/react/Radio/Radio.less
@@ -36,6 +36,7 @@
 .svg {
   background-color: @sk-white;
   width: @circumference;
+  min-width: @circumference;
   height: @circumference;
   border: @field-border-width solid @sk-mid-gray-light;
   border-radius: 100%;


### PR DESCRIPTION
Add min-width to `svg` so that is never goes below @circumference which in turns squishes it and makes it oval.

Before:
<img width="209" alt="screen shot 2018-10-30 at 3 43 27 pm" src="https://user-images.githubusercontent.com/7741507/47698526-68039500-dc5b-11e8-8704-1ad2c4141928.png">

After:
<img width="274" alt="screen shot 2018-10-30 at 3 46 20 pm" src="https://user-images.githubusercontent.com/7741507/47698517-60dc8700-dc5b-11e8-807b-7de75a1f5038.png">
