### PR TITLE
fix(ToggleContent): Set type to 'button'

### DIFF
--- a/react/ToggleContent/ToggleContent.js
+++ b/react/ToggleContent/ToggleContent.js
@@ -60,6 +60,7 @@ class ToggleContent extends PureComponent<Props, State> {
           color="transparent"
           chevron={showMore ? 'up' : 'down'}
           component={Button}
+          type="button"
           onClick={this.handleShowMore}
           aria-expanded={showMore}
           aria-controls={`${id}-content`} >


### PR DESCRIPTION
Fixes use case when `<ToggleContent />` is nested in a `<Form />`.