### PR TITLE
fix(TextField): Update aria attribute

### DIFF
--- a/react/Autosuggest/Autosuggest.js
+++ b/react/Autosuggest/Autosuggest.js
@@ -61,7 +61,7 @@ export default class Autosuggest extends Component {
     areSuggestionsShown: false
   };
 
-  componentWillUpdate(nextProps, nextState) {
+  UNSAFE_componentWillUpdate(nextProps, nextState) {
     if (
       !this.state.areSuggestionsShown &&
       nextState.areSuggestionsShown &&
@@ -155,7 +155,14 @@ export default class Autosuggest extends Component {
     return (
       <div>
         <ReactAutosuggest
-          inputProps={{ value, onChange, onFocus, onBlur, type, ...inputProps }}
+          inputProps={{
+            value,
+            onChange,
+            onFocus,
+            onBlur,
+            type,
+            ...inputProps
+          }}
           ref={this.storeInputReference}
           {...allAutosuggestProps}
         />

--- a/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
+++ b/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
@@ -29,7 +29,6 @@ exports[`Autosuggest should render with label 1`] = `
       </label>
       <input
         aria-autocomplete="list"
-        aria-describedby="testAutosuggest-message"
         aria-expanded="false"
         aria-owns="react-autowhatever-1"
         autocomplete="off"
@@ -96,7 +95,6 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
       </label>
       <input
         aria-autocomplete="list"
-        aria-describedby="testAutosuggest-message"
         aria-expanded="false"
         aria-owns="react-autowhatever-1"
         autocomplete="off"
@@ -144,7 +142,6 @@ exports[`Autosuggest should render with simple props 1`] = `
     >
       <input
         aria-autocomplete="list"
-        aria-describedby="testAutosuggest-message"
         aria-expanded="false"
         aria-owns="react-autowhatever-1"
         autocomplete="off"
@@ -192,7 +189,6 @@ exports[`Autosuggest should render with suggestions 1`] = `
     >
       <input
         aria-autocomplete="list"
-        aria-describedby="testAutosuggest-message"
         aria-expanded="true"
         aria-owns="react-autowhatever-1"
         autocomplete="off"

--- a/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
+++ b/react/MonthPicker/CustomMonthPicker/CustomMonthPicker.js
@@ -69,7 +69,7 @@ export default class CustomMonthPicker extends Component {
     this.yearOptions = getYearOptions(minYear, maxYear, ascendingYears);
   }
 
-  componentWillUpdate(newProps) {
+  UNSAFE_componentWillUpdate(newProps) {
     if (
       ['minYear', 'maxYear', 'ascendingYears'].filter(
         key => newProps[key] !== this.props[key]

--- a/react/TextField/TextField.js
+++ b/react/TextField/TextField.js
@@ -95,7 +95,7 @@ export default class TextField extends Component<Props> {
       type,
       ...combineClassNames(inputProps, styles.input),
       ref: attachRefs(this.storeInputReference, ref),
-      'aria-describedby': `${id}-message`
+      'aria-describedby': id
     };
 
     return <input {...allInputProps} />;

--- a/react/TextField/TextField.js
+++ b/react/TextField/TextField.js
@@ -83,7 +83,8 @@ export default class TextField extends Component<Props> {
       onFocus,
       onBlur,
       type,
-      inputProps = {}
+      inputProps = {},
+      message
     } = this.props;
     const { ref } = inputProps;
     const allInputProps = {
@@ -94,9 +95,12 @@ export default class TextField extends Component<Props> {
       onBlur,
       type,
       ...combineClassNames(inputProps, styles.input),
-      ref: attachRefs(this.storeInputReference, ref),
-      'aria-describedby': id
+      ref: attachRefs(this.storeInputReference, ref)
     };
+
+    if (message) {
+      allInputProps['aria-describedby'] = `${id}-message`;
+    }
 
     return <input {...allInputProps} />;
   };

--- a/react/TextField/TextField.test.js
+++ b/react/TextField/TextField.test.js
@@ -92,6 +92,14 @@ describe('TextField', () => {
     });
   });
 
+  describe('message', () => {
+    it('should render the message if the message prop is passed in', () => {
+      expect(
+        shallow(<TextField {...requiredProps} message="This is required" />)
+      ).toMatchSnapshot();
+    });
+  });
+
   describe('clear button', () => {
     const handleClear = () => {};
 

--- a/react/TextField/__snapshots__/TextField.test.js.snap
+++ b/react/TextField/__snapshots__/TextField.test.js.snap
@@ -12,7 +12,6 @@ exports[`TextField clear button inputProps should be visible when value has whit
     tertiaryLabel=""
   />
   <input
-    aria-describedby="testTextField-message"
     className="TextField__input"
     id="testTextField"
     onChange={[Function]}
@@ -50,7 +49,6 @@ exports[`TextField clear button inputProps should be visible when value is provi
     tertiaryLabel=""
   />
   <input
-    aria-describedby="testTextField-message"
     className="TextField__input"
     id="testTextField"
     onChange={[Function]}
@@ -88,7 +86,6 @@ exports[`TextField clear button inputProps should not be visible when value is e
     tertiaryLabel=""
   />
   <input
-    aria-describedby="testTextField-message"
     className="TextField__input"
     id="testTextField"
     onChange={[Function]}
@@ -126,7 +123,6 @@ exports[`TextField clear button inputProps should not be visible when value is p
     tertiaryLabel=""
   />
   <input
-    aria-describedby="testTextField-message"
     className="TextField__input"
     id="testTextField"
     onChange={[Function]}
@@ -164,7 +160,6 @@ exports[`TextField clear button should be visible when value has white spaces on
     tertiaryLabel=""
   />
   <input
-    aria-describedby="testTextField-message"
     className="TextField__input"
     id="testTextField"
     onChange={[Function]}
@@ -202,7 +197,6 @@ exports[`TextField clear button should be visible when value is provided 1`] = `
     tertiaryLabel=""
   />
   <input
-    aria-describedby="testTextField-message"
     className="TextField__input"
     id="testTextField"
     onChange={[Function]}
@@ -240,7 +234,6 @@ exports[`TextField clear button should not be visible when value is empty 1`] = 
     tertiaryLabel=""
   />
   <input
-    aria-describedby="testTextField-message"
     className="TextField__input"
     id="testTextField"
     onChange={[Function]}
@@ -278,7 +271,6 @@ exports[`TextField clear button should not be visible when value is provided but
     tertiaryLabel=""
   />
   <input
-    aria-describedby="testTextField-message"
     className="TextField__input"
     id="testTextField"
     onChange={[Function]}
@@ -304,7 +296,7 @@ exports[`TextField clear button should not be visible when value is provided but
 </div>
 `;
 
-exports[`TextField should render with defaults 1`] = `
+exports[`TextField message should render the message if the message prop is passed in 1`] = `
 <div
   className="TextField__root"
 >
@@ -317,6 +309,43 @@ exports[`TextField should render with defaults 1`] = `
   />
   <input
     aria-describedby="testTextField-message"
+    className="TextField__input"
+    id="testTextField"
+    onChange={[Function]}
+    value=""
+  />
+  <span
+    className="TextField__clearField"
+    onMouseDown={[Function]}
+  >
+    <ClearField />
+  </span>
+  <FieldMessage
+    id="testTextField-message"
+    message="This is required"
+    messageProps={
+      Object {
+        "critical": false,
+        "positive": false,
+        "secondary": false,
+      }
+    }
+  />
+</div>
+`;
+
+exports[`TextField should render with defaults 1`] = `
+<div
+  className="TextField__root"
+>
+  <FieldLabel
+    id="testTextField"
+    label=""
+    raw={false}
+    secondaryLabel=""
+    tertiaryLabel=""
+  />
+  <input
     className="TextField__input"
     id="testTextField"
     onChange={[Function]}
@@ -354,7 +383,6 @@ exports[`TextField should render with input props 1`] = `
     tertiaryLabel=""
   />
   <input
-    aria-describedby="testTextField-message"
     className="TextField__input first-name-field"
     data-automation="first-name-field"
     id="testTextField"
@@ -393,7 +421,6 @@ exports[`TextField valid / tone should not render the invalid style if tone is s
     tertiaryLabel=""
   />
   <input
-    aria-describedby="testTextField-message"
     className="TextField__input"
     id="testTextField"
     onChange={[Function]}
@@ -432,7 +459,6 @@ exports[`TextField valid / tone should render the invalid style for tone="critic
     tertiaryLabel=""
   />
   <input
-    aria-describedby="testTextField-message"
     className="TextField__input"
     id="testTextField"
     onChange={[Function]}
@@ -471,7 +497,6 @@ exports[`TextField valid / tone should render the invalid style for valid={false
     tertiaryLabel=""
   />
   <input
-    aria-describedby="testTextField-message"
     className="TextField__input"
     id="testTextField"
     onChange={[Function]}

--- a/react/private/react-autosuggest/Autosuggest.js
+++ b/react/private/react-autosuggest/Autosuggest.js
@@ -119,7 +119,7 @@ export default class Autosuggest extends Component {
     this.suggestionsContainer = this.autowhatever.itemsContainer;
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (shallowEqualArrays(nextProps.suggestions, this.props.suggestions)) {
       if (
         nextProps.highlightFirstSuggestion &&
@@ -168,7 +168,7 @@ export default class Autosuggest extends Component {
     }
   }
 
-  componentWillUnmount() {
+  componentDidUnmount() {
     document.removeEventListener('mousedown', this.onDocumentMouseDown);
   }
 


### PR DESCRIPTION
The attribute `aria-describedby` is currently set to an invalid value of `${id}-message` so any performance tool like webpagetest is calling this out.

From [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute)

"The aria-describedby attribute is used to indicate the IDs of the elements that describe the object. It is used to establish a relationship between widgets or groups and text that described them."

![Screen Shot 2019-10-29 at 4 31 45 pm](https://user-images.githubusercontent.com/1221164/67740374-a8ae0e00-fa69-11e9-971f-4eee50a62e62.png)

**_UPDATE: Conditionally render the aria attribute if/when the message prop is passed to the TextField component_**