### PR TITLE
fix(Footer): Split marketing blog links

### DIFF
--- a/react/Footer/__snapshots__/Footer.test.js.snap
+++ b/react/Footer/__snapshots__/Footer.test.js.snap
@@ -769,10 +769,21 @@ exports[`Footer: should render when authenticated 1`] = `
             >
               <a
                 class="FooterLink__link"
-                data-analytics="toolbar:insight+blog"
-                href="http://insightsresources.seek.com.au/"
+                data-analytics="toolbar:hirer+advice"
+                href="http://insightsresources.seek.com.au/hiring-advice/"
               >
-                Insights & Resources
+                Hiring Advice
+              </a>
+            </li>
+            <li
+              class=""
+            >
+              <a
+                class="FooterLink__link"
+                data-analytics="toolbar:market+insights"
+                href="http://insightsresources.seek.com.au/market-insights/"
+              >
+                Market Insights
               </a>
             </li>
             <li
@@ -1596,10 +1607,21 @@ exports[`Footer: should render when authentication is pending 1`] = `
             >
               <a
                 class="FooterLink__link"
-                data-analytics="toolbar:insight+blog"
-                href="http://insightsresources.seek.com.au/"
+                data-analytics="toolbar:hirer+advice"
+                href="http://insightsresources.seek.com.au/hiring-advice/"
               >
-                Insights & Resources
+                Hiring Advice
+              </a>
+            </li>
+            <li
+              class=""
+            >
+              <a
+                class="FooterLink__link"
+                data-analytics="toolbar:market+insights"
+                href="http://insightsresources.seek.com.au/market-insights/"
+              >
+                Market Insights
               </a>
             </li>
             <li
@@ -2423,10 +2445,21 @@ exports[`Footer: should render when unauthenticated 1`] = `
             >
               <a
                 class="FooterLink__link"
-                data-analytics="toolbar:insight+blog"
-                href="http://insightsresources.seek.com.au/"
+                data-analytics="toolbar:hirer+advice"
+                href="http://insightsresources.seek.com.au/hiring-advice/"
               >
-                Insights & Resources
+                Hiring Advice
+              </a>
+            </li>
+            <li
+              class=""
+            >
+              <a
+                class="FooterLink__link"
+                data-analytics="toolbar:market+insights"
+                href="http://insightsresources.seek.com.au/market-insights/"
+              >
+                Market Insights
               </a>
             </li>
             <li
@@ -3250,10 +3283,21 @@ exports[`Footer: should render with locale of AU 1`] = `
             >
               <a
                 class="FooterLink__link"
-                data-analytics="toolbar:insight+blog"
-                href="http://insightsresources.seek.com.au/"
+                data-analytics="toolbar:hirer+advice"
+                href="http://insightsresources.seek.com.au/hiring-advice/"
               >
-                Insights & Resources
+                Hiring Advice
+              </a>
+            </li>
+            <li
+              class=""
+            >
+              <a
+                class="FooterLink__link"
+                data-analytics="toolbar:market+insights"
+                href="http://insightsresources.seek.com.au/market-insights/"
+              >
+                Market Insights
               </a>
             </li>
             <li
@@ -4010,10 +4054,21 @@ exports[`Footer: should render with locale of NZ 1`] = `
             >
               <a
                 class="FooterLink__link"
-                data-analytics="toolbar:insight+blog"
-                href="http://insightsresources.seek.co.nz/"
+                data-analytics="toolbar:hirer+advice"
+                href="http://insightsresources.seek.co.nz/hiring-advice/"
               >
-                Insights & Resources
+                Hiring Advice
+              </a>
+            </li>
+            <li
+              class=""
+            >
+              <a
+                class="FooterLink__link"
+                data-analytics="toolbar:market+insights"
+                href="http://insightsresources.seek.co.nz/market-insights/"
+              >
+                Market Insights
               </a>
             </li>
             <li

--- a/react/Footer/data/employers.js
+++ b/react/Footer/data/employers.js
@@ -50,15 +50,27 @@ export default [
     specificLocale: 'NZ'
   },
   {
-    name: 'Insights & Resources',
-    href: 'http://insightsresources.seek.com.au/',
-    analytics: 'toolbar:insight+blog',
+    name: 'Hiring Advice',
+    href: 'http://insightsresources.seek.com.au/hiring-advice/',
+    analytics: 'toolbar:hirer+advice',
     specificLocale: 'AU'
   },
   {
-    name: 'Insights & Resources',
-    href: 'http://insightsresources.seek.co.nz/',
-    analytics: 'toolbar:insight+blog',
+    name: 'Hiring Advice',
+    href: 'http://insightsresources.seek.co.nz/hiring-advice/',
+    analytics: 'toolbar:hirer+advice',
+    specificLocale: 'NZ'
+  },
+  {
+    name: 'Market Insights',
+    href: 'http://insightsresources.seek.com.au/market-insights/',
+    analytics: 'toolbar:market+insights',
+    specificLocale: 'AU'
+  },
+  {
+    name: 'Market Insights',
+    href: 'http://insightsresources.seek.co.nz/market-insights/',
+    analytics: 'toolbar:market+insights',
     specificLocale: 'NZ'
   },
   {


### PR DESCRIPTION
The Marketing Insights blog has been 2 distinct content sites for a while now. A request has been made to split this link into separate URLs, same as the talent header already has.