### PR TITLE
feat(Header): Add applied jobs icon (desktop)

### DIFF
--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -11,6 +11,7 @@ import ProfileIcon from '../../ProfileIcon/ProfileIcon';
 import HeartIcon from '../../HeartIcon/HeartIcon';
 import StarIcon from '../../StarIcon/StarIcon';
 import ThumbsUpIcon from '../../ThumbsUpIcon/ThumbsUpIcon';
+import TickCircleIcon from '../../TickCircleIcon/TickCircleIcon';
 import Hidden from '../../Hidden/Hidden';
 import Loader from '../../Loader/Loader';
 import Badge from '../../Badge/Badge';
@@ -163,7 +164,15 @@ export default ({
           authenticationStatus,
           '/my-activity/applied-jobs'
         ),
-        children: APPLIED_JOBS
+        children: [
+          newBadgeTab === APPLIED_JOBS && <BadgeComponent />,
+          <span key="label">{APPLIED_JOBS}</span>,
+          <TickCircleIcon
+            key="icon"
+            className={classnames(styles.icon, styles.appliedJobs)}
+            svgClassName={styles.iconSvg}
+          />
+        ]
       })}
     </Hidden>
     <li

--- a/react/Header/UserAccountMenu/UserAccountMenu.less
+++ b/react/Header/UserAccountMenu/UserAccountMenu.less
@@ -99,6 +99,10 @@
   color: @sk-green-light;
 }
 
+.icon.appliedJobs {
+  color: @sk-green;
+}
+
 .crSvg {
   width: 14px;
   height: 14px;

--- a/react/Header/UserAccountMenu/UserAccountMenu.less
+++ b/react/Header/UserAccountMenu/UserAccountMenu.less
@@ -96,7 +96,7 @@
 }
 
 .icon.recommendedJobs {
-  color: @sk-green-light;
+  color: @sk-green;
 }
 
 .icon.appliedJobs {

--- a/react/Header/UserAccountMenu/UserAccountMenu.less
+++ b/react/Header/UserAccountMenu/UserAccountMenu.less
@@ -100,7 +100,8 @@
 }
 
 .icon.appliedJobs {
-  color: @sk-green;
+  @sk-connect-success-green: #00b600;
+  color: @sk-connect-success-green;
 }
 
 .crSvg {

--- a/react/Header/UserAccountMenu/UserAccountMenu.less
+++ b/react/Header/UserAccountMenu/UserAccountMenu.less
@@ -96,12 +96,11 @@
 }
 
 .icon.recommendedJobs {
-  color: @sk-green;
+  color: @sk-recommended-jobs;
 }
 
 .icon.appliedJobs {
-  @sk-connect-success-green: #00b600;
-  color: @sk-connect-success-green;
+  color: @sk-applied-jobs;
 }
 
 .crSvg {

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -222,7 +222,14 @@ exports[`Header: should append returnUrl to signin and register links if present
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -783,7 +790,14 @@ exports[`Header: should render first part of email address when username isn't p
                       data-analytics="header:applied+jobs"
                       href="/my-activity/applied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -1341,7 +1355,14 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -1902,7 +1923,14 @@ exports[`Header: should render when authenticated 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/my-activity/applied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -2460,7 +2488,14 @@ exports[`Header: should render when authenticated but username and email is not 
                       data-analytics="header:applied+jobs"
                       href="/my-activity/applied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -3018,7 +3053,14 @@ exports[`Header: should render when authentication is pending 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -3577,7 +3619,14 @@ exports[`Header: should render when unauthenticated 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -4110,7 +4159,14 @@ exports[`Header: should render with a custom logo 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -4667,7 +4723,14 @@ exports[`Header: should render with locale of AU 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -5224,7 +5287,14 @@ exports[`Header: should render with locale of NZ 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li
@@ -5728,7 +5798,14 @@ exports[`Header: should render with no divider 1`] = `
                       data-analytics="header:applied+jobs"
                       href="/sign-in?returnUrl=%2Fmy-activity%2Fapplied-jobs"
                     >
-                      Applied Jobs
+                      <span>
+                        Applied Jobs
+                      </span>
+                      <span
+                        class="Icon__root UserAccountMenu__icon UserAccountMenu__appliedJobs"
+                      >
+                        mock svg
+                      </span>
                     </a>
                   </li>
                   <li

--- a/theme/palette/elements.less
+++ b/theme/palette/elements.less
@@ -18,3 +18,5 @@
 @sk-critical-dark: #cc026a;
 @sk-help-light: @sk-off-white;
 @sk-help: @sk-charcoal;
+@sk-recommended-jobs: @sk-green;
+@sk-applied-jobs: #00b600;


### PR DESCRIPTION
### Changes
User Account Menu looks a bit strange containing most icons, but not the Applied Jobs icon.
We are adding an icon in with a colour value (`00b600`) that matches the Job Applied Success page's tick.

Also, after the addition of the Applied Jobs icon we have realised that this icon looks too similar in colour to the Recommended Jobs icon. 
We are changing the Recommended Jobs icon to `@sk-green` - the same colour as it is displayed on the dashboard panel.

#### Before
<img width="277" alt="Before icon has been added to Applied Jobs" src="https://user-images.githubusercontent.com/3631404/55360556-77e01780-5520-11e9-98f0-d81ea1c752b5.png">

#### After - adding Applied Jobs icon
<img width="275" alt="After icon has been added to Applied Jobs" src="https://user-images.githubusercontent.com/3631404/55360528-5e3ed000-5520-11e9-9e38-164816bfb42c.png">

#### After after - changing Recommended Jobs icon to `@sk-green` (matching its colour on the dashboard)
<img width="285" alt="After Recommended Jobs has its colour changed" src="https://user-images.githubusercontent.com/3631404/55451206-b1e31380-561d-11e9-8829-e6253e22b806.png">
<img width="356" alt="image" src="https://user-images.githubusercontent.com/3631404/55451359-4b122a00-561e-11e9-938e-e20538efaa4e.png">
