### PR TITLE
 feat(Footer): Add RSP link to footer

### DIFF
--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -786,6 +786,17 @@ exports[`Footer: should render when authenticated 1`] = `
                 Insights & Resources
               </a>
             </li>
+            <li
+              class=""
+            >
+              <a
+                class="FooterLink__link"
+                data-analytics="toolbar:integration-partners"
+                href="https://talent.seek.com.au/integration-partners/"
+              >
+                Recruitment software partners
+              </a>
+            </li>
           </ul>
         </nav>
       </div>
@@ -1618,6 +1629,17 @@ exports[`Footer: should render when authentication is pending 1`] = `
                 href="http://insightsresources.seek.com.au/"
               >
                 Insights & Resources
+              </a>
+            </li>
+            <li
+              class=""
+            >
+              <a
+                class="FooterLink__link"
+                data-analytics="toolbar:integration-partners"
+                href="https://talent.seek.com.au/integration-partners/"
+              >
+                Recruitment software partners
               </a>
             </li>
           </ul>
@@ -2454,6 +2476,17 @@ exports[`Footer: should render when unauthenticated 1`] = `
                 Insights & Resources
               </a>
             </li>
+            <li
+              class=""
+            >
+              <a
+                class="FooterLink__link"
+                data-analytics="toolbar:integration-partners"
+                href="https://talent.seek.com.au/integration-partners/"
+              >
+                Recruitment software partners
+              </a>
+            </li>
           </ul>
         </nav>
       </div>
@@ -3286,6 +3319,17 @@ exports[`Footer: should render with locale of AU 1`] = `
                 href="http://insightsresources.seek.com.au/"
               >
                 Insights & Resources
+              </a>
+            </li>
+            <li
+              class=""
+            >
+              <a
+                class="FooterLink__link"
+                data-analytics="toolbar:integration-partners"
+                href="https://talent.seek.com.au/integration-partners/"
+              >
+                Recruitment software partners
               </a>
             </li>
           </ul>

--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -4069,6 +4069,17 @@ exports[`Footer: should render with locale of NZ 1`] = `
                 Insights & Resources
               </a>
             </li>
+            <li
+              class=""
+            >
+              <a
+                class="FooterLink__link"
+                data-analytics="toolbar:integration-partners"
+                href="https://talent.seek.co.nz/integration-partners/"
+              >
+                Recruitment software partners
+              </a>
+            </li>
           </ul>
         </nav>
       </div>

--- a/react/Footer/data/employers.js
+++ b/react/Footer/data/employers.js
@@ -67,4 +67,10 @@ export default [
     analytics: 'toolbar:integration-partners',
     specificLocale: 'AU'
   },
+  {
+    name: 'Recruitment software partners',
+    href: 'https://talent.seek.co.nz/integration-partners/',
+    analytics: 'toolbar:integration-partners',
+    specificLocale: 'NZ'
+  },
 ];

--- a/react/Footer/data/employers.js
+++ b/react/Footer/data/employers.js
@@ -60,5 +60,11 @@ export default [
     href: 'http://insightsresources.seek.co.nz/',
     analytics: 'toolbar:insight+blog',
     specificLocale: 'NZ'
-  }
+  },
+  {
+    name: 'Recruitment software partners',
+    href: 'https://talent.seek.com.au/integration-partners/',
+    analytics: 'toolbar:integration-partners',
+    specificLocale: 'AU'
+  },
 ];

--- a/react/Footer/data/employers.js
+++ b/react/Footer/data/employers.js
@@ -72,5 +72,5 @@ export default [
     href: 'https://talent.seek.co.nz/integration-partners/',
     analytics: 'toolbar:integration-partners',
     specificLocale: 'NZ'
-  },
+  }
 ];


### PR DESCRIPTION
A new page promoting our Recruitment Software Partners has launched and needs to be surfaced in the candidate footer.