### PR TITLE
fix(Footer): Update career guide url

### DIFF
--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -2580,7 +2580,7 @@ exports[`Footer: should render with locale of AU 1`] = `
               <a
                 class="FooterLink__link"
                 data-analytics="toolbar:career+guide"
-                href="https://www.seek.com.au/career-guide/?campaigncode=seek_banner_29&sc_trk=skj-career-guide-link"
+                href="https://www.seek.com.au/career-advice/?campaigncode=seek_banner_29&sc_trk=skj-career-guide-link"
               >
                 Explore Careers
               </a>

--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -99,7 +99,7 @@ exports[`Footer: should render when authenticated 1`] = `
               <a
                 class="FooterLink__link"
                 data-analytics="toolbar:career+guide"
-                href="https://www.seek.com.au/career-guide/?campaigncode=seek_banner_29&sc_trk=skj-career-guide-link"
+                href="https://www.seek.com.au/career-advice/?campaigncode=seek_banner_29&sc_trk=skj-career-guide-link"
               >
                 Explore Careers
               </a>
@@ -926,7 +926,7 @@ exports[`Footer: should render when authentication is pending 1`] = `
               <a
                 class="FooterLink__link"
                 data-analytics="toolbar:career+guide"
-                href="https://www.seek.com.au/career-guide/?campaigncode=seek_banner_29&sc_trk=skj-career-guide-link"
+                href="https://www.seek.com.au/career-advice/?campaigncode=seek_banner_29&sc_trk=skj-career-guide-link"
               >
                 Explore Careers
               </a>
@@ -1753,7 +1753,7 @@ exports[`Footer: should render when unauthenticated 1`] = `
               <a
                 class="FooterLink__link"
                 data-analytics="toolbar:career+guide"
-                href="https://www.seek.com.au/career-guide/?campaigncode=seek_banner_29&sc_trk=skj-career-guide-link"
+                href="https://www.seek.com.au/career-advice/?campaigncode=seek_banner_29&sc_trk=skj-career-guide-link"
               >
                 Explore Careers
               </a>

--- a/react/Footer/data/tools.js
+++ b/react/Footer/data/tools.js
@@ -38,7 +38,7 @@ export default [
   {
     name: 'Explore Careers',
     href:
-      'https://www.seek.com.au/career-guide/?campaigncode=seek_banner_29&sc_trk=skj-career-guide-link',
+      'https://www.seek.com.au/career-advice/?campaigncode=seek_banner_29&sc_trk=skj-career-guide-link',
     analytics: 'toolbar:career+guide',
     specificLocale: 'AU'
   },


### PR DESCRIPTION
- This PR will be merged during a transition - Career Guide product will take `/career-advice` path
- Redirects will be in place - but it is important for SEO to internal products to point to new path

BREAKING CHANGE:

No breaking change

RFC URL:

no changes to API.

MIGRATION GUIDE:

not required
