### PR TITLE
refactor: Use correct font weight for @sk-bold

### DIFF
--- a/theme/type/type.less
+++ b/theme/type/type.less
@@ -65,5 +65,5 @@
 @sk-light: 300;
 @sk-regular: 400;
 @sk-medium: 500;
-@sk-bold: 600;
+@sk-bold: 700;
 @sk-secondary: @sk-mid-gray-dark;


### PR DESCRIPTION
We had incorrectly set `@sk-bold` to 600 (semi-bold) which is not available in our chosen font. As a result, the browser rounds the font weight up to 700 (bold). This is actually our desired font weight, so this wasn't technically an issue. The problem is that, when exporting to Sketch, this font weight gets rounded *down* to 500 (medium), causing a major discrepancy between our mock ups and the final medium.

For consumers, this doesn't actually change anything, so I'm marking this as a refactor.