### PR TITLE
feat(Header): Combine saved jobs and applied jobs in UserAccountMenu

### DIFF
--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -27,7 +27,6 @@ const JOB_SEARCH = 'Job Search';
 const PROFILE = 'Profile';
 const SAVED_SEARCHES = 'Saved Searches';
 const SAVED_AND_APPLIED = 'Saved & Applied Jobs';
-const APPLIED_JOBS = 'Applied Jobs';
 const RECOMMENDED_JOBS = 'Recommended Jobs';
 const SETTINGS = 'Settings';
 const CAREER_ADVICE = 'Career Advice';
@@ -38,7 +37,6 @@ type TabsType =
   | typeof PROFILE
   | typeof SAVED_SEARCHES
   | typeof SAVED_AND_APPLIED
-  | typeof APPLIED_JOBS
   | typeof RECOMMENDED_JOBS
   | typeof SETTINGS
   | typeof CAREER_ADVICE
@@ -143,9 +141,7 @@ export default ({
         href: urlForAuthStatus(authenticationStatus, '/my-activity/saved-jobs'),
         children: [
           newBadgeTab === SAVED_AND_APPLIED && <BadgeComponent />,
-          <span key="label">
-            Saved <Hidden desktop>& Applied </Hidden>Jobs
-          </span>,
+          <span key="label">Saved & Applied Jobs</span>,
           <StarIcon
             key="icon"
             className={classnames(styles.icon, styles.saveJobs)}
@@ -154,22 +150,6 @@ export default ({
         ]
       })}
     </li>
-
-    <Hidden
-      mobile
-      component="li"
-      className={classnames(activeTab === APPLIED_JOBS && styles.activeTab)}
-    >
-      {linkRenderer({
-        'data-analytics': 'header:applied+jobs',
-        className: `${styles.item} ${styles.subItem}`,
-        href: urlForAuthStatus(
-          authenticationStatus,
-          '/my-activity/applied-jobs'
-        ),
-        children: APPLIED_JOBS
-      })}
-    </Hidden>
 
     <Hidden
       desktop

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -199,30 +199,13 @@ exports[`Header: should append returnUrl to signin and register links if present
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
-                        Saved 
-                        <span
-                          class="Hidden__desktop"
-                        >
-                          & Applied 
-                        </span>
-                        Jobs
+                        Saved & Applied Jobs
                       </span>
                       <span
                         class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
-                    </a>
-                  </li>
-                  <li
-                    class="Hidden__mobile"
-                  >
-                    <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
-                      data-analytics="header:applied+jobs"
-                      href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
-                    >
-                      Applied Jobs
                     </a>
                   </li>
                   <li
@@ -757,30 +740,13 @@ exports[`Header: should render first part of email address when username isn't p
                       href="/my-activity/saved-jobs"
                     >
                       <span>
-                        Saved 
-                        <span
-                          class="Hidden__desktop"
-                        >
-                          & Applied 
-                        </span>
-                        Jobs
+                        Saved & Applied Jobs
                       </span>
                       <span
                         class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
-                    </a>
-                  </li>
-                  <li
-                    class="Hidden__mobile"
-                  >
-                    <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
-                      data-analytics="header:applied+jobs"
-                      href="/my-activity/applied-jobs"
-                    >
-                      Applied Jobs
                     </a>
                   </li>
                   <li
@@ -1312,30 +1278,13 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
-                        Saved 
-                        <span
-                          class="Hidden__desktop"
-                        >
-                          & Applied 
-                        </span>
-                        Jobs
+                        Saved & Applied Jobs
                       </span>
                       <span
                         class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
-                    </a>
-                  </li>
-                  <li
-                    class="Hidden__mobile"
-                  >
-                    <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
-                      data-analytics="header:applied+jobs"
-                      href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
-                    >
-                      Applied Jobs
                     </a>
                   </li>
                   <li
@@ -1870,30 +1819,13 @@ exports[`Header: should render when authenticated 1`] = `
                       href="/my-activity/saved-jobs"
                     >
                       <span>
-                        Saved 
-                        <span
-                          class="Hidden__desktop"
-                        >
-                          & Applied 
-                        </span>
-                        Jobs
+                        Saved & Applied Jobs
                       </span>
                       <span
                         class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
-                    </a>
-                  </li>
-                  <li
-                    class="Hidden__mobile"
-                  >
-                    <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
-                      data-analytics="header:applied+jobs"
-                      href="/my-activity/applied-jobs"
-                    >
-                      Applied Jobs
                     </a>
                   </li>
                   <li
@@ -2425,30 +2357,13 @@ exports[`Header: should render when authenticated but username and email is not 
                       href="/my-activity/saved-jobs"
                     >
                       <span>
-                        Saved 
-                        <span
-                          class="Hidden__desktop"
-                        >
-                          & Applied 
-                        </span>
-                        Jobs
+                        Saved & Applied Jobs
                       </span>
                       <span
                         class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
-                    </a>
-                  </li>
-                  <li
-                    class="Hidden__mobile"
-                  >
-                    <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
-                      data-analytics="header:applied+jobs"
-                      href="/my-activity/applied-jobs"
-                    >
-                      Applied Jobs
                     </a>
                   </li>
                   <li
@@ -2980,30 +2895,13 @@ exports[`Header: should render when authentication is pending 1`] = `
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
-                        Saved 
-                        <span
-                          class="Hidden__desktop"
-                        >
-                          & Applied 
-                        </span>
-                        Jobs
+                        Saved & Applied Jobs
                       </span>
                       <span
                         class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
-                    </a>
-                  </li>
-                  <li
-                    class="Hidden__mobile"
-                  >
-                    <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
-                      data-analytics="header:applied+jobs"
-                      href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
-                    >
-                      Applied Jobs
                     </a>
                   </li>
                   <li
@@ -3536,30 +3434,13 @@ exports[`Header: should render when unauthenticated 1`] = `
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
-                        Saved 
-                        <span
-                          class="Hidden__desktop"
-                        >
-                          & Applied 
-                        </span>
-                        Jobs
+                        Saved & Applied Jobs
                       </span>
                       <span
                         class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
-                    </a>
-                  </li>
-                  <li
-                    class="Hidden__mobile"
-                  >
-                    <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
-                      data-analytics="header:applied+jobs"
-                      href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
-                    >
-                      Applied Jobs
                     </a>
                   </li>
                   <li
@@ -4066,30 +3947,13 @@ exports[`Header: should render with a custom logo 1`] = `
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
-                        Saved 
-                        <span
-                          class="Hidden__desktop"
-                        >
-                          & Applied 
-                        </span>
-                        Jobs
+                        Saved & Applied Jobs
                       </span>
                       <span
                         class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
-                    </a>
-                  </li>
-                  <li
-                    class="Hidden__mobile"
-                  >
-                    <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
-                      data-analytics="header:applied+jobs"
-                      href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
-                    >
-                      Applied Jobs
                     </a>
                   </li>
                   <li
@@ -4620,30 +4484,13 @@ exports[`Header: should render with locale of AU 1`] = `
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
-                        Saved 
-                        <span
-                          class="Hidden__desktop"
-                        >
-                          & Applied 
-                        </span>
-                        Jobs
+                        Saved & Applied Jobs
                       </span>
                       <span
                         class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
-                    </a>
-                  </li>
-                  <li
-                    class="Hidden__mobile"
-                  >
-                    <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
-                      data-analytics="header:applied+jobs"
-                      href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
-                    >
-                      Applied Jobs
                     </a>
                   </li>
                   <li
@@ -5174,30 +5021,13 @@ exports[`Header: should render with locale of NZ 1`] = `
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
-                        Saved 
-                        <span
-                          class="Hidden__desktop"
-                        >
-                          & Applied 
-                        </span>
-                        Jobs
+                        Saved & Applied Jobs
                       </span>
                       <span
                         class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
-                    </a>
-                  </li>
-                  <li
-                    class="Hidden__mobile"
-                  >
-                    <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
-                      data-analytics="header:applied+jobs"
-                      href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
-                    >
-                      Applied Jobs
                     </a>
                   </li>
                   <li
@@ -5675,30 +5505,13 @@ exports[`Header: should render with no divider 1`] = `
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fsaved-jobs"
                     >
                       <span>
-                        Saved 
-                        <span
-                          class="Hidden__desktop"
-                        >
-                          & Applied 
-                        </span>
-                        Jobs
+                        Saved & Applied Jobs
                       </span>
                       <span
                         class="Icon__root UserAccountMenu__icon UserAccountMenu__saveJobs"
                       >
                         mock svg
                       </span>
-                    </a>
-                  </li>
-                  <li
-                    class="Hidden__mobile"
-                  >
-                    <a
-                      class="UserAccountMenu__item UserAccountMenu__subItem"
-                      data-analytics="header:applied+jobs"
-                      href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
-                    >
-                      Applied Jobs
                     </a>
                   </li>
                   <li


### PR DESCRIPTION
### Background
Saved / Applied jobs are a bit weird in the User Account Menu (desktop).
There is an icon missing for `Applied Jobs` on desktop.
Also on mobile, it has been combined to a single item: `Saved & Applied Jobs`.

_Recommended jobs will also be underneath this new item so the menu won't look so short and ~fat~ wide._

### Changes
- Remove the `Applied Jobs` menu item.
- On desktop, add text to `Saved Jobs` (unhide), it is now `Saved & Applied Jobs`.
- Update snapshot tests.

The User Account Menu on mobile remains untouched.

### Before
![User Account menu before merge of Saved & Applied jobs](https://user-images.githubusercontent.com/3631404/54500565-0164e680-4972-11e9-8c16-de0d49d26c61.png)

### After
![User Account menu after merge of Saved & Applied jobs](https://user-images.githubusercontent.com/3631404/54500525-b64ad380-4971-11e9-9a0e-0e6d436dbeef.png)
