### PR TITLE
feat(Checkbox): Support multiline label and improved VoiceOver focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "shallow-equal": "^1.0.0"
   },
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0",
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0",
     "react-helmet": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
@@ -134,16 +134,16 @@
     "query-string": "^6.1.0",
     "raf": "^3.4.0",
     "raw-loader": "^0.5.1",
-    "react": "^16.0.0",
+    "react": "^16.8.6",
     "react-copy-to-clipboard": "^5.0.1",
-    "react-dom": "^16.0.0",
+    "react-dom": "^16.8.6",
     "react-element-to-jsx-string": "^13.0.0",
     "react-helmet": "^5.2.0",
     "react-hot-loader": "^3.0.0-beta.7",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "react-shallow-testutils": "^3.0.0",
-    "react-test-renderer": "^16.0.0",
+    "react-test-renderer": "^16.8.6",
     "renovate-config-seek": "^0.4.0",
     "seek-style-guide-webpack": "^3.0.1",
     "semantic-release": "^8.1.2",

--- a/react/Checkbox/Checkbox.demo.js
+++ b/react/Checkbox/Checkbox.demo.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Checkbox from './Checkbox';
+import classnames from 'classnames';
+import Checkbox, { STANDARD, BUTTON } from './Checkbox';
 import * as sketch from './Checkbox.sketch';
 import demoStyles from './Checkbox.demo.less';
 import fieldMessageOptions from '../FieldMessage/FieldMessage.demoFragment';
@@ -15,26 +16,47 @@ class CheckboxContainer extends Component {
     super();
 
     this.state = {
-      checked: false
+      checked1: false,
+      checked2: false
     };
   }
 
