### PR TITLE
fix(Checkbox): Label over two lines should display like the Radio Button

### DIFF
--- a/react/Checkbox/Checkbox.js
+++ b/react/Checkbox/Checkbox.js
@@ -73,7 +73,7 @@ export default class Checkbox extends Component {
             className={styles.checkMark}
           />
         </div>
-        <span>{label}</span>
+        <span className={styles.checkboxLabel}>{label}</span>
       </div>
     );
   }

--- a/react/Checkbox/Checkbox.less
+++ b/react/Checkbox/Checkbox.less
@@ -34,6 +34,10 @@
   display: flex;
 }
 
+.checkboxLabel {
+  margin-top: (@row-height / 2);
+}
+
 .checkbox {
   .activeFocusReset();
 

--- a/react/Checkbox/Checkbox.less
+++ b/react/Checkbox/Checkbox.less
@@ -28,11 +28,10 @@
 
 .standard {
   .touchableText(@standard-type-scale);
-  line-height: normal;
+  line-height: (@row-height * 4);
   height: 100%;
   cursor: pointer;
   display: flex;
-  align-items: center;
 }
 
 .checkbox {

--- a/react/Checkbox/Checkbox.less
+++ b/react/Checkbox/Checkbox.less
@@ -28,6 +28,7 @@
 
 .standard {
   .touchableText(@standard-type-scale);
+  line-height: normal;
   height: 100%;
   cursor: pointer;
   display: flex;

--- a/react/Checkbox/Checkbox.sketch.js
+++ b/react/Checkbox/Checkbox.sketch.js
@@ -3,11 +3,14 @@ import PropTypes from 'prop-types';
 import Checkbox from './Checkbox';
 import styles from './Checkbox.demo.less';
 
-const Container = ({ children }) => (
-  <div className={styles.root}>{children}</div>
+const Container = ({ children, width }) => (
+  <div className={styles.root} style={{ width: width ? `${width}px` : 'auto' }}>
+    {children}
+  </div>
 );
 Container.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  width: PropTypes.number
 };
 
 const noop = () => {};
@@ -51,6 +54,16 @@ export const symbols = {
         label="Checkbox"
         type="button"
         checked={false}
+        onChange={noop}
+      />
+    </Container>
+  ),
+  'Checkbox/Button/LongLabel': (
+    <Container width={200}>
+      <Checkbox
+        id="checkbox5"
+        label="This is going to be a very long label that will most likely wrap"
+        checked={true}
         onChange={noop}
       />
     </Container>

--- a/react/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/react/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -30,7 +30,9 @@ exports[`Checkbox FieldMessage should render field message when passed 1`] = `
           svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
-      <span>
+      <span
+        className="Checkbox__checkboxLabel"
+      >
         Still in role
       </span>
     </div>
@@ -81,7 +83,9 @@ exports[`Checkbox inputProps should pass through other props to the input 1`] = 
           svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
-      <span>
+      <span
+        className="Checkbox__checkboxLabel"
+      >
         Still in role
       </span>
     </div>
@@ -130,7 +134,9 @@ exports[`Checkbox should not render the invalid style if tone is set to positive
           svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
-      <span>
+      <span
+        className="Checkbox__checkboxLabel"
+      >
         Still in role
       </span>
     </div>
@@ -180,7 +186,9 @@ exports[`Checkbox should render the invalid style for tone="critical" even if th
           svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
-      <span>
+      <span
+        className="Checkbox__checkboxLabel"
+      >
         Still in role
       </span>
     </div>
@@ -230,7 +238,9 @@ exports[`Checkbox should render the invalid style for valid={false} where no ton
           svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
-      <span>
+      <span
+        className="Checkbox__checkboxLabel"
+      >
         Still in role
       </span>
     </div>
@@ -315,7 +325,9 @@ exports[`Checkbox should render with className 1`] = `
           svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
-      <span>
+      <span
+        className="Checkbox__checkboxLabel"
+      >
         Still in role
       </span>
     </div>
@@ -364,7 +376,9 @@ exports[`Checkbox should render with simple props 1`] = `
           svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
-      <span>
+      <span
+        className="Checkbox__checkboxLabel"
+      >
         Still in role
       </span>
     </div>
@@ -413,7 +427,9 @@ exports[`Checkbox should render with standard checkbox style 1`] = `
           svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
         />
       </div>
-      <span>
+      <span
+        className="Checkbox__checkboxLabel"
+      >
         Still in role
       </span>
     </div>


### PR DESCRIPTION
When a label text in a checkbox spans over multiple lines, there is a massive gap between the lines. See screenshot. This is because of the line-height coming from `touchableText`.


Before Change:
![Screen Shot 2019-03-29 at 10 06 19 am](https://user-images.githubusercontent.com/1418428/55200535-b1f4a500-5212-11e9-9bf8-636ded3e6acd.png)


After Change:
![Screen Shot 2019-03-29 at 10 06 35 am](https://user-images.githubusercontent.com/1418428/55200539-b620c280-5212-11e9-9f75-07bfe4110306.png)
