### PR TITLE
feat: Add settings link on mobile

### DIFF
--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -255,9 +255,7 @@ export default ({
           case AUTHENTICATED:
             return (
               <Fragment>
-                <Hidden
-                  desktop
-                  component="li"
+                <li
                   className={classnames(
                     activeTab === SETTINGS && styles.activeTab
                   )}
@@ -271,7 +269,7 @@ export default ({
                       <div key="iconSpacer" className={styles.iconSpacer} />
                     ]
                   })}
-                </Hidden>
+                </li>
                 {linkRenderer({
                   'data-analytics': 'header:sign-out',
                   className: styles.item,
@@ -281,11 +279,7 @@ export default ({
                     : '/Login/Logout',
                   children: [
                     'Sign Out',
-                    <Hidden
-                      desktop
-                      key="iconSpacer"
-                      className={styles.iconSpacer}
-                    />
+                    <div key="iconSpacer" className={styles.iconSpacer} />
                   ]
                 })}
               </Fragment>

--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -2,7 +2,7 @@
 
 import styles from './UserAccountMenu.less';
 
-import React from 'react';
+import React, { Fragment } from 'react';
 import classnames from 'classnames';
 
 import ArticleIcon from '../../ArticleIcon/ArticleIcon';
@@ -253,22 +253,44 @@ export default ({
               </span>
             );
           case AUTHENTICATED:
-            return linkRenderer({
-              'data-analytics': 'header:sign-out',
-              className: styles.item,
-              onClick: clearLocalStorage,
-              href: returnUrl
-                ? appendReturnUrl('/login/LogoutWithReturnUrl', returnUrl)
-                : '/Login/Logout',
-              children: [
-                'Sign Out',
+            return (
+              <Fragment>
                 <Hidden
                   desktop
-                  key="iconSpacer"
-                  className={styles.iconSpacer}
-                />
-              ]
-            });
+                  component="li"
+                  className={classnames(
+                    activeTab === SETTINGS && styles.activeTab
+                  )}
+                >
+                  {linkRenderer({
+                    'data-analytics': 'header:settings',
+                    className: styles.item,
+                    href: '/settings/',
+                    children: [
+                      SETTINGS,
+                      <div key="iconSpacer" className={styles.iconSpacer} />
+                    ]
+                  })}
+                </Hidden>
+                {linkRenderer({
+                  'data-analytics': 'header:sign-out',
+                  className: styles.item,
+                  onClick: clearLocalStorage,
+                  href: returnUrl
+                    ? appendReturnUrl('/login/LogoutWithReturnUrl', returnUrl)
+                    : '/Login/Logout',
+                  children: [
+                    'Sign Out',
+                    <Hidden
+                      desktop
+                      key="iconSpacer"
+                      className={styles.iconSpacer}
+                    />
+                  ]
+                })}
+              </Fragment>
+            );
+
           default:
             return (
               <span className={classnames(styles.item, styles.pendingAuth)}>

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -850,18 +850,31 @@ exports[`Header: should render first part of email address when username isn't p
                   </li>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
+                  />
+                  <li
+                    class="Hidden__desktop"
                   >
                     <a
                       class="UserAccountMenu__item"
-                      data-analytics="header:sign-out"
-                      href="/Login/Logout"
+                      data-analytics="header:settings"
+                      href="/settings/"
                     >
-                      Sign Out
-                      <span
-                        class="UserAccountMenu__iconSpacer Hidden__desktop"
+                      Settings
+                      <div
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
+                  <a
+                    class="UserAccountMenu__item"
+                    data-analytics="header:sign-out"
+                    href="/Login/Logout"
+                  >
+                    Sign Out
+                    <span
+                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    />
+                  </a>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
@@ -1983,18 +1996,31 @@ exports[`Header: should render when authenticated 1`] = `
                   </li>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
+                  />
+                  <li
+                    class="Hidden__desktop"
                   >
                     <a
                       class="UserAccountMenu__item"
-                      data-analytics="header:sign-out"
-                      href="/login/LogoutWithReturnUrl?returnUrl=%2Fjobs"
+                      data-analytics="header:settings"
+                      href="/settings/"
                     >
-                      Sign Out
-                      <span
-                        class="UserAccountMenu__iconSpacer Hidden__desktop"
+                      Settings
+                      <div
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
+                  <a
+                    class="UserAccountMenu__item"
+                    data-analytics="header:sign-out"
+                    href="/login/LogoutWithReturnUrl?returnUrl=%2Fjobs"
+                  >
+                    Sign Out
+                    <span
+                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    />
+                  </a>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
@@ -2548,18 +2574,31 @@ exports[`Header: should render when authenticated but username and email is not 
                   </li>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
+                  />
+                  <li
+                    class="Hidden__desktop"
                   >
                     <a
                       class="UserAccountMenu__item"
-                      data-analytics="header:sign-out"
-                      href="/Login/Logout"
+                      data-analytics="header:settings"
+                      href="/settings/"
                     >
-                      Sign Out
-                      <span
-                        class="UserAccountMenu__iconSpacer Hidden__desktop"
+                      Settings
+                      <div
+                        class="UserAccountMenu__iconSpacer"
                       />
                     </a>
                   </li>
+                  <a
+                    class="UserAccountMenu__item"
+                    data-analytics="header:sign-out"
+                    href="/Login/Logout"
+                  >
+                    Sign Out
+                    <span
+                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    />
+                  </a>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -852,7 +852,7 @@ exports[`Header: should render first part of email address when username isn't p
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   />
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
                       class="UserAccountMenu__item"
@@ -871,8 +871,8 @@ exports[`Header: should render first part of email address when username isn't p
                     href="/Login/Logout"
                   >
                     Sign Out
-                    <span
-                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    <div
+                      class="UserAccountMenu__iconSpacer"
                     />
                   </a>
                   <li
@@ -1998,7 +1998,7 @@ exports[`Header: should render when authenticated 1`] = `
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   />
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
                       class="UserAccountMenu__item"
@@ -2017,8 +2017,8 @@ exports[`Header: should render when authenticated 1`] = `
                     href="/login/LogoutWithReturnUrl?returnUrl=%2Fjobs"
                   >
                     Sign Out
-                    <span
-                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    <div
+                      class="UserAccountMenu__iconSpacer"
                     />
                   </a>
                   <li
@@ -2576,7 +2576,7 @@ exports[`Header: should render when authenticated but username and email is not 
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   />
                   <li
-                    class="Hidden__desktop"
+                    class=""
                   >
                     <a
                       class="UserAccountMenu__item"
@@ -2595,8 +2595,8 @@ exports[`Header: should render when authenticated but username and email is not 
                     href="/Login/Logout"
                   >
                     Sign Out
-                    <span
-                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    <div
+                      class="UserAccountMenu__iconSpacer"
                     />
                   </a>
                   <li


### PR DESCRIPTION
Adding a link to the settings page for the mobile menu dropdown, as currently the link exists only for desktop.

![image](https://user-images.githubusercontent.com/4082442/73901694-b0424600-48e7-11ea-8734-b8a30013a05f.png)
