### PR TITLE
fix(Button): Add missing colour styles to white button option

### DIFF
--- a/react/Button/Button.less
+++ b/react/Button/Button.less
@@ -81,6 +81,10 @@
   .buttonColor(@sk-black, @sk-mid-gray-light);
 }
 
+.root_isWhite {
+  .buttonColor(@sk-black, @sk-white);
+}
+
 .root_isGhost,
 .root_isTransparent {
   background-color: transparent;

--- a/react/Button/Button.test.js
+++ b/react/Button/Button.test.js
@@ -19,6 +19,11 @@ describe('Button:', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
+    it('should render white button', () => {
+      const wrapper = shallow(<Button color="white">SEEK</Button>);
+      expect(wrapper).toMatchSnapshot();
+    });
+
     it('should render transparent button', () => {
       const wrapper = shallow(<Button color="transparent">SEEK</Button>);
       expect(wrapper).toMatchSnapshot();

--- a/react/Button/__snapshots__/Button.test.js.snap
+++ b/react/Button/__snapshots__/Button.test.js.snap
@@ -36,6 +36,15 @@ exports[`Button: color variants: should render transparent button 1`] = `
 </button>
 `;
 
+exports[`Button: color variants: should render white button 1`] = `
+<button
+  className="Button__root Button__root_isWhite"
+  disabled={false}
+>
+  SEEK
+</button>
+`;
+
 exports[`Button: color variants: should render white ghost button 1`] = `
 <button
   className="Button__root Button__root_isGhost Button__root_isWhite"


### PR DESCRIPTION
Style guide demo page for button component displays an ugly variant for the white colour option (without "ghost" prop selected)

![Screen Shot 2019-05-22 at 2 06 52 pm](https://user-images.githubusercontent.com/1221164/58147067-2d675580-7c9c-11e9-8b9f-ca7bc3249314.png)

**After:**
![Screen Shot 2019-05-22 at 2 16 59 pm](https://user-images.githubusercontent.com/1221164/58147097-4f60d800-7c9c-11e9-89b2-f49c8245ab7d.png)


NOTE: While a solid white button may not be part of the style guide (based on sketch example at bottom of page), at least this provides a nice looking fallback should the wrong prop options be provided.