### PR TITLE
fix(Footer): Remove sitemap from footer

### DIFF
--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -816,13 +816,6 @@ exports[`Footer: should render when authenticated 1`] = `
         >
           Protect yourself online
         </a>
-        <a
-          class="Footer__copyrightLink Footer__secondaryLink"
-          data-analytics="toolbar:site+map"
-          href="/sitemap"
-        >
-          Site Map
-        </a>
         <p
           class="Footer__copyrightMessage"
         >
@@ -1649,13 +1642,6 @@ exports[`Footer: should render when authentication is pending 1`] = `
           rel="nofollow"
         >
           Protect yourself online
-        </a>
-        <a
-          class="Footer__copyrightLink Footer__secondaryLink"
-          data-analytics="toolbar:site+map"
-          href="/sitemap"
-        >
-          Site Map
         </a>
         <p
           class="Footer__copyrightMessage"
@@ -2484,13 +2470,6 @@ exports[`Footer: should render when unauthenticated 1`] = `
         >
           Protect yourself online
         </a>
-        <a
-          class="Footer__copyrightLink Footer__secondaryLink"
-          data-analytics="toolbar:site+map"
-          href="/sitemap"
-        >
-          Site Map
-        </a>
         <p
           class="Footer__copyrightMessage"
         >
@@ -3318,13 +3297,6 @@ exports[`Footer: should render with locale of AU 1`] = `
         >
           Protect yourself online
         </a>
-        <a
-          class="Footer__copyrightLink Footer__secondaryLink"
-          data-analytics="toolbar:site+map"
-          href="/sitemap"
-        >
-          Site Map
-        </a>
         <p
           class="Footer__copyrightMessage"
         >
@@ -4084,13 +4056,6 @@ exports[`Footer: should render with locale of NZ 1`] = `
           rel="nofollow"
         >
           Protect yourself online
-        </a>
-        <a
-          class="Footer__copyrightLink Footer__secondaryLink"
-          data-analytics="toolbar:site+map"
-          href="/sitemap"
-        >
-          Site Map
         </a>
         <p
           class="Footer__copyrightMessage"

--- a/react/Footer/data/copyright.js
+++ b/react/Footer/data/copyright.js
@@ -16,11 +16,5 @@ export default [
     href: '/safe-job-searching/',
     rel: 'nofollow',
     analytics: 'toolbar:seek+safely'
-  },
-  {
-    name: 'Site Map',
-    href: '/sitemap',
-    analytics: 'toolbar:site+map',
-    secondary: true
   }
 ];


### PR DESCRIPTION
An experiment removing all sitemaps from the site is taking place and ensuring users are not able to click through to a non-existent page is the first step!
