### PR TITLE
feat(ReadMore): Add ability to access state of more button visiblity

### DIFF
--- a/react/ReadMore/ReadMore.js
+++ b/react/ReadMore/ReadMore.js
@@ -30,7 +30,8 @@ type Props = {|
   moreLabel: string,
   lessLabel: string,
   backgroundComponentName: 'card' | 'body' | 'gray-lightest',
-  onShowMore?: Function
+  onShowMore?: Function,
+  onMoreButtonToggle?: Function
 |};
 type State = {|
   showMore: boolean,
@@ -67,7 +68,7 @@ class ReadMore extends PureComponent<Props, State> {
   contentRef: ?HTMLDivElement;
 
   update = () => {
-    const { maxLines, maxRows } = this.props;
+    const { maxLines, maxRows, onMoreButtonToggle } = this.props;
 
     if (this.contentRef) {
       const { scrollHeight } = this.contentRef;
@@ -76,6 +77,10 @@ class ReadMore extends PureComponent<Props, State> {
         scrollHeight > getMaxHeight(maxLines, maxRows) + buttonHeight;
 
       this.setState({ tooLong, mounted: true }); // eslint-disable-line
+
+      if (onMoreButtonToggle && tooLong !== this.state.tooLong) {
+        onMoreButtonToggle(tooLong);
+      }
     }
   };
 

--- a/react/ReadMore/ReadMore.js
+++ b/react/ReadMore/ReadMore.js
@@ -31,7 +31,7 @@ type Props = {|
   lessLabel: string,
   backgroundComponentName: 'card' | 'body' | 'gray-lightest',
   onShowMore?: Function,
-  onMoreButtonToggle?: Function
+  onMoreButtonVisibilityChange?: Function
 |};
 type State = {|
   showMore: boolean,
@@ -68,7 +68,7 @@ class ReadMore extends PureComponent<Props, State> {
   contentRef: ?HTMLDivElement;
 
   update = () => {
-    const { maxLines, maxRows, onMoreButtonToggle } = this.props;
+    const { maxLines, maxRows, onMoreButtonVisibilityChange } = this.props;
 
     if (this.contentRef) {
       const { scrollHeight } = this.contentRef;
@@ -78,8 +78,8 @@ class ReadMore extends PureComponent<Props, State> {
 
       this.setState({ tooLong, mounted: true }); // eslint-disable-line
 
-      if (onMoreButtonToggle && tooLong !== this.state.tooLong) {
-        onMoreButtonToggle(tooLong);
+      if (onMoreButtonVisibilityChange && tooLong !== this.state.tooLong) {
+        onMoreButtonVisibilityChange(tooLong);
       }
     }
   };


### PR DESCRIPTION
There's currently no way to know if the more button is being displayed or not. I've got an analytics
requirement to find out if users are reading the text so am adding this prop to expose whether the
button is being displayed
