### PR TITLE
fix(deps): Support react-helmet 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "peerDependencies": {
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "react-helmet": "^3.0.0 || ^4.0.0 || ^5.0.0"
+    "react-helmet": "^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^6.1.0",

--- a/react/StyleGuideProvider/StyleGuideProvider.js
+++ b/react/StyleGuideProvider/StyleGuideProvider.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import classnames from 'classnames';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import ScreenReaderOnly from '../ScreenReaderOnly/ScreenReaderOnly';
 
 const defaultPageTitleAU =


### PR DESCRIPTION
The named export was added in `react-helmet` 5 and the default export was removed in `react-helmet` 6.

`react-helmet` 5 was released in 2017 so most people should already have matching versions.

BREAKING CHANGE: Requires `react-helmet` >= 5.0.0