### PR TITLE
fix(TextField): Set line-height to normal

### DIFF
--- a/react/TextField/TextField.less
+++ b/react/TextField/TextField.less
@@ -13,6 +13,7 @@
   color: @sk-charcoal;
   width: 100%;
   background-color: @sk-white;
+  line-height: normal;
   -webkit-appearance: none;
   -moz-appearance: none;
 


### PR DESCRIPTION
The cursor in a TextField element has some funky behaviour in Safari

![tallcursor](https://user-images.githubusercontent.com/36141055/51451475-9c35b000-1d89-11e9-91cd-c89d01e85c40.gif)

This is because the `touchableText` styles that get applied includes a `line-height` of 48px. Safari doesn't really know what to do with this, hence the issue.

This PR sets the line-height to `normal` for TextFields, fixing the cursor issue for Safari. I've tested clicking into the edges of the field in FF, Chrome, Safari, and IE, and they all support clicking right up to the edges still.