### PR TITLE
fix(Header): Disable event listener on input fields

### DIFF
--- a/docs/src/components/App/Header/Header.js
+++ b/docs/src/components/App/Header/Header.js
@@ -60,7 +60,7 @@ class Header extends Component {
   };
 
   handleDocumentKeydown = event => {
-    const isInputField = event.target.tagName.match(/INPUT|TEXTAREA/i) !== null;
+    const isInputField = /^(INPUT|TEXTAREA)$/i.test(event.target.tagName);
     if (event.key === '/' && !isInputField) {
       event.preventDefault();
       this.handleMenuToggle({ target: { checked: true } });

--- a/docs/src/components/App/Header/Header.js
+++ b/docs/src/components/App/Header/Header.js
@@ -60,7 +60,9 @@ class Header extends Component {
   };
 
   handleDocumentKeydown = event => {
-    if (event.key === '/' && event.target.id !== SEARCH_BAR_ID) {
+    const isInputField =
+      ['INPUT', 'TEXTAREA'].indexOf(event.target.tagName) !== -1;
+    if (event.key === '/' && !isInputField) {
       event.preventDefault();
       this.handleMenuToggle({ target: { checked: true } });
     } else if (event.key === 'Escape') {

--- a/docs/src/components/App/Header/Header.js
+++ b/docs/src/components/App/Header/Header.js
@@ -60,8 +60,7 @@ class Header extends Component {
   };
 
   handleDocumentKeydown = event => {
-    const isInputField =
-      ['INPUT', 'TEXTAREA'].indexOf(event.target.tagName) !== -1;
+    const isInputField = event.target.tagName.match(/INPUT|TEXTAREA/i) !== null;
     if (event.key === '/' && !isInputField) {
       event.preventDefault();
       this.handleMenuToggle({ target: { checked: true } });


### PR DESCRIPTION
When adding the searchbar keyboard shortcuts, I broke the sandbox by removing the ability to type `/`. The event listener now checks that the event wasn't called on an `<input>` or `<textarea>` field when deciding whether to open the menu.