### PR TITLE
fix(Header): Fix validateDOMNesting warning for header li tags

### DIFF
--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -228,11 +228,11 @@ export default ({
         children: SETTINGS
       })}
     </Hidden>
-    <Hidden desktop component="li" className={styles.firstItemInGroup}>
-      {(() => {
-        switch (authenticationStatus) {
-          case UNAUTHENTICATED:
-            return (
+    {(() => {
+      switch (authenticationStatus) {
+        case UNAUTHENTICATED:
+          return (
+            <Hidden desktop component="li" className={styles.firstItemInGroup}>
               <span className={styles.item}>
                 {linkRenderer({
                   'data-analytics': 'header:sign-in',
@@ -251,25 +251,30 @@ export default ({
                 })}
                 <div className={styles.iconSpacer} />
               </span>
-            );
-          case AUTHENTICATED:
-            return (
-              <Fragment>
-                <li
-                  className={classnames(
-                    activeTab === SETTINGS && styles.activeTab
-                  )}
-                >
-                  {linkRenderer({
-                    'data-analytics': 'header:settings',
-                    className: styles.item,
-                    href: '/settings/',
-                    children: [
-                      SETTINGS,
-                      <div key="iconSpacer" className={styles.iconSpacer} />
-                    ]
-                  })}
-                </li>
+            </Hidden>
+          );
+        case AUTHENTICATED:
+          return (
+            <Fragment>
+              <Hidden
+                desktop
+                component="li"
+                className={classnames(
+                  activeTab === SETTINGS && styles.activeTab,
+                  styles.firstItemInGroup
+                )}
+              >
+                {linkRenderer({
+                  'data-analytics': 'header:settings',
+                  className: styles.item,
+                  href: '/settings/',
+                  children: [
+                    SETTINGS,
+                    <div key="iconSpacer" className={styles.iconSpacer} />
+                  ]
+                })}
+              </Hidden>
+              <Hidden desktop component="li">
                 {linkRenderer({
                   'data-analytics': 'header:sign-out',
                   className: styles.item,
@@ -282,23 +287,19 @@ export default ({
                     <div key="iconSpacer" className={styles.iconSpacer} />
                   ]
                 })}
-              </Fragment>
-            );
+              </Hidden>
+            </Fragment>
+          );
 
-          default:
-            return (
-              <span className={classnames(styles.item, styles.pendingAuth)}>
-                <Loader inline xsmall />
-                <Hidden
-                  desktop
-                  key="iconSpacer"
-                  className={styles.iconSpacer}
-                />
-              </span>
-            );
-        }
-      })()}
-    </Hidden>
+        default:
+          return (
+            <span className={classnames(styles.item, styles.pendingAuth)}>
+              <Loader inline xsmall />
+              <Hidden desktop key="iconSpacer" className={styles.iconSpacer} />
+            </span>
+          );
+      }
+    })()}
     {locale === 'NZ' ? null : (
       <Hidden
         desktop

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -280,30 +280,26 @@ exports[`Header: should append returnUrl to signin and register links if present
                       Settings
                     </a>
                   </li>
-                  <li
-                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
+                  <span
+                    class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                   >
-                    <span
-                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
+                    <div
+                      class="Loader__root Loader__inline Loader__xsmall"
                     >
                       <div
-                        class="Loader__root Loader__inline Loader__xsmall"
-                      >
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                      </div>
-                      <span
-                        class="UserAccountMenu__iconSpacer Hidden__desktop"
+                        class="Loader__ball"
                       />
-                    </span>
-                  </li>
+                      <div
+                        class="Loader__ball"
+                      />
+                      <div
+                        class="Loader__ball"
+                      />
+                    </div>
+                    <span
+                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    />
+                  </span>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
@@ -850,9 +846,6 @@ exports[`Header: should render first part of email address when username isn't p
                   </li>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
-                  />
-                  <li
-                    class=""
                   >
                     <a
                       class="UserAccountMenu__item"
@@ -865,16 +858,20 @@ exports[`Header: should render first part of email address when username isn't p
                       />
                     </a>
                   </li>
-                  <a
-                    class="UserAccountMenu__item"
-                    data-analytics="header:sign-out"
-                    href="/Login/Logout"
+                  <li
+                    class="Hidden__desktop"
                   >
-                    Sign Out
-                    <div
-                      class="UserAccountMenu__iconSpacer"
-                    />
-                  </a>
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:sign-out"
+                      href="/Login/Logout"
+                    >
+                      Sign Out
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
@@ -1426,30 +1423,26 @@ exports[`Header: should render when activeTab is 'Profile' 1`] = `
                       Settings
                     </a>
                   </li>
-                  <li
-                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
+                  <span
+                    class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                   >
-                    <span
-                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
+                    <div
+                      class="Loader__root Loader__inline Loader__xsmall"
                     >
                       <div
-                        class="Loader__root Loader__inline Loader__xsmall"
-                      >
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                      </div>
-                      <span
-                        class="UserAccountMenu__iconSpacer Hidden__desktop"
+                        class="Loader__ball"
                       />
-                    </span>
-                  </li>
+                      <div
+                        class="Loader__ball"
+                      />
+                      <div
+                        class="Loader__ball"
+                      />
+                    </div>
+                    <span
+                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    />
+                  </span>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
@@ -1996,9 +1989,6 @@ exports[`Header: should render when authenticated 1`] = `
                   </li>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
-                  />
-                  <li
-                    class=""
                   >
                     <a
                       class="UserAccountMenu__item"
@@ -2011,16 +2001,20 @@ exports[`Header: should render when authenticated 1`] = `
                       />
                     </a>
                   </li>
-                  <a
-                    class="UserAccountMenu__item"
-                    data-analytics="header:sign-out"
-                    href="/login/LogoutWithReturnUrl?returnUrl=%2Fjobs"
+                  <li
+                    class="Hidden__desktop"
                   >
-                    Sign Out
-                    <div
-                      class="UserAccountMenu__iconSpacer"
-                    />
-                  </a>
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:sign-out"
+                      href="/login/LogoutWithReturnUrl?returnUrl=%2Fjobs"
+                    >
+                      Sign Out
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
@@ -2574,9 +2568,6 @@ exports[`Header: should render when authenticated but username and email is not 
                   </li>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
-                  />
-                  <li
-                    class=""
                   >
                     <a
                       class="UserAccountMenu__item"
@@ -2589,16 +2580,20 @@ exports[`Header: should render when authenticated but username and email is not 
                       />
                     </a>
                   </li>
-                  <a
-                    class="UserAccountMenu__item"
-                    data-analytics="header:sign-out"
-                    href="/Login/Logout"
+                  <li
+                    class="Hidden__desktop"
                   >
-                    Sign Out
-                    <div
-                      class="UserAccountMenu__iconSpacer"
-                    />
-                  </a>
+                    <a
+                      class="UserAccountMenu__item"
+                      data-analytics="header:sign-out"
+                      href="/Login/Logout"
+                    >
+                      Sign Out
+                      <div
+                        class="UserAccountMenu__iconSpacer"
+                      />
+                    </a>
+                  </li>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
@@ -3150,30 +3145,26 @@ exports[`Header: should render when authentication is pending 1`] = `
                       Settings
                     </a>
                   </li>
-                  <li
-                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
+                  <span
+                    class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                   >
-                    <span
-                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
+                    <div
+                      class="Loader__root Loader__inline Loader__xsmall"
                     >
                       <div
-                        class="Loader__root Loader__inline Loader__xsmall"
-                      >
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                      </div>
-                      <span
-                        class="UserAccountMenu__iconSpacer Hidden__desktop"
+                        class="Loader__ball"
                       />
-                    </span>
-                  </li>
+                      <div
+                        class="Loader__ball"
+                      />
+                      <div
+                        class="Loader__ball"
+                      />
+                    </div>
+                    <span
+                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    />
+                  </span>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
@@ -4256,30 +4247,26 @@ exports[`Header: should render with a custom logo 1`] = `
                       Settings
                     </a>
                   </li>
-                  <li
-                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
+                  <span
+                    class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                   >
-                    <span
-                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
+                    <div
+                      class="Loader__root Loader__inline Loader__xsmall"
                     >
                       <div
-                        class="Loader__root Loader__inline Loader__xsmall"
-                      >
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                      </div>
-                      <span
-                        class="UserAccountMenu__iconSpacer Hidden__desktop"
+                        class="Loader__ball"
                       />
-                    </span>
-                  </li>
+                      <div
+                        class="Loader__ball"
+                      />
+                      <div
+                        class="Loader__ball"
+                      />
+                    </div>
+                    <span
+                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    />
+                  </span>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
@@ -4820,30 +4807,26 @@ exports[`Header: should render with locale of AU 1`] = `
                       Settings
                     </a>
                   </li>
-                  <li
-                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
+                  <span
+                    class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                   >
-                    <span
-                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
+                    <div
+                      class="Loader__root Loader__inline Loader__xsmall"
                     >
                       <div
-                        class="Loader__root Loader__inline Loader__xsmall"
-                      >
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                      </div>
-                      <span
-                        class="UserAccountMenu__iconSpacer Hidden__desktop"
+                        class="Loader__ball"
                       />
-                    </span>
-                  </li>
+                      <div
+                        class="Loader__ball"
+                      />
+                      <div
+                        class="Loader__ball"
+                      />
+                    </div>
+                    <span
+                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    />
+                  </span>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
@@ -5368,30 +5351,26 @@ exports[`Header: should render with locale of NZ 1`] = `
                       Settings
                     </a>
                   </li>
-                  <li
-                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
+                  <span
+                    class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                   >
-                    <span
-                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
+                    <div
+                      class="Loader__root Loader__inline Loader__xsmall"
                     >
                       <div
-                        class="Loader__root Loader__inline Loader__xsmall"
-                      >
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                      </div>
-                      <span
-                        class="UserAccountMenu__iconSpacer Hidden__desktop"
+                        class="Loader__ball"
                       />
-                    </span>
-                  </li>
+                      <div
+                        class="Loader__ball"
+                      />
+                      <div
+                        class="Loader__ball"
+                      />
+                    </div>
+                    <span
+                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    />
+                  </span>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >
@@ -5895,30 +5874,26 @@ exports[`Header: should render with no divider 1`] = `
                       Settings
                     </a>
                   </li>
-                  <li
-                    class="UserAccountMenu__firstItemInGroup Hidden__desktop"
+                  <span
+                    class="UserAccountMenu__item UserAccountMenu__pendingAuth"
                   >
-                    <span
-                      class="UserAccountMenu__item UserAccountMenu__pendingAuth"
+                    <div
+                      class="Loader__root Loader__inline Loader__xsmall"
                     >
                       <div
-                        class="Loader__root Loader__inline Loader__xsmall"
-                      >
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                        <div
-                          class="Loader__ball"
-                        />
-                      </div>
-                      <span
-                        class="UserAccountMenu__iconSpacer Hidden__desktop"
+                        class="Loader__ball"
                       />
-                    </span>
-                  </li>
+                      <div
+                        class="Loader__ball"
+                      />
+                      <div
+                        class="Loader__ball"
+                      />
+                    </div>
+                    <span
+                      class="UserAccountMenu__iconSpacer Hidden__desktop"
+                    />
+                  </span>
                   <li
                     class="UserAccountMenu__firstItemInGroup Hidden__desktop"
                   >


### PR DESCRIPTION
I noticed this warning appearing after #657 was merged.

![image](https://user-images.githubusercontent.com/1896277/74126746-d12ed200-4c2c-11ea-84d2-e71693247622.png)

There's currently an `<li>` within an `<li>` that's triggering the warning. I've rejigged the jsx to produce valid html