### PR TITLE
fix(AccordionItem): Make text and link black

### DIFF
--- a/react/AccordionItem/AccordionItem.less
+++ b/react/AccordionItem/AccordionItem.less
@@ -22,6 +22,10 @@
 
 .titleText {
   padding: (@row-height * 3) 0;
+
+  a {
+    color: @sk-black;
+  }
 }
 
 .expander {
@@ -39,7 +43,7 @@
 
 .chevron {
   margin-left: 9px;
-  color: @sk-blue-lighter;
+  color: @sk-black;
   transition: transform 0.3s ease;
 }
 


### PR DESCRIPTION
Have changed the Accordion text and chevron to be `@sk-black`, according to changes requested by Carmelia, after discussions with the broader UX team.

![image](https://user-images.githubusercontent.com/4082442/63569435-b607d180-c5bc-11e9-90f8-160931f817c4.png)