-  handleChange = event => {
+  handleChange1 = event => {
     this.setState({
-      checked: event.target.checked
+      checked1: event.target.checked
+    });
+  };
+
+  handleChange2 = event => {
+    this.setState({
+      checked2: event.target.checked
     });
   };
 
   render() {
     const { component: DemoComponent, componentProps } = this.props;
-    const { checked } = this.state;
+    const { checked1, checked2 } = this.state;
 
     return (
-      <div className={demoStyles.root}>
+      <div
+        className={classnames({
+          [demoStyles.root_isStandard]: componentProps.type === STANDARD,
+          [demoStyles.root_isButton]: componentProps.type === BUTTON
+        })}
+      >
         <DemoComponent
           {...componentProps}
-          checked={checked}
-          onChange={this.handleChange}
+          id="fullTime"
+          label="Full time"
+          checked={checked1}
+          onChange={this.handleChange1}
+        />
+        <DemoComponent
+          {...componentProps}
+          id="partTime"
+          label="Part time / casual / vacation"
+          checked={checked2}
+          onChange={this.handleChange2}
         />
       </div>
     );
@@ -49,10 +71,9 @@ export default {
   container: CheckboxContainer,
   sketch,
   initialProps: {
-    id: 'stillInRole',
-    label: 'Still in role',
     type: 'standard',
     // Documentation only:
+    label: 'Full Time',
     checked: false,
     onChange: () => {}
   },

--- a/react/Checkbox/Checkbox.demo.less
+++ b/react/Checkbox/Checkbox.demo.less
@@ -1,3 +1,11 @@
-.root > :global(*) {
-  min-width: 150px; // :(
+@import "~seek-style-guide/theme";
+
+.root_isStandard {
+  display: flex;
+  flex-direction: column;
+  width: 220px;
+}
+
+.root_isButton > :not(*:last-child) {
+  margin-right: @gutter-width / 2;
 }

--- a/react/Checkbox/Checkbox.js
+++ b/react/Checkbox/Checkbox.js
@@ -1,13 +1,14 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styles from './Checkbox.less';
 import CheckMarkIcon from '../CheckMarkIcon/CheckMarkIcon';
 import classnames from 'classnames';
 import FieldMessage from '../FieldMessage/FieldMessage';
+import Text from '../Text/Text';
 import { TONE } from '../private/tone';
 
-const STANDARD = 'standard';
-const BUTTON = 'button';
+export const STANDARD = 'standard';
+export const BUTTON = 'button';
 
 function combineClassNames(props = {}, ...classNames) {
   const { className, ...restProps } = props;
@@ -51,12 +52,21 @@ export default class Checkbox extends Component {
   };
 
   renderButton(label) {
-    return <span className={styles.button}>{label}</span>;
+    return (
+      <Text
+        component="span"
+        baseline={false}
+        raw={true}
+        className={styles.button}
+      >
+        {label}
+      </Text>
+    );
   }
 
   renderStandard(label) {
     return (
-      <div className={styles.standard}>
+      <Fragment>
         <div className={styles.checkbox}>
           <CheckMarkIcon
             className={styles.checkMark}
@@ -73,8 +83,15 @@ export default class Checkbox extends Component {
             className={styles.checkMark}
           />
         </div>
-        <span>{label}</span>
-      </div>
+        <Text
+          component="span"
+          baseline={false}
+          raw={true}
+          className={styles.labelText}
+        >
+          {label}
+        </Text>
+      </Fragment>
     );
   }
 
@@ -112,7 +129,8 @@ export default class Checkbox extends Component {
       onChange,
       onFocus,
       onBlur,
-      inputProps
+      inputProps,
+      type
     } = this.props;
 
     const allInputProps = {
@@ -122,7 +140,11 @@ export default class Checkbox extends Component {
       onChange,
       onFocus,
       onBlur,
-      ...combineClassNames(inputProps, styles.input),
+      ...combineClassNames(inputProps, {
+        [styles.input]: true,
+        [styles.input_isCheckbox]: type === STANDARD,
+        [styles.input_isButton]: type === BUTTON
+      }),
       type: 'checkbox'
     };
 

--- a/react/Checkbox/Checkbox.less
+++ b/react/Checkbox/Checkbox.less
@@ -1,4 +1,6 @@
 @import (reference) "~seek-style-guide/theme";
+@checkbox-size: @row-height * 5;
+@touchable-margin: (@touchableTextHeight - @checkbox-size) / 2;
 
 .activeFocusReset() {
   .input:not([readonly]):not([disabled]):focus + .label &,
@@ -11,38 +13,69 @@
 
 .root {
   display: inline-block;
+  position: relative;
 }
 
 .input {
   opacity: 0;
   position: absolute;
+  pointer-events: none;
+}
+
+.input_isCheckbox {
+  width: @checkbox-size;
+  height: @checkbox-size;
+  margin: @touchable-margin 0 0 0;
+}
+
+.input_isButton {
+  width: 100%;
+  height: @touchableTextHeight;
+  margin: 0;
 }
 
 .label {
-  display: block;
+  display: flex;
+  cursor: pointer;
+  min-height: @touchableTextHeight;
 
-  :checked + & {
+  :global(*) {
+    pointer-events: none;
+  }
+
+  .input:checked + &,
+  .input:checked + & .labelText {
     font-weight: @sk-bold;
   }
 }
 
-.standard {
-  .touchableText(@standard-type-scale);
-  height: 100%;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
+.labelText {
+  @media @desktop {
+    padding: (
+        ((@interaction-type-row-span - @standard-type-row-span) / 2) *
+          @row-height
+      )
+      0;
+  }
+  @media @mobile {
+    padding: (
+        ((@interaction-type-row-span - @standard-type-row-span-mobile) / 2) *
+          @row-height
+      )
+      0;
+  }
 }
 
 .checkbox {
   .activeFocusReset();
 
   background-color: @sk-white;
-  width: @row-height * 5;
-  height: @row-height * 5;
-  flex: 0 0 (@row-height * 5);
+  width: @checkbox-size;
+  height: @checkbox-size;
+  flex: 0 0 @checkbox-size;
   border: @field-border-width solid @sk-mid-gray-light;
   border-radius: @field-border-radius;
+  margin-top: @touchable-margin;
   margin-right: @field-gutter-width;
   position: relative;
 
@@ -94,18 +127,18 @@
 
 .button {
   .activeFocusReset();
-  .touchableText(@standard-type-scale-mobile);
+  width: 100%;
   display: flex;
   align-items: center;
-  justify-content: center;
+  text-align: center;
+  padding: 0 @field-gutter-width;
+  white-space: nowrap;
+  overflow: hidden;
   background-color: @sk-gray-light;
   color: @sk-charcoal;
   border: 1px solid @sk-mid-gray-light;
   border-radius: 2px;
   cursor: pointer;
-  @media @desktop {
-    .touchableText(@standard-type-scale);
-  }
 
   .input:checked + .label & {
     font-weight: @sk-bold;

--- a/react/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/react/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -6,7 +6,7 @@ exports[`Checkbox FieldMessage should render field message when passed 1`] = `
 >
   <input
     checked={false}
-    className="Checkbox__input"
+    className="Checkbox__input Checkbox__input_isCheckbox"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
@@ -16,24 +16,25 @@ exports[`Checkbox FieldMessage should render field message when passed 1`] = `
     htmlFor="testCheckbox"
   >
     <div
-      className="Checkbox__standard"
+      className="Checkbox__checkbox"
     >
-      <div
-        className="Checkbox__checkbox"
-      >
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
-        />
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
-        />
-      </div>
-      <span>
-        Still in role
-      </span>
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
+      />
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
+      />
     </div>
+    <Text
+      baseline={false}
+      className="Checkbox__labelText"
+      component="span"
+      raw={true}
+    >
+      Still in role
+    </Text>
   </label>
   <FieldMessage
     id="testCheckbox-message"
@@ -56,7 +57,7 @@ exports[`Checkbox inputProps should pass through other props to the input 1`] = 
 >
   <input
     checked={false}
-    className="Checkbox__input"
+    className="Checkbox__input Checkbox__input_isCheckbox"
     data-automation="first-name-field"
     id="testCheckbox"
     onChange={[Function]}
@@ -67,24 +68,25 @@ exports[`Checkbox inputProps should pass through other props to the input 1`] = 
     htmlFor="testCheckbox"
   >
     <div
-      className="Checkbox__standard"
+      className="Checkbox__checkbox"
     >
-      <div
-        className="Checkbox__checkbox"
-      >
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
-        />
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
-        />
-      </div>
-      <span>
-        Still in role
-      </span>
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
+      />
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
+      />
     </div>
+    <Text
+      baseline={false}
+      className="Checkbox__labelText"
+      component="span"
+      raw={true}
+    >
+      Still in role
+    </Text>
   </label>
   <FieldMessage
     id="testCheckbox-message"
@@ -106,7 +108,7 @@ exports[`Checkbox should not render the invalid style if tone is set to positive
 >
   <input
     checked={false}
-    className="Checkbox__input"
+    className="Checkbox__input Checkbox__input_isCheckbox"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
@@ -116,24 +118,25 @@ exports[`Checkbox should not render the invalid style if tone is set to positive
     htmlFor="testCheckbox"
   >
     <div
-      className="Checkbox__standard"
+      className="Checkbox__checkbox"
     >
-      <div
-        className="Checkbox__checkbox"
-      >
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
-        />
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
-        />
-      </div>
-      <span>
-        Still in role
-      </span>
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
+      />
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
+      />
     </div>
+    <Text
+      baseline={false}
+      className="Checkbox__labelText"
+      component="span"
+      raw={true}
+    >
+      Still in role
+    </Text>
   </label>
   <FieldMessage
     id="testCheckbox-message"
@@ -156,7 +159,7 @@ exports[`Checkbox should render the invalid style for tone="critical" even if th
 >
   <input
     checked={false}
-    className="Checkbox__input"
+    className="Checkbox__input Checkbox__input_isCheckbox"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
@@ -166,24 +169,25 @@ exports[`Checkbox should render the invalid style for tone="critical" even if th
     htmlFor="testCheckbox"
   >
     <div
-      className="Checkbox__standard"
+      className="Checkbox__checkbox"
     >
-      <div
-        className="Checkbox__checkbox"
-      >
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
-        />
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
-        />
-      </div>
-      <span>
-        Still in role
-      </span>
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
+      />
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
+      />
     </div>
+    <Text
+      baseline={false}
+      className="Checkbox__labelText"
+      component="span"
+      raw={true}
+    >
+      Still in role
+    </Text>
   </label>
   <FieldMessage
     id="testCheckbox-message"
@@ -206,7 +210,7 @@ exports[`Checkbox should render the invalid style for valid={false} where no ton
 >
   <input
     checked={false}
-    className="Checkbox__input"
+    className="Checkbox__input Checkbox__input_isCheckbox"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
@@ -216,24 +220,25 @@ exports[`Checkbox should render the invalid style for valid={false} where no ton
     htmlFor="testCheckbox"
   >
     <div
-      className="Checkbox__standard"
+      className="Checkbox__checkbox"
     >
-      <div
-        className="Checkbox__checkbox"
-      >
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
-        />
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
-        />
-      </div>
-      <span>
-        Still in role
-      </span>
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
+      />
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
+      />
     </div>
+    <Text
+      baseline={false}
+      className="Checkbox__labelText"
+      component="span"
+      raw={true}
+    >
+      Still in role
+    </Text>
   </label>
   <FieldMessage
     id="testCheckbox-message"
@@ -256,7 +261,7 @@ exports[`Checkbox should render with button style 1`] = `
 >
   <input
     checked={false}
-    className="Checkbox__input"
+    className="Checkbox__input Checkbox__input_isButton"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
@@ -265,11 +270,14 @@ exports[`Checkbox should render with button style 1`] = `
     className="Checkbox__label"
     htmlFor="testCheckbox"
   >
-    <span
+    <Text
+      baseline={false}
       className="Checkbox__button"
+      component="span"
+      raw={true}
     >
       Still in role
-    </span>
+    </Text>
   </label>
   <FieldMessage
     id="testCheckbox-message"
@@ -291,7 +299,7 @@ exports[`Checkbox should render with className 1`] = `
 >
   <input
     checked={false}
-    className="Checkbox__input"
+    className="Checkbox__input Checkbox__input_isCheckbox"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
@@ -301,24 +309,25 @@ exports[`Checkbox should render with className 1`] = `
     htmlFor="testCheckbox"
   >
     <div
-      className="Checkbox__standard"
+      className="Checkbox__checkbox"
     >
-      <div
-        className="Checkbox__checkbox"
-      >
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
-        />
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
-        />
-      </div>
-      <span>
-        Still in role
-      </span>
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
+      />
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
+      />
     </div>
+    <Text
+      baseline={false}
+      className="Checkbox__labelText"
+      component="span"
+      raw={true}
+    >
+      Still in role
+    </Text>
   </label>
   <FieldMessage
     id="testCheckbox-message"
@@ -340,7 +349,7 @@ exports[`Checkbox should render with simple props 1`] = `
 >
   <input
     checked={false}
-    className="Checkbox__input"
+    className="Checkbox__input Checkbox__input_isCheckbox"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
@@ -350,24 +359,25 @@ exports[`Checkbox should render with simple props 1`] = `
     htmlFor="testCheckbox"
   >
     <div
-      className="Checkbox__standard"
+      className="Checkbox__checkbox"
     >
-      <div
-        className="Checkbox__checkbox"
-      >
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
-        />
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
-        />
-      </div>
-      <span>
-        Still in role
-      </span>
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
+      />
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
+      />
     </div>
+    <Text
+      baseline={false}
+      className="Checkbox__labelText"
+      component="span"
+      raw={true}
+    >
+      Still in role
+    </Text>
   </label>
   <FieldMessage
     id="testCheckbox-message"
@@ -389,7 +399,7 @@ exports[`Checkbox should render with standard checkbox style 1`] = `
 >
   <input
     checked={false}
-    className="Checkbox__input"
+    className="Checkbox__input Checkbox__input_isCheckbox"
     id="testCheckbox"
     onChange={[Function]}
     type="checkbox"
@@ -399,24 +409,25 @@ exports[`Checkbox should render with standard checkbox style 1`] = `
     htmlFor="testCheckbox"
   >
     <div
-      className="Checkbox__standard"
+      className="Checkbox__checkbox"
     >
-      <div
-        className="Checkbox__checkbox"
-      >
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
-        />
-        <CheckMarkIcon
-          className="Checkbox__checkMark"
-          svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
-        />
-      </div>
-      <span>
-        Still in role
-      </span>
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isHover"
+      />
+      <CheckMarkIcon
+        className="Checkbox__checkMark"
+        svgClassName="Checkbox__checkMarkSvg Checkbox__checkMarkSvg_isSelected"
+      />
     </div>
+    <Text
+      baseline={false}
+      className="Checkbox__labelText"
+      component="span"
+      raw={true}
+    >
+      Still in role
+    </Text>
   </label>
   <FieldMessage
     id="testCheckbox-message"


### PR DESCRIPTION
BREAKING CHANGE: Requires consumers to have React v16.3+. Also introduces horizontal padding to the Checkbox in button mode to prevent label text colliding with button border.

## Description
Addresses the primary issue of supporting multiline labels as raised [here](https://github.com/seek-oss/seek-style-guide/pull/610). Also taking the opportunity to bring the `Checkbox` up to the standard of `Radio` in terms of screen reader outline by correctly positioning and sizing the hidden native input element.

## Migration Guide
### React
Now takes a peer dependency on React v16.3+. Please ensure your app is compatible, see [the React v16 release](https://reactjs.org/blog/2017/09/26/react-v16.0.html) blog to see what is relevant for your app.

### Checkbox
If using `<Checkbox type="button" />` please validate that the addition of the field gutter width padding does not introduce any undesired wrapping or overflow.

## Change details
### Support for multiline checkbox labels
Before: [See current production playroom](https://seek-style-guide--e1fa3f4b590e7be06ad6cee654c78e3d649edcb3.surge.sh/playroom/#?code=PENhcmQ-CiAgPFNlY3Rpb24-CiAgICA8Q2hlY2tib3ggaWQ9InRlc3QiIGxhYmVsPSJSZWFsbHkgbG9uZyBjaGVja2JveCBsYWJlbCB0byBkZW1vbnN0cmF0ZSB1bmRlc2lyZWQgd3JhcHBpbmcgb2YgdGV4dCBhbmQgbWlzYWxpZ25lZCBjaGVja2JveCBlbGVtZW50LiIgLz4KICA8L1NlY3Rpb24-CjwvQ2FyZD4)
After: [See branch playroom](https://seek-style-guide--87e4e9f4fa686efbbb0b22ef0662be13d60a8f89.surge.sh/playroom/#?code=PENhcmQ-CiAgPFNlY3Rpb24-CiAgICA8Q2hlY2tib3ggaWQ9InRlc3QiIGxhYmVsPSJSZWFsbHkgbG9uZyBjaGVja2JveCBsYWJlbCB0byBkZW1vbnN0cmF0ZSB1bmRlc2lyZWQgd3JhcHBpbmcgb2YgdGV4dCBhbmQgbWlzYWxpZ25lZCBjaGVja2JveCBlbGVtZW50LiIgLz4KICA8L1NlY3Rpb24-CjwvQ2FyZD4)

### Standard checkbox screen reader outline (VoiceOver)
Before: 
<img width="221" alt="Screen Shot 2019-04-04 at 9 06 50 am" src="https://user-images.githubusercontent.com/912060/55516492-130bf500-56b9-11e9-8007-6d8f3655aa11.png">
After:
<img width="254" alt="Screen Shot 2019-04-04 at 9 05 54 am" src="https://user-images.githubusercontent.com/912060/55516489-130bf500-56b9-11e9-9919-9195fa436646.png">

### Button checkbox screen reader outline (VoiceOver)
Before:
<img width="247" alt="Screen Shot 2019-04-04 at 9 06 59 am" src="https://user-images.githubusercontent.com/912060/55516493-13a48b80-56b9-11e9-8336-8dfca37c34e1.png">
After:
<img width="388" alt="Screen Shot 2019-04-04 at 9 06 11 am" src="https://user-images.githubusercontent.com/912060/55516490-130bf500-56b9-11e9-847c-0f520d8d4336.png">