### PR TITLE
fix(AccordionItem): Set height to auto

### DIFF
--- a/react/AccordionItem/AccordionItem.js
+++ b/react/AccordionItem/AccordionItem.js
@@ -17,7 +17,7 @@ function AccordionItem({
   ...restProps
 }) {
   const contentEl = useRef(null);
-  const [currentHeight, setCurrentHeight] = useState(CLOSED_HEIGHT);
+  const [cssHeight, setCssHeight] = useState(CLOSED_HEIGHT);
   const [cssVisibility, setCssVisibility] = useState('hidden');
   const [cssOverflow, setCssOverflow] = useState('hidden');
   const [cssOpacity, setCssOpacity] = useState(0);
@@ -36,7 +36,7 @@ function AccordionItem({
         onClose,
         timeoutHandle,
         setTimeoutHandle,
-        setCurrentHeight,
+        setCssHeight,
         setCssOpacity,
         setCssOverflow,
         setCssVisibility
@@ -81,7 +81,7 @@ function AccordionItem({
       <div
         className={styles.expander}
         style={{
-          height: currentHeight,
+          height: cssHeight,
           overflow: cssOverflow,
           opacity: cssOpacity
         }}

--- a/react/AccordionItem/AccordionItem.js
+++ b/react/AccordionItem/AccordionItem.js
@@ -18,8 +18,8 @@ function AccordionItem({
 }) {
   const contentEl = useRef(null);
   const [currentHeight, setCurrentHeight] = useState(CLOSED_HEIGHT);
-  const [cssVisibility, setCssVisibility] = useState('visible');
-  const [cssOverflow, setCssOverflow] = useState('visible');
+  const [cssVisibility, setCssVisibility] = useState('hidden');
+  const [cssOverflow, setCssOverflow] = useState('hidden');
   const [cssOpacity, setCssOpacity] = useState(0);
   const [timeoutHandle, setTimeoutHandle] = useState(null);
   const [isOpen, setIsOpen] = useState(false);

--- a/react/AccordionItem/utils.js
+++ b/react/AccordionItem/utils.js
@@ -1,7 +1,9 @@
 import { CLOSED_HEIGHT, DURATION } from './constants';
 
 function onAnimationStart(fn) {
-  requestAnimationFrame(fn, 0);
+  // 20ms is just enough to delay by a single frame
+  // since 1000ms / 60fps = 16.66ms
+  setTimeout(fn, 20);
 }
 
 function onAnimationEnd(fn) {
@@ -12,7 +14,7 @@ export function toggleContent({
   el,
   onOpen,
   onClose,
-  setCurrentHeight,
+  setCssHeight,
   timeoutHandle,
   setTimeoutHandle,
   isOpen,
@@ -28,15 +30,15 @@ export function toggleContent({
       onOpen();
     }
     setCssVisibility('visible');
-    setCurrentHeight(`${contentHeight}px`);
+    setCssHeight(`${contentHeight}px`);
     setCssOpacity(1);
 
     setTimeoutHandle(
       onAnimationEnd(() => {
         // After the animation finishes, we change the height to auto, to account
-        // for things that may change height within the content area, such as 
-        // expanding text fields, etc.
-        setCurrentHeight('auto');
+        // for things that may change height within the content area, such as
+        // expanding text fields, and also browser resizing etc.
+        setCssHeight('auto');
         // We toggle overflow on and off to avoid cropping the focus state
         // on form fields
         setCssOverflow('visible');
@@ -46,13 +48,13 @@ export function toggleContent({
     if (onClose) {
       onClose();
     }
-    setCurrentHeight(`${contentHeight}px`);
+    setCssHeight(`${contentHeight}px`);
     setCssOverflow('hidden');
     setCssOpacity(0);
 
     onAnimationStart(() => {
-      setCurrentHeight(CLOSED_HEIGHT);
-    })
+      setCssHeight(CLOSED_HEIGHT);
+    });
 
     setTimeoutHandle(
       onAnimationEnd(() => {

--- a/react/AccordionItem/utils.js
+++ b/react/AccordionItem/utils.js
@@ -1,5 +1,9 @@
 import { CLOSED_HEIGHT, DURATION } from './constants';
 
+function onAnimationStart(fn) {
+  requestAnimationFrame(fn, 0);
+}
+
 function onAnimationEnd(fn) {
   return setTimeout(fn, DURATION);
 }
@@ -29,6 +33,10 @@ export function toggleContent({
 
     setTimeoutHandle(
       onAnimationEnd(() => {
+        // After the animation finishes, we change the height to auto, to account
+        // for things that may change height within the content area, such as 
+        // expanding text fields, etc.
+        setCurrentHeight('auto');
         // We toggle overflow on and off to avoid cropping the focus state
         // on form fields
         setCssOverflow('visible');
@@ -38,9 +46,13 @@ export function toggleContent({
     if (onClose) {
       onClose();
     }
-    setCurrentHeight(CLOSED_HEIGHT);
+    setCurrentHeight(`${contentHeight}px`);
     setCssOverflow('hidden');
     setCssOpacity(0);
+
+    onAnimationStart(() => {
+      setCurrentHeight(CLOSED_HEIGHT);
+    })
 
     setTimeoutHandle(
       onAnimationEnd(() => {


### PR DESCRIPTION
This PR fixes:

- The content being set to the incorrect initialState
- Adds back the `height` being set to `auto` when the animation finishes. This accounts for content that could dynamically change size, such as textareas.