### PR TITLE
fix(StyleGuideProvider): Remove use of :global from html style

### DIFF
--- a/react/StyleGuideProvider/StyleGuideProvider.less
+++ b/react/StyleGuideProvider/StyleGuideProvider.less
@@ -1,14 +1,12 @@
 @import (reference) "~seek-style-guide/theme";
 
 :global {
-  /* stylelint-disable selector-max-type */
   @import "./reset";
+}
 
-  html {
-    background-color: @sk-background;
-    min-height: 100%;
-  }
-  /* stylelint-enable selector-max-type */
+html {
+  background-color: @sk-background;
+  min-height: 100%;
 }
 
 .root {


### PR DESCRIPTION
Addresses an issue with later versions of css-loader that can cause

```
Inconsistent rule global/local result in rule
```

The error can occur when some tags have `:global` and others do not.