### PR TITLE
feat(Header): Update sign out urls

### DIFF
--- a/react/Header/UserAccountMenu/UserAccountMenu.js
+++ b/react/Header/UserAccountMenu/UserAccountMenu.js
@@ -279,9 +279,7 @@ export default ({
                   'data-analytics': 'header:sign-out',
                   className: styles.item,
                   onClick: clearLocalStorage,
-                  href: returnUrl
-                    ? appendReturnUrl('/login/LogoutWithReturnUrl', returnUrl)
-                    : '/Login/Logout',
+                  href: appendReturnUrl('/oauth/logout/', returnUrl),
                   children: [
                     'Sign Out',
                     <div key="iconSpacer" className={styles.iconSpacer} />
@@ -353,9 +351,7 @@ export default ({
           'data-analytics': 'header:sign-out',
           className: styles.item,
           onClick: clearLocalStorage,
-          href: returnUrl
-            ? appendReturnUrl('/login/LogoutWithReturnUrl', returnUrl)
-            : '/Login/Logout',
+          href: appendReturnUrl('/oauth/logout/', returnUrl),
           children: 'Sign Out'
         })}
       </Hidden>

--- a/react/Header/__snapshots__/Header.test.js.snap
+++ b/react/Header/__snapshots__/Header.test.js.snap
@@ -852,7 +852,7 @@ exports[`Header: should render first part of email address when username isn't p
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:sign-out"
-                      href="/Login/Logout"
+                      href="/oauth/logout/"
                     >
                       Sign Out
                       <div
@@ -908,7 +908,7 @@ exports[`Header: should render first part of email address when username isn't p
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:sign-out"
-                      href="/Login/Logout"
+                      href="/oauth/logout/"
                     >
                       Sign Out
                     </a>
@@ -1971,7 +1971,7 @@ exports[`Header: should render when authenticated 1`] = `
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:sign-out"
-                      href="/login/LogoutWithReturnUrl?returnUrl=%2Fjobs"
+                      href="/oauth/logout/?returnUrl=%2Fjobs"
                     >
                       Sign Out
                       <div
@@ -2027,7 +2027,7 @@ exports[`Header: should render when authenticated 1`] = `
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:sign-out"
-                      href="/login/LogoutWithReturnUrl?returnUrl=%2Fjobs"
+                      href="/oauth/logout/?returnUrl=%2Fjobs"
                     >
                       Sign Out
                     </a>
@@ -2538,7 +2538,7 @@ exports[`Header: should render when authenticated but username and email is not 
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:sign-out"
-                      href="/Login/Logout"
+                      href="/oauth/logout/"
                     >
                       Sign Out
                       <div
@@ -2594,7 +2594,7 @@ exports[`Header: should render when authenticated but username and email is not 
                     <a
                       class="UserAccountMenu__item"
                       data-analytics="header:sign-out"
-                      href="/Login/Logout"
+                      href="/oauth/logout/"
                     >
                       Sign Out
                     </a>


### PR DESCRIPTION
SEEK candidate site is in the process of migrating to Auth0 from Layer7. During the migration period (approximately 6 months) the user may be signed in to zero, one or both providers. The signout button in the SEEK style guide currently only signs the user out of Layer7.

This change updates the signout links to take the user to the new `/oauth/logout` route. This route will sign the user out of Auth0 before redirecting the user to the legacy route which will sign them out of Layer7.