### PR TITLE
feat(ts): Add type definitions for Button and ErrorIcon

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "sketch-to-git": "node scripts/sketch-to-git",
     "git-to-sketch": "node scripts/git-to-sketch",
+    "generate-flow-types": "node scripts/generate-flow-types.js",
     "flow": "flow focus-check ."
   },
   "config": {
@@ -103,7 +104,9 @@
     "eslint-plugin-jest": "^21.22.0",
     "eslint-plugin-react": "^7.11.1",
     "flow-bin": "^0.81.0",
+    "flowgen": "^1.3.0",
     "gh-pages": "^1.0.0",
+    "glob": "^7.1.3",
     "hex-rgb": "^3.0.0",
     "html-minifier": "^3.5.6",
     "html-sketchapp-cli": "0.6.2",

--- a/react/Button/Button.d.ts
+++ b/react/Button/Button.d.ts
@@ -1,0 +1,18 @@
+import { ReactNode, Component } from 'react';
+
+type Props = React.HTMLProps<HTMLButtonElement> & {
+  color: 'pink' | 'blue' | 'gray' | 'transparent' | 'white',
+  children: ReactNode,
+  className?: string,
+  component?: string | ReactNode,
+  ghost?: boolean,
+  loading?: boolean,
+  fullWidth?: boolean
+};
+
+
+// export type Button = Component<Props>
+
+declare class RemoveButton extends Component<Props, any> {}
+
+export default RemoveButton;

--- a/react/Button/Button.js.flow
+++ b/react/Button/Button.js.flow
@@ -1,0 +1,12 @@
+/** THIS FILE IS GENERATED, MANUAL CHANGES WILL BE DISCARDED **/
+// @flow
+declare type Props = React.HTMLProps<HTMLButtonElement> & {
+  color: "pink" | "blue" | "gray" | "transparent" | "white",
+  children: ReactNode,
+  className?: string,
+  component?: string | ReactNode,
+  ghost?: boolean,
+  loading?: boolean,
+  fullWidth?: boolean
+};
+declare module.exports: typeof RemoveButton;

--- a/react/ErrorIcon/ErrorIcon.d.ts
+++ b/react/ErrorIcon/ErrorIcon.d.ts
@@ -1,0 +1,9 @@
+import { SFC } from 'react';
+
+export type ErrorIconProps = React.HTMLProps<HTMLSpanElement> & {
+  filled?: boolean
+}
+
+declare const ErrorIcon: SFC<ErrorIconProps>
+
+export default ErrorIcon;

--- a/react/ErrorIcon/ErrorIcon.js.flow
+++ b/react/ErrorIcon/ErrorIcon.js.flow
@@ -1,0 +1,7 @@
+/** THIS FILE IS GENERATED, MANUAL CHANGES WILL BE DISCARDED **/
+// @flow
+export type ErrorIconProps = React.HTMLProps<HTMLSpanElement> & {
+  filled?: boolean
+};
+declare var ErrorIcon: SFC<ErrorIconProps>;
+declare module.exports: typeof ErrorIcon;

--- a/scripts/generate-flow-types.js
+++ b/scripts/generate-flow-types.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const { promisify } = require('util');
+const { compiler, beautify } = require('flowgen').default;
+const glob = promisify(require('glob'));
+
+const WARNING = '/** THIS FILE IS GENERATED, MANUAL CHANGES WILL BE DISCARDED **/\n';
+const FLOW_DECLARATION = '// @flow\n';
+
+(async() => {
+  const definitionFiles = await glob(`${__dirname}/../react/**/*.d.ts`);
+
+  definitionFiles.forEach((filePath) => {
+    generateFlowFile(filePath)
+  })
+})();
+
+function generateFlowFile(filename) {
+  const flowDefs = compiler.compileDefinitionFile(filename);
+  const beautifiedFlowDefs = beautify(WARNING + FLOW_DECLARATION + flowDefs);
+  const { directory, componentName } = parsePath(filename);
+  const flowFilePath = `${directory}/${componentName}.js.flow`;
+
+  fs.writeFileSync(flowFilePath, beautifiedFlowDefs);
+}
+
+function parsePath(filename) {
+  const split = filename.split('/');
+  const lastIndex = split.length - 1;
+  const directory = split.slice(0, lastIndex).join('/');
+  const componentName = split[lastIndex].split('.d.ts')[0];
+
+  return {
+    directory,
+    componentName
+  }
+}


### PR DESCRIPTION
Going to start the process of creating type definitions for components in preparation for more typescript consumers coming into existence. Also, without definitions, typescript is inferring types from the propTypes (incorrectly) and is causing linting errors.