### PR TITLE
fix(ReadMore): Fix css order styling bug

### DIFF
--- a/react/ReadMore/ReadMore.less
+++ b/react/ReadMore/ReadMore.less
@@ -35,6 +35,6 @@
 }
 
 .showMore {
-  padding-bottom: 3 * @row-height;
+  padding-bottom: 3 * @row-height !important;
   font-weight: @sk-medium !important;
 }


### PR DESCRIPTION
The order of importance of the styles in the screenshot depends on the order of the styles in the css file. I'm making the `showMore` style more important than the base style of the `Text` component it's being applied to

![Screen Shot 2020-04-29 at 5 36 41 pm](https://user-images.githubusercontent.com/1896277/80571589-35994a80-8a40-11ea-89e0-e36f4359af07.png)
