### PR TITLE
feat(Header): Add icon to Applied Jobs (UserAccountMenu)

### DIFF
--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -11,6 +11,7 @@ import ProfileIcon from '../../ProfileIcon/ProfileIcon';
 import HeartIcon from '../../HeartIcon/HeartIcon';
 import StarIcon from '../../StarIcon/StarIcon';
 import ThumbsUpIcon from '../../ThumbsUpIcon/ThumbsUpIcon';
+import TickCircleIcon from '../../TickCircleIcon/TickCircleIcon';
 import Hidden from '../../Hidden/Hidden';
 import Loader from '../../Loader/Loader';
 import Badge from '../../Badge/Badge';
@@ -163,7 +164,15 @@ export default ({
           authenticationStatus,
           '/my-activity/applied-jobs'
         ),
-        children: APPLIED_JOBS
+        children: [
+          newBadgeTab === APPLIED_JOBS && <BadgeComponent />,
+          <span key="label">{APPLIED_JOBS}</span>,
+          <TickCircleIcon
+            key="icon"
+            className={classnames(styles.icon, styles.appliedJobs)}
+            svgClassName={styles.iconSvg}
+          />
+        ]
       })}
     </Hidden>
     <li

--- a/react/Header/UserAccountMenu/UserAccountMenu.less
+++ b/react/Header/UserAccountMenu/UserAccountMenu.less
@@ -99,6 +99,10 @@
   color: @sk-green-light;
 }
 
+.icon.appliedJobs {
+  color: @sk-green;
+}
+
 .crSvg {
   width: 14px;
   height: 14px;

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -222,7 +222,14 @@ exports[`Header: should append returnUrl to signin and register links if present
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -783,7 +790,14 @@ exports[`Header: should render first part of email address when username isn't p
                       data-analytics="header:applied+jobs"
                       href="/my-activity/applied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -1341,7 +1355,14 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -1902,7 +1923,14 @@ exports[`Header: should render when authenticated 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/my-activity/applied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -2460,7 +2488,14 @@ exports[`Header: should render when authenticated but username and email is not 
                       data-analytics="header:applied+jobs"
                       href="/my-activity/applied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -3018,7 +3053,14 @@ exports[`Header: should render when authentication is pending 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -3577,7 +3619,14 @@ exports[`Header: should render when unauthenticated 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -4110,7 +4159,14 @@ exports[`Header: should render with a custom logo 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -4667,7 +4723,14 @@ exports[`Header: should render with locale of AU 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -5224,7 +5287,14 @@ exports[`Header: should render with locale of NZ 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -5728,7 +5798,14 @@ exports[`Header: should render with no divider 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li


### PR DESCRIPTION
### (Desktop) User Account Menu
**Add icon to Applied Jobs**
We have decided against merging the `Saved Jobs` and `Applied Jobs` user account menu items.
Instead we are fixing the current awkwardness which is `Applied Jobs` not having its own icon.

This change adds a `TickCircleIcon`, with the colour of `@sk-green`.


#### Before
![Applied Jobs without an icon](https://user-images.githubusercontent.com/3631404/54733328-3892fc00-4bed-11e9-8ca7-8798d706b6f1.png)

#### After
![Applied Jobs with an icon](https://user-images.githubusercontent.com/3631404/54733345-55c7ca80-4bed-11e9-8636-481bddfc13c8.png)
