### PR TITLE
 feat(Header): Add Recommended Jobs to user account menu

### DIFF
--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -96,7 +96,6 @@ export default ({
         ]
       })}
     </Hidden>
-
     <li className={classnames(activeTab === PROFILE && styles.activeTab)}>
       {linkRenderer({
         'data-analytics': 'header:profile',
@@ -113,13 +112,12 @@ export default ({
         ]
       })}
     </li>
-
     <li
       className={classnames(activeTab === SAVED_SEARCHES && styles.activeTab)}
     >
       {linkRenderer({
         'data-analytics': 'header:saved+searches',
-        className: `${styles.item} ${styles.subItem}`,
+        className: styles.item,
         href: '/my-activity/saved-searches',
         children: [
           <span key="label">{SAVED_SEARCHES}</span>,
@@ -131,7 +129,6 @@ export default ({
         ]
       })}
     </li>
-
     <li
       className={classnames(
         activeTab === SAVED_AND_APPLIED && styles.activeTab
@@ -139,7 +136,7 @@ export default ({
     >
       {linkRenderer({
         'data-analytics': 'header:saved+jobs',
-        className: `${styles.item} ${styles.subItem}`,
+        className: styles.item,
         href: urlForAuthStatus(authenticationStatus, '/my-activity/saved-jobs'),
         children: [
           newBadgeTab === SAVED_AND_APPLIED && <BadgeComponent />,
@@ -154,7 +151,6 @@ export default ({
         ]
       })}
     </li>
-
     <Hidden
       mobile
       component="li"
@@ -162,7 +158,7 @@ export default ({
     >
       {linkRenderer({
         'data-analytics': 'header:applied+jobs',
-        className: `${styles.item} ${styles.subItem}`,
+        className: styles.item,
         href: urlForAuthStatus(
           authenticationStatus,
           '/my-activity/applied-jobs'
@@ -170,15 +166,12 @@ export default ({
         children: APPLIED_JOBS
       })}
     </Hidden>
-
-    <Hidden
-      desktop
-      component="li"
+    <li
       className={classnames(activeTab === RECOMMENDED_JOBS && styles.activeTab)}
     >
       {linkRenderer({
         'data-analytics': 'header:recommended+jobs',
-        className: `${styles.item} ${styles.subItem}`,
+        className: styles.item,
         href: urlForAuthStatus(authenticationStatus, '/recommended'),
         children: [
           newBadgeTab === RECOMMENDED_JOBS && <BadgeComponent />,
@@ -190,8 +183,8 @@ export default ({
           />
         ]
       })}
-    </Hidden>
-
+    </li>
+    <hr className={styles.menuSeparator} />
     {locale === 'NZ' ? null : (
       <Hidden
         desktop
@@ -202,7 +195,7 @@ export default ({
       >
         {linkRenderer({
           'data-analytics': 'header:companies',
-          className: `${styles.item} ${styles.subItem}`,
+          className: styles.item,
           href: '/companies/',
           children: [
             newBadgeTab === COMPANY_REVIEWS && <BadgeComponent />,
@@ -216,7 +209,6 @@ export default ({
         })}
       </Hidden>
     )}
-
     <Hidden
       mobile
       component="li"
@@ -229,7 +221,6 @@ export default ({
         children: SETTINGS
       })}
     </Hidden>
-
     <Hidden desktop component="li" className={styles.firstItemInGroup}>
       {(() => {
         switch (authenticationStatus) {
@@ -285,7 +276,6 @@ export default ({
         }
       })()}
     </Hidden>
-
     {locale === 'NZ' ? null : (
       <Hidden
         desktop
@@ -307,7 +297,6 @@ export default ({
         })}
       </Hidden>
     )}
-
     <Hidden
       desktop
       component="li"
@@ -323,7 +312,6 @@ export default ({
         ]
       })}
     </Hidden>
-
     <Hidden desktop component="li">
       {linkRenderer({
         'data-analytics': 'header:courses',
@@ -335,7 +323,6 @@ export default ({
         ]
       })}
     </Hidden>
-
     {authenticationStatus === AUTHENTICATED ? (
       <Hidden mobile component="li">
         {linkRenderer({

--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -184,7 +184,7 @@ export default ({
         ]
       })}
     </li>
-    <hr className={styles.menuSeparator} />
+    <Hidden mobile component="hr" className={styles.menuSeparator} />
     {locale === 'NZ' ? null : (
       <Hidden
         desktop

--- a/react/Header/UserAccountMenu/UserAccountMenu.less
+++ b/react/Header/UserAccountMenu/UserAccountMenu.less
@@ -65,7 +65,7 @@
   height: 1px;
   border: 0;
   background-color: @sk-mid-gray-light;
-  margin: 5px 8px;
+  margin: @row-height @row-height (@row-height - 1);
 }
 
 .icon {

--- a/react/Header/UserAccountMenu/UserAccountMenu.less
+++ b/react/Header/UserAccountMenu/UserAccountMenu.less
@@ -40,7 +40,7 @@
     background-color: darken(@sk-blue, 5%);
     @media @desktop {
       color: @sk-black;
-      background-color: @sk-mid-gray-light;
+      background-color: @sk-gray-light;
     }
   }
   @media @desktop {
@@ -64,7 +64,7 @@
 .menuSeparator {
   height: 1px;
   border: 0;
-  background-color: @sk-gray-light;
+  background-color: @sk-mid-gray-light;
   margin: 5px 8px;
 }
 

--- a/react/Header/UserAccountMenu/UserAccountMenu.less
+++ b/react/Header/UserAccountMenu/UserAccountMenu.less
@@ -61,10 +61,11 @@
   opacity: 0.5;
 }
 
-.subItem {
-  @media @desktop {
-    background-color: @sk-gray-light;
-  }
+.menuSeparator {
+  height: 1px;
+  border: 0;
+  background-color: @sk-gray-light;
+  margin: 5px 8px;
 }
 
 .icon {

--- a/react/Header/UserAccountMenu/UserAccountMenu.less
+++ b/react/Header/UserAccountMenu/UserAccountMenu.less
@@ -1,6 +1,8 @@
 @import (reference) "~seek-style-guide/theme";
 @import (reference) "../Header.less";
 
+@separator-height = @row-height - 1;
+
 .root {
   @media @desktop {
     @border-width: 1px;
@@ -62,10 +64,11 @@
 }
 
 .menuSeparator {
-  height: 1px;
+  @separator-height: 1px;
+  height: @separator-height;
   border: 0;
   background-color: @sk-mid-gray-light;
-  margin: @row-height @row-height (@row-height - 1);
+  margin: @row-height (@gutter-width / 2) (@row-height - @separator-height);
 }
 
 .icon {

--- a/react/Header/UserAccountMenu/UserAccountMenu.less
+++ b/react/Header/UserAccountMenu/UserAccountMenu.less
@@ -1,8 +1,6 @@
 @import (reference) "~seek-style-guide/theme";
 @import (reference) "../Header.less";
 
-@separator-height = @row-height - 1;
-
 .root {
   @media @desktop {
     @border-width: 1px;

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -176,7 +176,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+searches"
                       href="/my-activity/saved-searches"
                     >
@@ -194,7 +194,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
@@ -218,7 +218,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                     class="Hidden__mobile"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
@@ -226,10 +226,10 @@ exports[`Header: should append returnUrl to signin and register links if present
                     </a>
                   </li>
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -243,11 +243,14 @@ exports[`Header: should append returnUrl to signin and register links if present
                       </span>
                     </a>
                   </li>
+                  <hr
+                    class="UserAccountMenu__menuSeparator"
+                  />
                   <li
                     class="Hidden__desktop"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
@@ -734,7 +737,7 @@ exports[`Header: should render first part of email address when username isn't p
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+searches"
                       href="/my-activity/saved-searches"
                     >
@@ -752,7 +755,7 @@ exports[`Header: should render first part of email address when username isn't p
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+jobs"
                       href="/my-activity/saved-jobs"
                     >
@@ -776,7 +779,7 @@ exports[`Header: should render first part of email address when username isn't p
                     class="Hidden__mobile"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:applied+jobs"
                       href="/my-activity/applied-jobs"
                     >
@@ -784,10 +787,10 @@ exports[`Header: should render first part of email address when username isn't p
                     </a>
                   </li>
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:recommended+jobs"
                       href="/recommended"
                     >
@@ -801,11 +804,14 @@ exports[`Header: should render first part of email address when username isn't p
                       </span>
                     </a>
                   </li>
+                  <hr
+                    class="UserAccountMenu__menuSeparator"
+                  />
                   <li
                     class="Hidden__desktop"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
@@ -1289,7 +1295,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+searches"
                       href="/my-activity/saved-searches"
                     >
@@ -1307,7 +1313,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
@@ -1331,7 +1337,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                     class="Hidden__mobile"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
@@ -1339,10 +1345,10 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                     </a>
                   </li>
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -1356,11 +1362,14 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                       </span>
                     </a>
                   </li>
+                  <hr
+                    class="UserAccountMenu__menuSeparator"
+                  />
                   <li
                     class="Hidden__desktop"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
@@ -1847,7 +1856,7 @@ exports[`Header: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+searches"
                       href="/my-activity/saved-searches"
                     >
@@ -1865,7 +1874,7 @@ exports[`Header: should render when authenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+jobs"
                       href="/my-activity/saved-jobs"
                     >
@@ -1889,7 +1898,7 @@ exports[`Header: should render when authenticated 1`] = `
                     class="Hidden__mobile"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:applied+jobs"
                       href="/my-activity/applied-jobs"
                     >
@@ -1897,10 +1906,10 @@ exports[`Header: should render when authenticated 1`] = `
                     </a>
                   </li>
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:recommended+jobs"
                       href="/recommended"
                     >
@@ -1914,11 +1923,14 @@ exports[`Header: should render when authenticated 1`] = `
                       </span>
                     </a>
                   </li>
+                  <hr
+                    class="UserAccountMenu__menuSeparator"
+                  />
                   <li
                     class="Hidden__desktop"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
@@ -2402,7 +2414,7 @@ exports[`Header: should render when authenticated but username and email is not 
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+searches"
                       href="/my-activity/saved-searches"
                     >
@@ -2420,7 +2432,7 @@ exports[`Header: should render when authenticated but username and email is not 
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+jobs"
                       href="/my-activity/saved-jobs"
                     >
@@ -2444,7 +2456,7 @@ exports[`Header: should render when authenticated but username and email is not 
                     class="Hidden__mobile"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:applied+jobs"
                       href="/my-activity/applied-jobs"
                     >
@@ -2452,10 +2464,10 @@ exports[`Header: should render when authenticated but username and email is not 
                     </a>
                   </li>
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:recommended+jobs"
                       href="/recommended"
                     >
@@ -2469,11 +2481,14 @@ exports[`Header: should render when authenticated but username and email is not 
                       </span>
                     </a>
                   </li>
+                  <hr
+                    class="UserAccountMenu__menuSeparator"
+                  />
                   <li
                     class="Hidden__desktop"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
@@ -2957,7 +2972,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+searches"
                       href="/my-activity/saved-searches"
                     >
@@ -2975,7 +2990,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
@@ -2999,7 +3014,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                     class="Hidden__mobile"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
@@ -3007,10 +3022,10 @@ exports[`Header: should render when authentication is pending 1`] = `
                     </a>
                   </li>
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -3024,11 +3039,14 @@ exports[`Header: should render when authentication is pending 1`] = `
                       </span>
                     </a>
                   </li>
+                  <hr
+                    class="UserAccountMenu__menuSeparator"
+                  />
                   <li
                     class="Hidden__desktop"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
@@ -3513,7 +3531,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+searches"
                       href="/my-activity/saved-searches"
                     >
@@ -3531,7 +3549,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
@@ -3555,7 +3573,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                     class="Hidden__mobile"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
@@ -3563,10 +3581,10 @@ exports[`Header: should render when unauthenticated 1`] = `
                     </a>
                   </li>
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -3580,11 +3598,14 @@ exports[`Header: should render when unauthenticated 1`] = `
                       </span>
                     </a>
                   </li>
+                  <hr
+                    class="UserAccountMenu__menuSeparator"
+                  />
                   <li
                     class="Hidden__desktop"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
@@ -4043,7 +4064,7 @@ exports[`Header: should render with a custom logo 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+searches"
                       href="/my-activity/saved-searches"
                     >
@@ -4061,7 +4082,7 @@ exports[`Header: should render with a custom logo 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
@@ -4085,7 +4106,7 @@ exports[`Header: should render with a custom logo 1`] = `
                     class="Hidden__mobile"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
@@ -4093,10 +4114,10 @@ exports[`Header: should render with a custom logo 1`] = `
                     </a>
                   </li>
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -4110,11 +4131,14 @@ exports[`Header: should render with a custom logo 1`] = `
                       </span>
                     </a>
                   </li>
+                  <hr
+                    class="UserAccountMenu__menuSeparator"
+                  />
                   <li
                     class="Hidden__desktop"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
@@ -4597,7 +4621,7 @@ exports[`Header: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+searches"
                       href="/my-activity/saved-searches"
                     >
@@ -4615,7 +4639,7 @@ exports[`Header: should render with locale of AU 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
@@ -4639,7 +4663,7 @@ exports[`Header: should render with locale of AU 1`] = `
                     class="Hidden__mobile"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
@@ -4647,10 +4671,10 @@ exports[`Header: should render with locale of AU 1`] = `
                     </a>
                   </li>
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -4664,11 +4688,14 @@ exports[`Header: should render with locale of AU 1`] = `
                       </span>
                     </a>
                   </li>
+                  <hr
+                    class="UserAccountMenu__menuSeparator"
+                  />
                   <li
                     class="Hidden__desktop"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:companies"
                       href="/companies/"
                     >
@@ -5151,7 +5178,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+searches"
                       href="/my-activity/saved-searches"
                     >
@@ -5169,7 +5196,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
@@ -5193,7 +5220,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                     class="Hidden__mobile"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
@@ -5201,10 +5228,10 @@ exports[`Header: should render with locale of NZ 1`] = `
                     </a>
                   </li>
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -5218,6 +5245,9 @@ exports[`Header: should render with locale of NZ 1`] = `
                       </span>
                     </a>
                   </li>
+                  <hr
+                    class="UserAccountMenu__menuSeparator"
+                  />
                   <li
                     class="Hidden__mobile"
                   >
@@ -5652,7 +5682,7 @@ exports[`Header: should render with no divider 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+searches"
                       href="/my-activity/saved-searches"
                     >
@@ -5670,7 +5700,7 @@ exports[`Header: should render with no divider 1`] = `
                     class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:saved+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
@@ -5694,7 +5724,7 @@ exports[`Header: should render with no divider 1`] = `
                     class="Hidden__mobile"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
@@ -5702,10 +5732,10 @@ exports[`Header: should render with no divider 1`] = `
                     </a>
                   </li>
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:recommended+jobs"
                       href="/sign-in?returnUrl=%2Frecommended"
                     >
@@ -5719,11 +5749,14 @@ exports[`Header: should render with no divider 1`] = `
                       </span>
                     </a>
                   </li>
+                  <hr
+                    class="UserAccountMenu__menuSeparator"
+                  />
                   <li
                     class="Hidden__desktop"
                   >
                     <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
+                      class="UserAccountMenu__item"
                       data-analytics="header:companies"
                       href="/companies/"
                     >

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -244,7 +244,7 @@ exports[`Header: should append returnUrl to signin and register links if present
                     </a>
                   </li>
                   <hr
-                    class="UserAccountMenu__menuSeparator"
+                    class="UserAccountMenu__menuSeparator Hidden__mobile"
                   />
                   <li
                     class="Hidden__desktop"
@@ -805,7 +805,7 @@ exports[`Header: should render first part of email address when username isn't p
                     </a>
                   </li>
                   <hr
-                    class="UserAccountMenu__menuSeparator"
+                    class="UserAccountMenu__menuSeparator Hidden__mobile"
                   />
                   <li
                     class="Hidden__desktop"
@@ -1363,7 +1363,7 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                     </a>
                   </li>
                   <hr
-                    class="UserAccountMenu__menuSeparator"
+                    class="UserAccountMenu__menuSeparator Hidden__mobile"
                   />
                   <li
                     class="Hidden__desktop"
@@ -1924,7 +1924,7 @@ exports[`Header: should render when authenticated 1`] = `
                     </a>
                   </li>
                   <hr
-                    class="UserAccountMenu__menuSeparator"
+                    class="UserAccountMenu__menuSeparator Hidden__mobile"
                   />
                   <li
                     class="Hidden__desktop"
@@ -2482,7 +2482,7 @@ exports[`Header: should render when authenticated but username and email is not 
                     </a>
                   </li>
                   <hr
-                    class="UserAccountMenu__menuSeparator"
+                    class="UserAccountMenu__menuSeparator Hidden__mobile"
                   />
                   <li
                     class="Hidden__desktop"
@@ -3040,7 +3040,7 @@ exports[`Header: should render when authentication is pending 1`] = `
                     </a>
                   </li>
                   <hr
-                    class="UserAccountMenu__menuSeparator"
+                    class="UserAccountMenu__menuSeparator Hidden__mobile"
                   />
                   <li
                     class="Hidden__desktop"
@@ -3599,7 +3599,7 @@ exports[`Header: should render when unauthenticated 1`] = `
                     </a>
                   </li>
                   <hr
-                    class="UserAccountMenu__menuSeparator"
+                    class="UserAccountMenu__menuSeparator Hidden__mobile"
                   />
                   <li
                     class="Hidden__desktop"
@@ -4132,7 +4132,7 @@ exports[`Header: should render with a custom logo 1`] = `
                     </a>
                   </li>
                   <hr
-                    class="UserAccountMenu__menuSeparator"
+                    class="UserAccountMenu__menuSeparator Hidden__mobile"
                   />
                   <li
                     class="Hidden__desktop"
@@ -4689,7 +4689,7 @@ exports[`Header: should render with locale of AU 1`] = `
                     </a>
                   </li>
                   <hr
-                    class="UserAccountMenu__menuSeparator"
+                    class="UserAccountMenu__menuSeparator Hidden__mobile"
                   />
                   <li
                     class="Hidden__desktop"
@@ -5246,7 +5246,7 @@ exports[`Header: should render with locale of NZ 1`] = `
                     </a>
                   </li>
                   <hr
-                    class="UserAccountMenu__menuSeparator"
+                    class="UserAccountMenu__menuSeparator Hidden__mobile"
                   />
                   <li
                     class="Hidden__mobile"
@@ -5750,7 +5750,7 @@ exports[`Header: should render with no divider 1`] = `
                     </a>
                   </li>
                   <hr
-                    class="UserAccountMenu__menuSeparator"
+                    class="UserAccountMenu__menuSeparator Hidden__mobile"
                   />
                   <li
                     class="Hidden__desktop"


### PR DESCRIPTION
### Changes:
- Added (un-hide)`Recommended Jobs` link (to desktop).
- Remove the gray background behind Saved Search / Saved Jobs / Applied Jobs.
- Change on-hover colour to @sk-mid-gray-light.
- Add separator above Settings / Sign Out group.

The menu is wider now but saved / applied jobs will become saved & applied jobs (single item) in the future too.

### Before:
![Before](https://user-images.githubusercontent.com/3631404/54167613-bc970680-44be-11e9-97d8-862ccd028191.png)

### After:
![After](https://user-images.githubusercontent.com/3631404/54167651-e51f0080-44be-11e9-9bc0-8d5c400ea294.png)

### After (on hover):
![image](https://user-images.githubusercontent.com/3631404/54170270-21a42980-44ca-11e9-8b08-6d5359cd5f02.png)
