### PR TITLE
fix(Textarea): Remove max-height

### DIFF
--- a/docs/src/components/Demo/Demo.less
+++ b/docs/src/components/Demo/Demo.less
@@ -26,7 +26,7 @@
 .options {
   padding: (@row-height * 3) @gutter-width;
   @media @desktop {
-    height: @row-height * 12;
+    flex-wrap: wrap;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/react/Textarea/Textarea.demo.js
+++ b/react/Textarea/Textarea.demo.js
@@ -71,7 +71,7 @@ export default {
           })
         },
         {
-          label: 'Count',
+          label: 'Show Count',
           transformProps: props => ({
             ...props,
             countFeedback: value => ({
@@ -87,10 +87,10 @@ export default {
           })
         },
         {
-          label: 'Inital Rows 20',
+          label: 'Initial Rows 20',
           transformProps: props => ({
             ...props,
-            initalRows: 10
+            initialRows: 20
           })
         },
         {
@@ -113,7 +113,7 @@ export default {
           })
         },
         {
-          label: 'Disallowed words',
+          label: 'Disallowed word(s)',
           transformProps: props => ({
             ...props,
             invalidText: 'bad',
@@ -132,7 +132,7 @@ export default {
           })
         },
         {
-          label: 'Multi invalid range',
+          label: 'Multiple invalid ranges',
           transformProps: props => ({
             ...props,
             invalidText: [

--- a/react/Textarea/Textarea.demo.js
+++ b/react/Textarea/Textarea.demo.js
@@ -71,7 +71,7 @@ export default {
           })
         },
         {
-          label: 'Show Count',
+          label: 'Count',
           transformProps: props => ({
             ...props,
             countFeedback: value => ({
@@ -84,6 +84,20 @@ export default {
           transformProps: props => ({
             ...props,
             description: 'Describe a descriptive description descriptively'
+          })
+        },
+        {
+          label: 'Inital Rows 20',
+          transformProps: props => ({
+            ...props,
+            initalRows: 10
+          })
+        },
+        {
+          label: 'Max Rows 50',
+          transformProps: props => ({
+            ...props,
+            maxRows: 50
           })
         }
       ]
@@ -99,7 +113,7 @@ export default {
           })
         },
         {
-          label: 'Disallowed word(s)',
+          label: 'Disallowed words',
           transformProps: props => ({
             ...props,
             invalidText: 'bad',
@@ -118,7 +132,7 @@ export default {
           })
         },
         {
-          label: 'Multiple invalid ranges',
+          label: 'Multi invalid range',
           transformProps: props => ({
             ...props,
             invalidText: [

--- a/react/Textarea/Textarea.js
+++ b/react/Textarea/Textarea.js
@@ -9,6 +9,7 @@ import { TONE } from '../private/tone';
 import { formatInvalidText } from './textAreaUtils';
 import attachRefs from '../private/attachRefs';
 
+// Hard codded as lessToJS is not prod ready, should be in sync with seek-style-guide/theme/layout/grid.less:1
 const rowHeight = 6;
 
 function combineClassNames(props = {}, ...classNames) {
@@ -34,7 +35,7 @@ export default class Textarea extends Component {
     valid: PropTypes.bool,
     description: PropTypes.string,
     inputProps: PropTypes.object,
-    initalRows: PropTypes.number,
+    initialRows: PropTypes.number,
     maxRows: PropTypes.number,
     countFeedback: (props, propName, componentName) => {
       const { value, inputProps = {} } = props;
@@ -76,7 +77,7 @@ export default class Textarea extends Component {
     className: '',
     description: '',
     inputProps: {},
-    initalRows: 15,
+    initialRows: 15,
     maxRows: 30
   };
 
@@ -137,7 +138,7 @@ export default class Textarea extends Component {
       onFocus,
       onBlur,
       inputProps,
-      initalRows,
+      initialRows,
       maxRows
     } = this.props;
     const { ref: inputRef } = inputProps;
@@ -151,7 +152,7 @@ export default class Textarea extends Component {
       );
     }
 
-    const height = initalRows * rowHeight;
+    const height = initialRows * rowHeight;
     const maxHeight = maxRows * rowHeight;
 
     const style = {

--- a/react/Textarea/Textarea.js
+++ b/react/Textarea/Textarea.js
@@ -9,6 +9,12 @@ import { TONE } from '../private/tone';
 import { formatInvalidText } from './textAreaUtils';
 import attachRefs from '../private/attachRefs';
 
+import lessToJs from 'less-vars-to-js';
+
+import grid from '!!raw-loader!seek-style-guide/theme/layout/grid.less';
+const gridValues = lessToJs(grid);
+const rowHeight = parseInt(gridValues['@row-height'], 10);
+
 function combineClassNames(props = {}, ...classNames) {
   const { className, ...restProps } = props;
 
@@ -32,6 +38,8 @@ export default class Textarea extends Component {
     valid: PropTypes.bool,
     description: PropTypes.string,
     inputProps: PropTypes.object,
+    initalRows: PropTypes.number,
+    maxRows: PropTypes.number,
     countFeedback: (props, propName, componentName) => {
       const { value, inputProps = {} } = props;
 
@@ -71,7 +79,9 @@ export default class Textarea extends Component {
   static defaultProps = {
     className: '',
     description: '',
-    inputProps: {}
+    inputProps: {},
+    initalRows: 15,
+    maxRows: 30
   };
 
   constructor() {
@@ -130,7 +140,9 @@ export default class Textarea extends Component {
       onChange,
       onFocus,
       onBlur,
-      inputProps
+      inputProps,
+      initalRows,
+      maxRows
     } = this.props;
     const { ref: inputRef } = inputProps;
     let formattedText;
@@ -143,6 +155,14 @@ export default class Textarea extends Component {
       );
     }
 
+    const height = initalRows * rowHeight;
+    const maxHeight = maxRows * rowHeight;
+
+    const style = {
+      height: `${height}px`,
+      maxHeight: `${maxHeight}px`
+    };
+
     const renderTextarea = (props = {}, classname) => (
       <textarea
         {...{
@@ -154,6 +174,7 @@ export default class Textarea extends Component {
           ...combineClassNames(inputProps, styles.textarea, classname),
           'aria-describedby': `${id}-message`,
           ref: attachRefs(this.storeTextareaRef, inputRef),
+          style,
           ...props
         }}
       />

--- a/react/Textarea/Textarea.js
+++ b/react/Textarea/Textarea.js
@@ -9,11 +9,7 @@ import { TONE } from '../private/tone';
 import { formatInvalidText } from './textAreaUtils';
 import attachRefs from '../private/attachRefs';
 
-import lessToJs from 'less-vars-to-js';
-
-import grid from '!!raw-loader!seek-style-guide/theme/layout/grid.less';
-const gridValues = lessToJs(grid);
-const rowHeight = parseInt(gridValues['@row-height'], 10);
+const rowHeight = 6;
 
 function combineClassNames(props = {}, ...classNames) {
   const { className, ...restProps } = props;

--- a/react/Textarea/Textarea.less
+++ b/react/Textarea/Textarea.less
@@ -13,7 +13,6 @@
   height: @row-height * 15;
   resize: vertical;
   overflow: auto;
-  max-height: @row-height * 30;
   line-height: 25px; // Deliberate deviation to avoid looking like body copy
   color: @sk-charcoal;
   border: @field-border-width solid @sk-mid-gray-light;

--- a/react/Textarea/Textarea.less
+++ b/react/Textarea/Textarea.less
@@ -10,7 +10,6 @@
   .touchableText();
   width: 100%;
   display: inline-block;
-  height: @row-height * 15;
   resize: vertical;
   overflow: auto;
   line-height: 25px; // Deliberate deviation to avoid looking like body copy


### PR DESCRIPTION
We require a `<Textarea />` with a height greater than 180px. While it is possible to override it using a CSS selector (something like .className textarea) it becomes extremely fragile when having highlighting enabled as it also inherits everything from `styles.textarea`.