### PR TITLE
fix(Footer): Add in new native app download links

### DIFF
--- a/react/Footer/Footer.js
+++ b/react/Footer/Footer.js
@@ -64,7 +64,7 @@ export default class Footer extends Component {
             <div className={styles.columns}>
               <FooterNav label="Tools">
                 { tools.map(this.renderLink) }
-                <ToggleContainer name="DownloadAppsToggle" label="Download Apps">
+                <ToggleContainer name="DownloadAppsToggle" label="Download apps">
                   { seekApps.map(this.renderLink) }
                 </ToggleContainer>
                 <ToggleContainer name="PartnerSitesToggle" label="SEEK sites">

--- a/react/Footer/Footer.js
+++ b/react/Footer/Footer.js
@@ -1,6 +1,6 @@
 import styles from './Footer.less';
 
-import tools, { seekSites } from './data/tools';
+import tools, { seekSites, seekApps } from './data/tools';
 import company, { partners, services } from './data/company';
 import connect, { social } from './data/connect';
 import employers from './data/employers';
@@ -64,6 +64,9 @@ export default class Footer extends Component {
             <div className={styles.columns}>
               <FooterNav label="Tools">
                 { tools.map(this.renderLink) }
+                <ToggleContainer name="DownloadAppsToggle" label="Download Apps">
+                  { seekApps.map(this.renderLink) }
+                </ToggleContainer>
                 <ToggleContainer name="PartnerSitesToggle" label="SEEK sites">
                   { seekSites.map(this.renderLink) }
                 </ToggleContainer>

--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -128,6 +128,50 @@ exports[`Footer: should render when authenticated 1`] = `
             >
               <input
                 class="ToggleContainer__toggle"
+                id="DownloadAppsToggle"
+                type="checkbox"
+              />
+              <label
+                class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
+                for="DownloadAppsToggle"
+              >
+                Download Apps
+                <span
+                  class="Icon__root ChevronIcon__root ToggleContainer__chevron"
+                >
+                  mock svg
+                </span>
+              </label>
+              <ul
+                class="ToggleContainer__toggleContainer"
+              >
+                <li
+                  class=""
+                >
+                  <a
+                    class="FooterLink__link"
+                    href="https://itunes.apple.com/au/app/seek-jobs/id520400855?mt=8"
+                  >
+                    iOS
+                  </a>
+                </li>
+                <li
+                  class=""
+                >
+                  <a
+                    class="FooterLink__link"
+                    href="https://play.google.com/store/apps/details?id=au.com.seek&hl=en_AU"
+                  >
+                    Android
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              class=""
+            >
+              <input
+                class="ToggleContainer__toggle"
                 id="PartnerSitesToggle"
                 type="checkbox"
               />
@@ -901,6 +945,50 @@ exports[`Footer: should render when authentication is pending 1`] = `
               >
                 Company reviews
               </a>
+            </li>
+            <li
+              class=""
+            >
+              <input
+                class="ToggleContainer__toggle"
+                id="DownloadAppsToggle"
+                type="checkbox"
+              />
+              <label
+                class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
+                for="DownloadAppsToggle"
+              >
+                Download Apps
+                <span
+                  class="Icon__root ChevronIcon__root ToggleContainer__chevron"
+                >
+                  mock svg
+                </span>
+              </label>
+              <ul
+                class="ToggleContainer__toggleContainer"
+              >
+                <li
+                  class=""
+                >
+                  <a
+                    class="FooterLink__link"
+                    href="https://itunes.apple.com/au/app/seek-jobs/id520400855?mt=8"
+                  >
+                    iOS
+                  </a>
+                </li>
+                <li
+                  class=""
+                >
+                  <a
+                    class="FooterLink__link"
+                    href="https://play.google.com/store/apps/details?id=au.com.seek&hl=en_AU"
+                  >
+                    Android
+                  </a>
+                </li>
+              </ul>
             </li>
             <li
               class=""
@@ -1686,6 +1774,50 @@ exports[`Footer: should render when unauthenticated 1`] = `
             >
               <input
                 class="ToggleContainer__toggle"
+                id="DownloadAppsToggle"
+                type="checkbox"
+              />
+              <label
+                class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
+                for="DownloadAppsToggle"
+              >
+                Download Apps
+                <span
+                  class="Icon__root ChevronIcon__root ToggleContainer__chevron"
+                >
+                  mock svg
+                </span>
+              </label>
+              <ul
+                class="ToggleContainer__toggleContainer"
+              >
+                <li
+                  class=""
+                >
+                  <a
+                    class="FooterLink__link"
+                    href="https://itunes.apple.com/au/app/seek-jobs/id520400855?mt=8"
+                  >
+                    iOS
+                  </a>
+                </li>
+                <li
+                  class=""
+                >
+                  <a
+                    class="FooterLink__link"
+                    href="https://play.google.com/store/apps/details?id=au.com.seek&hl=en_AU"
+                  >
+                    Android
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              class=""
+            >
+              <input
+                class="ToggleContainer__toggle"
                 id="PartnerSitesToggle"
                 type="checkbox"
               />
@@ -2465,6 +2597,50 @@ exports[`Footer: should render with locale of AU 1`] = `
             >
               <input
                 class="ToggleContainer__toggle"
+                id="DownloadAppsToggle"
+                type="checkbox"
+              />
+              <label
+                class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
+                for="DownloadAppsToggle"
+              >
+                Download Apps
+                <span
+                  class="Icon__root ChevronIcon__root ToggleContainer__chevron"
+                >
+                  mock svg
+                </span>
+              </label>
+              <ul
+                class="ToggleContainer__toggleContainer"
+              >
+                <li
+                  class=""
+                >
+                  <a
+                    class="FooterLink__link"
+                    href="https://itunes.apple.com/au/app/seek-jobs/id520400855?mt=8"
+                  >
+                    iOS
+                  </a>
+                </li>
+                <li
+                  class=""
+                >
+                  <a
+                    class="FooterLink__link"
+                    href="https://play.google.com/store/apps/details?id=au.com.seek&hl=en_AU"
+                  >
+                    Android
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              class=""
+            >
+              <input
+                class="ToggleContainer__toggle"
                 id="PartnerSitesToggle"
                 type="checkbox"
               />
@@ -3214,6 +3390,50 @@ exports[`Footer: should render with locale of NZ 1`] = `
             >
               <input
                 class="ToggleContainer__toggle"
+                id="DownloadAppsToggle"
+                type="checkbox"
+              />
+              <label
+                class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
+                for="DownloadAppsToggle"
+              >
+                Download Apps
+                <span
+                  class="Icon__root ChevronIcon__root ToggleContainer__chevron"
+                >
+                  mock svg
+                </span>
+              </label>
+              <ul
+                class="ToggleContainer__toggleContainer"
+              >
+                <li
+                  class=""
+                >
+                  <a
+                    class="FooterLink__link"
+                    href="https://itunes.apple.com/nz/app/seek-jobs/id520400855?mt=8"
+                  >
+                    iOS
+                  </a>
+                </li>
+                <li
+                  class=""
+                >
+                  <a
+                    class="FooterLink__link"
+                    href="https://play.google.com/store/apps/details?id=au.com.seek&hl=en_AU"
+                  >
+                    Android
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              class=""
+            >
+              <input
+                class="ToggleContainer__toggle"
                 id="PartnerSitesToggle"
                 type="checkbox"
               />
@@ -3281,7 +3501,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                   <a
                     class="FooterLink__link"
                     data-analytics="toolbar:volunteering"
-                    href="https://www.volunteer.co.nz/?tracking=SKMNZ:main+header"
+                    href="https://seekvolunteer.co.nz/?tracking=SKMNZ:main+header"
                   >
                     Volunteering
                   </a>

--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -3412,7 +3412,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 >
                   <a
                     class="FooterLink__link"
-                    href="https://itunes.apple.com/nz/app/seek-jobs/id520400855?mt=8"
+                    href="https://itunes.apple.com/nz/app/seek-job-search/id520400855?mt=8"
                   >
                     iOS
                   </a>

--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -135,7 +135,7 @@ exports[`Footer: should render when authenticated 1`] = `
                 class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                 for="DownloadAppsToggle"
               >
-                Download Apps
+                Download apps
                 <span
                   class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                 >
@@ -958,7 +958,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                 for="DownloadAppsToggle"
               >
-                Download Apps
+                Download apps
                 <span
                   class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                 >
@@ -1781,7 +1781,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                 for="DownloadAppsToggle"
               >
-                Download Apps
+                Download apps
                 <span
                   class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                 >
@@ -2604,7 +2604,7 @@ exports[`Footer: should render with locale of AU 1`] = `
                 class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                 for="DownloadAppsToggle"
               >
-                Download Apps
+                Download apps
                 <span
                   class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                 >
@@ -3397,7 +3397,7 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 class="ToggleContainer__toggleLink ToggleContainer__toggleLabel"
                 for="DownloadAppsToggle"
               >
-                Download Apps
+                Download apps
                 <span
                   class="Icon__root ChevronIcon__root ToggleContainer__chevron"
                 >

--- a/react/Footer/data/tools.js
+++ b/react/Footer/data/tools.js
@@ -58,7 +58,7 @@ export const seekApps = [
   },
   {
     name: 'iOS',
-    href: 'https://itunes.apple.com/nz/app/seek-jobs/id520400855?mt=8',
+    href: 'https://itunes.apple.com/nz/app/seek-job-search/id520400855?mt=8',
     specificLocale: 'NZ'
   },
   {

--- a/react/Footer/data/tools.js
+++ b/react/Footer/data/tools.js
@@ -50,6 +50,23 @@ export default [
   }
 ];
 
+export const seekApps = [
+  {
+    name: 'iOS',
+    href: 'https://itunes.apple.com/au/app/seek-jobs/id520400855?mt=8',
+    specificLocale: 'AU'
+  },
+  {
+    name: 'iOS',
+    href: 'https://itunes.apple.com/nz/app/seek-jobs/id520400855?mt=8',
+    specificLocale: 'NZ'
+  },
+  {
+    name: 'Android',
+    href: 'https://play.google.com/store/apps/details?id=au.com.seek&hl=en_AU'
+  }
+];
+
 export const seekSites = [
   {
     name: 'Employer site',
@@ -107,7 +124,7 @@ export const seekSites = [
   },
   {
     name: 'Volunteering',
-    href: 'https://www.volunteer.co.nz/?tracking=SKMNZ:main+header',
+    href: 'https://seekvolunteer.co.nz/?tracking=SKMNZ:main+header',
     analytics: 'toolbar:volunteering',
     specificLocale: 'NZ'
   }


### PR DESCRIPTION
Added download links for iOS and Android into footer, and also fixed the Volunteering link on the NZ
site that was pointed to a non-SEEK url.