### PR TITLE
feat(Header): Add courses link to mobile site

### DIFF
--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -277,6 +277,20 @@ export default ({ locale, authenticationStatus, linkRenderer, returnUrl, activeT
       }
     </Hidden>
 
+    <Hidden desktop component="li">
+      {
+        linkRenderer({
+          'data-analytics': 'header:courses',
+          className: styles.item,
+          href: '/learning/',
+          children: [
+            'Courses',
+            <div key="iconSpacer" className={styles.iconSpacer} />
+          ]
+        })
+      }
+    </Hidden>
+
     {
       authenticationStatus === AUTHENTICATED ? (
         <Hidden mobile component="li">

--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -282,7 +282,7 @@ export default ({ locale, authenticationStatus, linkRenderer, returnUrl, activeT
         linkRenderer({
           'data-analytics': 'header:courses',
           className: styles.item,
-          href: '/learning/',
+          href: 'https://www.seek.com.au/learning/',
           children: [
             'Courses',
             <div key="iconSpacer" className={styles.iconSpacer} />

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -322,6 +322,20 @@ exports[`Header: should append returnUrl to signin and register links if present
                       />
                     </a>
                   </li>
+                  <li
+                    class="Hidden__desktop"
+                  >
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:courses"
+                      href="/learning/"
+                    >
+                      Courses
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
                 </ul>
               </div>
             </nav>
@@ -851,6 +865,20 @@ exports[`Header: should render first part of email address when username isn't p
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="Hidden__desktop"
+                  >
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:courses"
+                      href="/learning/"
+                    >
+                      Courses
                       <div
                         class="UserAccountMenu__iconSpacer"
                       />
@@ -1407,6 +1435,20 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                       />
                     </a>
                   </li>
+                  <li
+                    class="Hidden__desktop"
+                  >
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:courses"
+                      href="/learning/"
+                    >
+                      Courses
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
                 </ul>
               </div>
             </nav>
@@ -1936,6 +1978,20 @@ exports[`Header: should render when authenticated 1`] = `
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="Hidden__desktop"
+                  >
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:courses"
+                      href="/learning/"
+                    >
+                      Courses
                       <div
                         class="UserAccountMenu__iconSpacer"
                       />
@@ -2477,6 +2533,20 @@ exports[`Header: should render when authenticated but username and email is not 
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="Hidden__desktop"
+                  >
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:courses"
+                      href="/learning/"
+                    >
+                      Courses
                       <div
                         class="UserAccountMenu__iconSpacer"
                       />
@@ -3033,6 +3103,20 @@ exports[`Header: should render when authentication is pending 1`] = `
                       />
                     </a>
                   </li>
+                  <li
+                    class="Hidden__desktop"
+                  >
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:courses"
+                      href="/learning/"
+                    >
+                      Courses
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
                 </ul>
               </div>
             </nav>
@@ -3583,6 +3667,20 @@ exports[`Header: should render when unauthenticated 1`] = `
                       />
                     </a>
                   </li>
+                  <li
+                    class="Hidden__desktop"
+                  >
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:courses"
+                      href="/learning/"
+                    >
+                      Courses
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
                 </ul>
               </div>
             </nav>
@@ -4086,6 +4184,20 @@ exports[`Header: should render with a custom logo 1`] = `
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="Hidden__desktop"
+                  >
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:courses"
+                      href="/learning/"
+                    >
+                      Courses
                       <div
                         class="UserAccountMenu__iconSpacer"
                       />
@@ -4631,6 +4743,20 @@ exports[`Header: should render with locale of AU 1`] = `
                       />
                     </a>
                   </li>
+                  <li
+                    class="Hidden__desktop"
+                  >
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:courses"
+                      href="/learning/"
+                    >
+                      Courses
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
                 </ul>
               </div>
             </nav>
@@ -5136,6 +5262,20 @@ exports[`Header: should render with locale of NZ 1`] = `
                       href="https://talent.seek.co.nz/"
                     >
                       Employer Site
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="Hidden__desktop"
+                  >
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:courses"
+                      href="/learning/"
+                    >
+                      Courses
                       <div
                         class="UserAccountMenu__iconSpacer"
                       />
@@ -5653,6 +5793,20 @@ exports[`Header: should render with no divider 1`] = `
                       href="https://talent.seek.com.au/"
                     >
                       Employer Site
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
+                  <li
+                    class="Hidden__desktop"
+                  >
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:courses"
+                      href="/learning/"
+                    >
+                      Courses
                       <div
                         class="UserAccountMenu__iconSpacer"
                       />

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -328,7 +328,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:courses"
-                      href="/learning/"
+                      href="https://www.seek.com.au/learning/"
                     >
                       Courses
                       <div
@@ -876,7 +876,7 @@ exports[`Header: should render first part of email address when username isn't p
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:courses"
-                      href="/learning/"
+                      href="https://www.seek.com.au/learning/"
                     >
                       Courses
                       <div
@@ -1441,7 +1441,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:courses"
-                      href="/learning/"
+                      href="https://www.seek.com.au/learning/"
                     >
                       Courses
                       <div
@@ -1989,7 +1989,7 @@ exports[`Header: should render when authenticated 1`] = `
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:courses"
-                      href="/learning/"
+                      href="https://www.seek.com.au/learning/"
                     >
                       Courses
                       <div
@@ -2544,7 +2544,7 @@ exports[`Header: should render when authenticated but username and email is not 
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:courses"
-                      href="/learning/"
+                      href="https://www.seek.com.au/learning/"
                     >
                       Courses
                       <div
@@ -3109,7 +3109,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:courses"
-                      href="/learning/"
+                      href="https://www.seek.com.au/learning/"
                     >
                       Courses
                       <div
@@ -3673,7 +3673,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:courses"
-                      href="/learning/"
+                      href="https://www.seek.com.au/learning/"
                     >
                       Courses
                       <div
@@ -4195,7 +4195,7 @@ exports[`Header: should render with a custom logo 1`] = `
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:courses"
-                      href="/learning/"
+                      href="https://www.seek.com.au/learning/"
                     >
                       Courses
                       <div
@@ -4749,7 +4749,7 @@ exports[`Header: should render with locale of AU 1`] = `
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:courses"
-                      href="/learning/"
+                      href="https://www.seek.com.au/learning/"
                     >
                       Courses
                       <div
@@ -5273,7 +5273,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:courses"
-                      href="/learning/"
+                      href="https://www.seek.com.au/learning/"
                     >
                       Courses
                       <div
@@ -5804,7 +5804,7 @@ exports[`Header: should render with no divider 1`] = `
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:courses"
-                      href="/learning/"
+                      href="https://www.seek.com.au/learning/"
                     >
                       Courses
                       <div


### PR DESCRIPTION
Add courses link in SKJ mobile site menu.
- Design: no icon below Employer Site
- Link to Seek Learning Course Directory site: https://www.seek.com.au/learning/
- `co.nz/learning` has been redirect to its au equivalent, so safe to just use `/learning` on both domain

BREAKING CHANGE: n/a

Design: 
![image](https://user-images.githubusercontent.com/1400753/51944090-3e7f2300-246f-11e9-8ef4-9fb55d94cdab.png)


